### PR TITLE
feat: six RDF / codegen-friendliness enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,12 +264,20 @@ Marks a slot as a path variable in the item endpoint URL.
 
 | Value | Behaviour |
 |-------|-----------|
-| `"true"` | Slot appears as `{slot_name}` in the item path |
+| `"true"` | Slot appears as `{slot_name}` in the item path; the parameter schema mirrors the slot's range (alias for `"iri"`) |
+| `"iri"` | Same as `"true"` — preserves any `format: uri` typing from a uri-range slot |
+| `"slug"` | Slot appears as `{slot_name}` but the parameter schema is plain `string`, regardless of the slot's range |
 | omitted | Slot is not a path variable |
+
+Use `"slug"` when the URL segment is a short identifier (`main`,
+`uk-population-2026`) derived from the resource's IRI rather than the IRI
+itself — the body still carries the absolute IRI in the same field. Use
+`"iri"` (or `"true"`) when the URL segment is the full IRI (e.g. behind a
+URL-encoding gateway).
 
 When one or more slots are annotated as path variables, they replace the default identifier-based placeholder. Multiple path variables are joined in order: `/people/{id}/{version}`.
 
-When no slots are annotated as path variables, the generator falls back to the class's identifier slot (or a slot named `id`).
+When no slots are annotated as path variables, the generator falls back to the class's identifier slot (or a slot named `id`) in `iri` mode.
 
 ```yaml
   Person:
@@ -279,7 +287,20 @@ When no slots are annotated as path variables, the generator falls back to the c
     slot_usage:
       id:
         annotations:
-          openapi.path_variable: "true"   # GET /people/{id}
+          openapi.path_variable: "true"   # GET /people/{id}, schema mirrors slot range
+
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+    attributes:
+      id:
+        identifier: true
+        range: uri
+    slot_usage:
+      id:
+        annotations:
+          openapi.path_variable: slug     # GET /catalogs/{id}, schema is plain string
 ```
 
 #### `openapi.query_param`

--- a/README.md
+++ b/README.md
@@ -141,6 +141,31 @@ Default when omitted: all five operations (`list,create,read,update,delete`).
       openapi.operations: "list"        # Collection-only, no item endpoint
 ```
 
+#### `openapi.media_types`
+
+Comma-separated list of media types each operation generated for the class
+should advertise on its responses and request bodies.
+
+| Value | Example result |
+|-------|----------------|
+| `"application/json"` | JSON only (default when omitted) |
+| `"application/json,application/ld+json,text/turtle,application/rdf+xml"` | Every listed type appears under `responses[*].content` and `requestBody.content` |
+
+The first listed type stays the default. Each operation's response (and the
+request body, on `POST` / `PUT`) gets one `content` entry per media type, all
+referencing the same component schema. Use this for RDF-shaped APIs (JSON-LD,
+Turtle, RDF/XML) or any other content negotiation surface (CSV, NDJSON,
+XML, …) — it removes the need for a postprocessor that fans out the content
+blocks by hand.
+
+```yaml
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+      openapi.media_types: "application/json,application/ld+json,text/turtle,application/rdf+xml"
+```
+
 ### Slot-level annotations
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.
@@ -205,6 +230,7 @@ When no slots are annotated with `openapi.query_param`, the generator auto-infer
 | `openapi.resource` | class | `"true"` / `"false"` | All non-abstract, non-mixin classes |
 | `openapi.path` | class | path segment string | Auto-pluralized snake_case of class name |
 | `openapi.operations` | class | comma-separated list | `list,create,read,update,delete` |
+| `openapi.media_types` | class | comma-separated list | `application/json` |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` | Auto-inferred from slot type |
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ json_str = gen.serialize(format="json")
 | `server_url` | `str` | `"http://localhost:8000"` | `servers[0].url` in the spec |
 | `resource_filter` | `list[str]` | `None` | Only generate endpoints for these classes |
 | `format` | `str` | `"yaml"` | Output format: `"yaml"` or `"json"` |
+| `openapi_version` | `str` | `"3.0.3"` | OpenAPI dialect to emit (`"3.0.3"` or `"3.1.0"`) |
+| `flatten_inheritance` | `bool` | `False` | Inline parent properties instead of using `allOf` |
+
+> **Why default to 3.0.3?** Several popular codegens — notably
+> `openapi-generator`'s Spring server library — still mishandle `allOf`-based
+> inheritance under OpenAPI 3.1.0, silently producing duplicate `Foo_1`
+> schemas. 3.0.3 round-trips the same schemas cleanly. Pass
+> `--openapi-version 3.1.0` to opt into the newer dialect once your
+> downstream tooling is ready.
+
+> **`--flatten-inheritance`** inlines every inherited property directly into
+> the subclass schema, so each component is self-contained and there is no
+> `allOf` at all. Use it for codegens that still trip on inline-schema-inside
+> -allOf, or whenever you prefer denormalized schemas.
 
 ## Annotations
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,43 @@ needing the original LinkML source.
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.
 
+#### `openapi.format`
+
+Override the OpenAPI `format` string for a slot's emitted schema. Useful
+when the LinkML range alone doesn't carry enough information — for example
+to mark an `integer` slot as `int64` (large byte sizes, epoch milliseconds,
+high-cardinality IDs that overflow `Integer`) or to mark a `string` slot
+as `binary` / `byte` / `password`.
+
+| Slot range | Without annotation | With `openapi.format: int64` |
+|------------|---------------------|------------------------------|
+| `integer`  | `type: integer`     | `type: integer, format: int64` |
+| `string`   | `type: string`      | `type: string, format: <value>` |
+
+```yaml
+slots:
+  byte_size:
+    range: integer
+    annotations:
+      openapi.format: int64       # avoids 32-bit overflow downstream
+
+  avatar:
+    range: string
+    annotations:
+      openapi.format: binary       # raw bytes, not text
+
+  api_key:
+    range: string
+    annotations:
+      openapi.format: password     # Swagger UI redacts
+```
+
+For multivalued slots, the format is applied to the array's `items`
+schema, not the array itself (which has no `format` in OpenAPI).
+
+The annotation accepts any string; no allow-list is enforced, so vendor
+formats pass through unchanged.
+
 #### `openapi.path_variable`
 
 Marks a slot as a path variable in the item endpoint URL.
@@ -284,6 +321,7 @@ When no slots are annotated with `openapi.query_param`, the generator auto-infer
 | `openapi.media_types` | class | comma-separated list | `application/json` |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` | Auto-inferred from slot type |
+| `openapi.format` | slot | format string | derived from slot range |
 
 ## Type Mapping
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,43 @@ blocks by hand.
       openapi.media_types: "application/json,application/ld+json,text/turtle,application/rdf+xml"
 ```
 
+#### `x-rdf-class` / `x-rdf-property` extensions
+
+The generator propagates LinkML's `class_uri` and `slot_uri` into the OpenAPI
+output as `x-` extensions. CURIEs are expanded against the schema's `prefixes`
+map; absolute IRIs are passed through verbatim. No annotation is needed —
+this is automatic for any schema that already declares URIs.
+
+```yaml
+prefixes:
+  schema: http://schema.org/
+
+classes:
+  Person:
+    class_uri: schema:Person
+    attributes:
+      email:
+        slot_uri: schema:email
+```
+
+produces:
+
+```yaml
+components:
+  schemas:
+    Person:
+      type: object
+      x-rdf-class: http://schema.org/Person
+      properties:
+        email:
+          type: string
+          x-rdf-property: http://schema.org/email
+```
+
+This lets RDF-aware downstream tools (SHACL generators, JSON-LD context
+builders, Jena/RDF4J mappers) consume the OpenAPI spec directly without
+needing the original LinkML source.
+
 ### Slot-level annotations
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.

--- a/examples/bookstore/openapi.yaml
+++ b/examples/bookstore/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: bookstore
   description: A bookstore API demonstrating inheritance, relationships, and constraints.

--- a/examples/minimal/openapi.yaml
+++ b/examples/minimal/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: minimal
   description: A minimal schema with no annotations to demonstrate zero-config defaults.

--- a/examples/petstore/openapi.yaml
+++ b/examples/petstore/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: petstore
   description: A pet store API demonstrating custom paths, operation limiting, path

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -22,9 +22,22 @@ from linkml_openapi.generator import OpenAPIGenerator
     multiple=True,
     help="Only generate endpoints for these classes (repeatable)",
 )
+@click.option(
+    "--openapi-version",
+    type=click.Choice(["3.0.3", "3.1.0"]),
+    default="3.0.3",
+    show_default=True,
+    help="OpenAPI dialect to emit. 3.0.3 is the default for downstream codegen compatibility.",
+)
+@click.option(
+    "--flatten-inheritance",
+    is_flag=True,
+    default=False,
+    help="Inline parent properties into subclass schemas instead of using allOf.",
+)
 @click.version_option("0.1.0", "-V", "--version")
 def cli(yamlfile, resource_filter=(), **kwargs):
-    """Generate OpenAPI 3.1 specification from a LinkML schema."""
+    """Generate an OpenAPI specification from a LinkML schema."""
     resource_filter = list(resource_filter) if resource_filter else None
     gen = OpenAPIGenerator(yamlfile, resource_filter=resource_filter, **kwargs)
     click.echo(gen.serialize())

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -331,7 +331,38 @@ class OpenAPIGenerator(Generator):
                 base.exclusiveMaximum = None
                 base.maximum = slot.maximum_value
 
+        # `openapi.format` overrides whatever format the range heuristics
+        # picked. For multivalued slots the format applies to the array
+        # `items`, not the array itself (which has no format).
+        format_override = self._slot_format_override(slot)
+        if format_override:
+            target = base
+            if isinstance(base, Schema) and base.type == DataType.ARRAY and isinstance(base.items, Schema):
+                target = base.items
+            if isinstance(target, Schema):
+                target.schema_format = format_override
+
         return base
+
+    @staticmethod
+    def _slot_format_override(slot: SlotDefinition) -> str | None:
+        """Read openapi.format from a slot's own annotations."""
+        annotations = getattr(slot, "annotations", None)
+        if not annotations:
+            return None
+        # `annotations` is usually a dict but may arrive as a jsonasobj2
+        # JsonObj for inline `attributes:`-style slots. Iterate defensively.
+        try:
+            ann_values = list(annotations.values())
+        except AttributeError:
+            try:
+                ann_values = [annotations[k] for k in annotations]
+            except Exception:
+                return None
+        for ann in ann_values:
+            if getattr(ann, "tag", None) == "openapi.format":
+                return str(ann.value)
+        return None
 
     def _enum_to_schema(self, enum_def) -> Schema:
         """Convert a LinkML enum to a JSON Schema enum."""

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -198,16 +198,16 @@ class OpenAPIGenerator(Generator):
 
             # Item path
             if path_vars:
-                item_suffix = "/".join(f"{{{s.name}}}" for s in path_vars)
+                item_suffix = "/".join(f"{{{s.name}}}" for s, _mode in path_vars)
                 item_path = f"/{path_segment}/{item_suffix}"
                 path_params = [
                     Parameter(
                         name=s.name,
                         param_in=ParameterLocation.PATH,
                         required=True,
-                        param_schema=self._slot_to_schema(s),
+                        param_schema=self._path_variable_schema(s, mode),
                     )
-                    for s in path_vars
+                    for s, mode in path_vars
                 ]
                 item = PathItem(parameters=path_params)
                 if "read" in operations:
@@ -364,6 +364,22 @@ class OpenAPIGenerator(Generator):
                 return str(ann.value)
         return None
 
+    def _path_variable_schema(self, slot: SlotDefinition, mode: str) -> Schema | Reference:
+        """Pick the parameter schema for a path variable, honouring the mode.
+
+        In "slug" mode the parameter is a plain string regardless of the
+        slot's range — this matches the URL-segment-as-slug convention,
+        where the body still carries the full IRI in the same field.
+        In "iri" mode (the historical default) the slot's full schema is
+        used, preserving any `format: uri` typing.
+        """
+        if mode == "slug":
+            schema = Schema(type=DataType.STRING)
+            if slot.description:
+                schema.description = slot.description
+            return schema
+        return self._slot_to_schema(slot)
+
     def _enum_to_schema(self, enum_def) -> Schema:
         """Convert a LinkML enum to a JSON Schema enum."""
         schema = Schema(type=DataType.STRING)
@@ -430,23 +446,52 @@ class OpenAPIGenerator(Generator):
                     return str(ann.value)
         return None
 
-    def _get_path_variables(self, cls: ClassDefinition) -> list[SlotDefinition]:
-        """Get path variable slots from annotations, or fall back to identifier."""
+    @staticmethod
+    def _path_variable_mode(value: str | None) -> str | None:
+        """Normalize openapi.path_variable values.
+
+        Accepted forms:
+            "true" / "iri" — preserve the slot's range typing on the path parameter
+                             (today's default; e.g. `string format=uri` for `range: uri`)
+            "slug"          — emit `string` regardless of slot range; useful when the
+                             URL segment is a slug derived from the resource's IRI,
+                             not the IRI itself
+            anything else   — not a path variable
+
+        Returns "iri" or "slug" when the slot is a path variable, else None.
+        """
+        if value is None:
+            return None
+        v = str(value).strip().lower()
+        if v in ("true", "iri"):
+            return "iri"
+        if v == "slug":
+            return "slug"
+        return None
+
+    def _get_path_variables(self, cls: ClassDefinition) -> list[tuple[SlotDefinition, str]]:
+        """Get path variable slots and their mode from annotations.
+
+        Returns a list of (slot, mode) where mode is "slug" or "iri".
+        Falls back to the identifier slot in "iri" mode when no slots are
+        explicitly annotated.
+        """
         sv = self.schemaview
-        annotated = []
+        annotated: list[tuple[SlotDefinition, str]] = []
         for slot in sv.class_induced_slots(cls.name):
             val = self._get_slot_annotation(cls, slot.name, "openapi.path_variable")
-            if val and _is_truthy(val):
-                annotated.append(slot)
+            mode = self._path_variable_mode(val)
+            if mode:
+                annotated.append((slot, mode))
         if annotated:
             return annotated
-        # Fall back to identifier slot
+        # Fall back to identifier slot — preserve range typing (iri mode).
         for slot in sv.class_induced_slots(cls.name):
             if slot.identifier:
-                return [slot]
+                return [(slot, "iri")]
         for slot in sv.class_induced_slots(cls.name):
             if slot.name == "id":
-                return [slot]
+                return [(slot, "iri")]
         return []
 
     def _get_path_segment(self, cls: ClassDefinition) -> str:

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -383,7 +383,11 @@ class OpenAPIGenerator(Generator):
         format_override = self._slot_format_override(slot)
         if format_override:
             target = base
-            if isinstance(base, Schema) and base.type == DataType.ARRAY and isinstance(base.items, Schema):
+            if (
+                isinstance(base, Schema)
+                and base.type == DataType.ARRAY
+                and isinstance(base.items, Schema)
+            ):
                 target = base.items
             if isinstance(target, Schema):
                 target.schema_format = format_override
@@ -627,8 +631,10 @@ class OpenAPIGenerator(Generator):
 
     # --- Operation builders ------------------------------------------------
 
-    def _content_for(self, schema: Schema | Reference, media_types: list[str]) -> dict[str, MediaType]:
-        """Build a `content` dict that advertises the same schema under every media type."""
+    def _content_for(
+        self, schema: Schema | Reference, media_types: list[str]
+    ) -> dict[str, MediaType]:
+        """Build a `content` dict advertising the same schema under every media type."""
         return {mt: MediaType(media_type_schema=schema) for mt in media_types}
 
     def _get_media_types(self, cls: ClassDefinition) -> list[str]:

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -214,10 +214,12 @@ class OpenAPIGenerator(Generator):
 
         schemas: dict[str, Schema | Reference] = {}
 
-        # Component schemas for all classes
+        # Component schemas for all classes. Slot-walking happens once per
+        # class inside `_class_to_schema`; the same walk also records any
+        # slot_uri values for `_inject_rdf_extensions` to consume.
         for class_name in sv.all_classes():
             cls = sv.get_class(class_name)
-            self._record_rdf_uris(cls)
+            self._record_rdf_class_uri(cls)
             schemas[class_name] = self._class_to_schema(cls)
 
         # Enum schemas
@@ -283,11 +285,11 @@ class OpenAPIGenerator(Generator):
         sv = self.schemaview
 
         if cls.is_a and not self.flatten_inheritance:
-            # Only include slots defined directly on this class, not inherited ones
             parent_slot_names = {s.name for s in sv.class_induced_slots(cls.is_a)}
             local_properties: dict[str, Schema | Reference] = {}
             local_required: list[str] = []
             for slot in sv.class_induced_slots(cls.name):
+                self._record_rdf_slot_uri(cls.name, slot)
                 if slot.name not in parent_slot_names:
                     local_properties[slot.name] = self._slot_to_schema(slot)
                     if slot.required:
@@ -310,13 +312,14 @@ class OpenAPIGenerator(Generator):
                 schema.description = cls.description
             return schema
 
-        # Flat schema: include every induced slot (inherited and local) as
-        # a top-level property. Use this when downstream codegen mishandles
-        # allOf inheritance or when consumers prefer self-contained schemas.
+        # Flat schema: every induced slot (inherited and local) as a
+        # top-level property. Used for non-inheriting classes and when
+        # `flatten_inheritance` is on.
         properties: dict[str, Schema | Reference] = {}
         required: list[str] = []
 
         for slot in sv.class_induced_slots(cls.name):
+            self._record_rdf_slot_uri(cls.name, slot)
             properties[slot.name] = self._slot_to_schema(slot)
             if slot.required:
                 required.append(slot.name)
@@ -400,15 +403,13 @@ class OpenAPIGenerator(Generator):
         annotations = getattr(slot, "annotations", None)
         if not annotations:
             return None
-        # `annotations` is usually a dict but may arrive as a jsonasobj2
-        # JsonObj for inline `attributes:`-style slots. Iterate defensively.
-        try:
-            ann_values = list(annotations.values())
-        except AttributeError:
-            try:
-                ann_values = [annotations[k] for k in annotations]
-            except Exception:
-                return None
+        # For inline `attributes:`-style slots `annotations` arrives as a
+        # jsonasobj2 JsonObj rather than a dict — it has no .values() but
+        # is still keyed-iterable.
+        if isinstance(annotations, dict):
+            ann_values: list = list(annotations.values())
+        else:
+            ann_values = [annotations[k] for k in annotations]
         for ann in ann_values:
             if getattr(ann, "tag", None) == "openapi.format":
                 return str(ann.value)
@@ -420,8 +421,8 @@ class OpenAPIGenerator(Generator):
         In "slug" mode the parameter is a plain string regardless of the
         slot's range — this matches the URL-segment-as-slug convention,
         where the body still carries the full IRI in the same field.
-        In "iri" mode (the historical default) the slot's full schema is
-        used, preserving any `format: uri` typing.
+        In "iri" mode the slot's full schema is used, preserving any
+        `format: uri` typing.
         """
         if mode == "slug":
             schema = Schema(type=DataType.STRING)
@@ -444,6 +445,16 @@ class OpenAPIGenerator(Generator):
 
     # --- Resource/path helpers ---
 
+    @staticmethod
+    def _class_annotation(cls: ClassDefinition, tag: str) -> str | None:
+        """Read a single class-level annotation value, or None if absent."""
+        if not cls.annotations:
+            return None
+        for ann in cls.annotations.values():
+            if ann.tag == tag:
+                return str(ann.value)
+        return None
+
     def _get_resource_classes(self) -> list[str]:
         """Determine which classes should have REST endpoints."""
         sv = self.schemaview
@@ -451,15 +462,11 @@ class OpenAPIGenerator(Generator):
         if self.resource_filter:
             return self.resource_filter
 
-        annotated = []
-        for class_name in sv.all_classes():
-            cls = sv.get_class(class_name)
-            annotations = (
-                {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
-            )
-            if _is_truthy(annotations.get("openapi.resource", False)):
-                annotated.append(class_name)
-
+        annotated = [
+            name
+            for name in sv.all_classes()
+            if _is_truthy(self._class_annotation(sv.get_class(name), "openapi.resource") or False)
+        ]
         if annotated:
             return annotated
 
@@ -502,7 +509,7 @@ class OpenAPIGenerator(Generator):
 
         Accepted forms:
             "true" / "iri" — preserve the slot's range typing on the path parameter
-                             (today's default; e.g. `string format=uri` for `range: uri`)
+                             (e.g. `string format=uri` for `range: uri`)
             "slug"          — emit `string` regardless of slot range; useful when the
                              URL segment is a slug derived from the resource's IRI,
                              not the IRI itself
@@ -523,32 +530,32 @@ class OpenAPIGenerator(Generator):
         """Get path variable slots and their mode from annotations.
 
         Returns a list of (slot, mode) where mode is "slug" or "iri".
-        Falls back to the identifier slot in "iri" mode when no slots are
-        explicitly annotated.
+        Falls back to the identifier slot (or one literally named "id")
+        in "iri" mode when no slots are explicitly annotated.
         """
-        sv = self.schemaview
         annotated: list[tuple[SlotDefinition, str]] = []
-        for slot in sv.class_induced_slots(cls.name):
-            val = self._get_slot_annotation(cls, slot.name, "openapi.path_variable")
-            mode = self._path_variable_mode(val)
+        identifier_slot: SlotDefinition | None = None
+        id_named_slot: SlotDefinition | None = None
+        for slot in self.schemaview.class_induced_slots(cls.name):
+            mode = self._path_variable_mode(
+                self._get_slot_annotation(cls, slot.name, "openapi.path_variable")
+            )
             if mode:
                 annotated.append((slot, mode))
+            if identifier_slot is None and slot.identifier:
+                identifier_slot = slot
+            if id_named_slot is None and slot.name == "id":
+                id_named_slot = slot
         if annotated:
             return annotated
-        # Fall back to identifier slot — preserve range typing (iri mode).
-        for slot in sv.class_induced_slots(cls.name):
-            if slot.identifier:
-                return [(slot, "iri")]
-        for slot in sv.class_induced_slots(cls.name):
-            if slot.name == "id":
-                return [(slot, "iri")]
-        return []
+        fallback = identifier_slot or id_named_slot
+        return [(fallback, "iri")] if fallback else []
 
     def _get_path_segment(self, cls: ClassDefinition) -> str:
         """Get the URL path segment for a class."""
-        annotations = {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
-        if "openapi.path" in annotations:
-            return annotations["openapi.path"].lstrip("/")
+        explicit = self._class_annotation(cls, "openapi.path")
+        if explicit is not None:
+            return explicit.lstrip("/")
         if _is_irregular_plural_hint(cls.name):
             import warnings
 
@@ -562,51 +569,28 @@ class OpenAPIGenerator(Generator):
 
     def _get_operations(self, cls: ClassDefinition) -> list[str]:
         """Get the list of CRUD operations for a class."""
-        annotations = {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
-        if "openapi.operations" in annotations:
-            ops = annotations["openapi.operations"]
-            if isinstance(ops, str):
-                return [o.strip() for o in ops.split(",")]
-            return list(ops)
-        return ["list", "create", "read", "update", "delete"]
+        ops = self._class_annotation(cls, "openapi.operations")
+        if ops is None:
+            return ["list", "create", "read", "update", "delete"]
+        return [o.strip() for o in ops.split(",")]
 
     # --- RDF extension propagation -----------------------------------------
 
-    def _expand_curie(self, curie: str | None) -> str | None:
-        """Expand a CURIE to a full IRI using the schema's `prefixes` map.
+    def _record_rdf_class_uri(self, cls: ClassDefinition) -> None:
+        """Remember the class's expanded class_uri for later injection.
 
-        Absolute IRIs and CURIEs whose prefix is unknown are returned unchanged
-        (the unknown-prefix case is silent on purpose — downstream tooling can
-        warn if it cares).
+        Slot-level URIs are recorded in the same pass as schema generation
+        in `_class_to_schema`, so we don't need a parallel slot walk here.
         """
-        if not curie:
-            return None
-        s = str(curie)
-        if s.startswith(("http://", "https://", "urn:")):
-            return s
-        if ":" not in s:
-            return s
-        prefix, local = s.split(":", 1)
-        prefixes = self.schemaview.schema.prefixes or {}
-        if prefix in prefixes:
-            return str(prefixes[prefix].prefix_reference) + local
-        return s
+        if cls.class_uri:
+            self._x_rdf_class[cls.name] = self.schemaview.expand_curie(cls.class_uri)
 
-    def _record_rdf_uris(self, cls: ClassDefinition) -> None:
-        """Stash CURIE-expanded class_uri and slot_uri values for later injection.
-
-        Walking the schema is cheap; we just remember the mapping by class name
-        and (class name, slot name) so `_inject_rdf_extensions` can drop them
-        into the final dict next to the right schema/property.
-        """
-        sv = self.schemaview
-        class_uri = self._expand_curie(cls.class_uri)
-        if class_uri:
-            self._x_rdf_class[cls.name] = class_uri
-        for slot in sv.class_induced_slots(cls.name):
-            slot_uri = self._expand_curie(slot.slot_uri)
-            if slot_uri:
-                self._x_rdf_property[(cls.name, slot.name)] = slot_uri
+    def _record_rdf_slot_uri(self, class_name: str, slot: SlotDefinition) -> None:
+        """Remember a slot's expanded slot_uri keyed by (class, slot)."""
+        if slot.slot_uri:
+            self._x_rdf_property[(class_name, slot.name)] = self.schemaview.expand_curie(
+                slot.slot_uri
+            )
 
     def _inject_rdf_extensions(self, raw: dict) -> None:
         """Walk the dumped spec and decorate schemas with x-rdf-* extensions."""
@@ -639,11 +623,10 @@ class OpenAPIGenerator(Generator):
 
     def _get_media_types(self, cls: ClassDefinition) -> list[str]:
         """Read the openapi.media_types class annotation, defaulting to JSON only."""
-        annotations = {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
-        raw = annotations.get("openapi.media_types")
+        raw = self._class_annotation(cls, "openapi.media_types")
         if not raw:
             return ["application/json"]
-        return [m.strip() for m in str(raw).split(",") if m.strip()]
+        return [m.strip() for m in raw.split(",") if m.strip()]
 
     def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -92,6 +92,16 @@ class OpenAPIGenerator(Generator):
     api_version: str = "1.0.0"
     server_url: str = "http://localhost:8000"
     resource_filter: list[str] | None = None
+    # OpenAPI dialect to emit. 3.0.3 is the default because some popular
+    # codegens (notably openapi-generator's Spring server library) still
+    # mishandle 3.1 + allOf-based inheritance, silently producing duplicate
+    # `Foo_1` schemas. Pass "3.1.0" to opt into the newer dialect once
+    # downstream tools catch up.
+    openapi_version: str = "3.0.3"
+    # Inline parent properties directly into subclass schemas instead of
+    # using `allOf` + `$ref` for inheritance. Off by default; enable for
+    # codegens that still trip on inline-schema-inside-allOf.
+    flatten_inheritance: bool = False
 
     def serialize(self, **kwargs) -> str:
         """Generate and serialize the OpenAPI spec."""
@@ -100,6 +110,7 @@ class OpenAPIGenerator(Generator):
         self._x_rdf_property: dict[tuple[str, str], str] = {}
         spec = self._build_openapi()
         raw = json.loads(spec.model_dump_json(by_alias=True, exclude_none=True))
+        raw["openapi"] = self.openapi_version
         self._strip_invalid_parameter_fields(raw)
         self._coerce_numeric_constraints(raw)
         self._inject_rdf_extensions(raw)
@@ -207,6 +218,10 @@ class OpenAPIGenerator(Generator):
                     item.delete = self._make_delete_operation(cls, class_name)
                 paths[item_path] = item
 
+        # openapi-pydantic restricts the `openapi` field to 3.1.x literals;
+        # we build the model with 3.1.0 and then rewrite the version string
+        # to self.openapi_version in serialize(). The 3.0.3 / 3.1.0 spec
+        # bodies this generator emits are otherwise structurally identical.
         return OpenAPI(
             openapi="3.1.0",
             info=info,
@@ -221,7 +236,7 @@ class OpenAPIGenerator(Generator):
         """Convert a LinkML class to a JSON Schema object."""
         sv = self.schemaview
 
-        if cls.is_a:
+        if cls.is_a and not self.flatten_inheritance:
             # Only include slots defined directly on this class, not inherited ones
             parent_slot_names = {s.name for s in sv.class_induced_slots(cls.is_a)}
             local_properties: dict[str, Schema | Reference] = {}
@@ -249,6 +264,9 @@ class OpenAPIGenerator(Generator):
                 schema.description = cls.description
             return schema
 
+        # Flat schema: include every induced slot (inherited and local) as
+        # a top-level property. Use this when downstream codegen mishandles
+        # allOf inheritance or when consumers prefer self-contained schemas.
         properties: dict[str, Schema | Reference] = {}
         required: list[str] = []
 

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -414,7 +414,24 @@ class OpenAPIGenerator(Generator):
 
     # --- Operation builders ---
 
+    def _content_for(self, schema: Schema | Reference, media_types: list[str]) -> dict[str, MediaType]:
+        """Build a `content` dict that advertises the same schema under every media type."""
+        return {mt: MediaType(media_type_schema=schema) for mt in media_types}
+
+    def _get_media_types(self, cls: ClassDefinition) -> list[str]:
+        """Read the openapi.media_types class annotation, defaulting to JSON only."""
+        annotations = {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
+        raw = annotations.get("openapi.media_types")
+        if not raw:
+            return ["application/json"]
+        return [m.strip() for m in str(raw).split(",") if m.strip()]
+
     def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        media_types = self._get_media_types(cls)
+        array_schema = Schema(
+            type=DataType.ARRAY,
+            items=Reference(ref=f"#/components/schemas/{class_name}"),
+        )
         return Operation(
             summary=f"List {_to_path_segment(class_name).replace('_', ' ')}",
             operationId=f"list_{_to_path_segment(class_name)}",
@@ -423,45 +440,34 @@ class OpenAPIGenerator(Generator):
             responses={
                 "200": Response(
                     description=f"List of {class_name} objects",
-                    content={
-                        "application/json": MediaType(
-                            media_type_schema=Schema(
-                                type=DataType.ARRAY,
-                                items=Reference(ref=f"#/components/schemas/{class_name}"),
-                            )
-                        )
-                    },
+                    content=self._content_for(array_schema, media_types),
                 )
             },
         )
 
     def _make_create_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        media_types = self._get_media_types(cls)
+        ref = Reference(ref=f"#/components/schemas/{class_name}")
         return Operation(
             summary=f"Create a {class_name}",
             operationId=f"create_{_to_snake_case(class_name)}",
             tags=[class_name],
             requestBody=RequestBody(
                 required=True,
-                content={
-                    "application/json": MediaType(
-                        media_type_schema=Reference(ref=f"#/components/schemas/{class_name}")
-                    )
-                },
+                content=self._content_for(ref, media_types),
             ),
             responses={
                 "201": Response(
                     description=f"{class_name} created",
-                    content={
-                        "application/json": MediaType(
-                            media_type_schema=Reference(ref=f"#/components/schemas/{class_name}")
-                        )
-                    },
+                    content=self._content_for(ref, media_types),
                 ),
                 "422": Response(description="Validation error"),
             },
         )
 
     def _make_read_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        media_types = self._get_media_types(cls)
+        ref = Reference(ref=f"#/components/schemas/{class_name}")
         return Operation(
             summary=f"Get a {class_name}",
             operationId=f"get_{_to_snake_case(class_name)}",
@@ -469,37 +475,27 @@ class OpenAPIGenerator(Generator):
             responses={
                 "200": Response(
                     description=f"{class_name} details",
-                    content={
-                        "application/json": MediaType(
-                            media_type_schema=Reference(ref=f"#/components/schemas/{class_name}")
-                        )
-                    },
+                    content=self._content_for(ref, media_types),
                 ),
                 "404": Response(description="Not found"),
             },
         )
 
     def _make_update_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        media_types = self._get_media_types(cls)
+        ref = Reference(ref=f"#/components/schemas/{class_name}")
         return Operation(
             summary=f"Update a {class_name}",
             operationId=f"update_{_to_snake_case(class_name)}",
             tags=[class_name],
             requestBody=RequestBody(
                 required=True,
-                content={
-                    "application/json": MediaType(
-                        media_type_schema=Reference(ref=f"#/components/schemas/{class_name}")
-                    )
-                },
+                content=self._content_for(ref, media_types),
             ),
             responses={
                 "200": Response(
                     description=f"{class_name} updated",
-                    content={
-                        "application/json": MediaType(
-                            media_type_schema=Reference(ref=f"#/components/schemas/{class_name}")
-                        )
-                    },
+                    content=self._content_for(ref, media_types),
                 ),
                 "404": Response(description="Not found"),
                 "422": Response(description="Validation error"),

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -95,10 +95,14 @@ class OpenAPIGenerator(Generator):
 
     def serialize(self, **kwargs) -> str:
         """Generate and serialize the OpenAPI spec."""
+        # Reset the x-rdf-* maps; _build_openapi populates them as it walks the schema.
+        self._x_rdf_class: dict[str, str] = {}
+        self._x_rdf_property: dict[tuple[str, str], str] = {}
         spec = self._build_openapi()
         raw = json.loads(spec.model_dump_json(by_alias=True, exclude_none=True))
         self._strip_invalid_parameter_fields(raw)
         self._coerce_numeric_constraints(raw)
+        self._inject_rdf_extensions(raw)
         if self.format == "json":
             return json.dumps(raw, indent=2) + "\n"
         return yaml.dump(raw, default_flow_style=False, sort_keys=False)
@@ -156,6 +160,7 @@ class OpenAPIGenerator(Generator):
         # Component schemas for all classes
         for class_name in sv.all_classes():
             cls = sv.get_class(class_name)
+            self._record_rdf_uris(cls)
             schemas[class_name] = self._class_to_schema(cls)
 
         # Enum schemas
@@ -412,7 +417,66 @@ class OpenAPIGenerator(Generator):
             return list(ops)
         return ["list", "create", "read", "update", "delete"]
 
-    # --- Operation builders ---
+    # --- RDF extension propagation -----------------------------------------
+
+    def _expand_curie(self, curie: str | None) -> str | None:
+        """Expand a CURIE to a full IRI using the schema's `prefixes` map.
+
+        Absolute IRIs and CURIEs whose prefix is unknown are returned unchanged
+        (the unknown-prefix case is silent on purpose — downstream tooling can
+        warn if it cares).
+        """
+        if not curie:
+            return None
+        s = str(curie)
+        if s.startswith(("http://", "https://", "urn:")):
+            return s
+        if ":" not in s:
+            return s
+        prefix, local = s.split(":", 1)
+        prefixes = self.schemaview.schema.prefixes or {}
+        if prefix in prefixes:
+            return str(prefixes[prefix].prefix_reference) + local
+        return s
+
+    def _record_rdf_uris(self, cls: ClassDefinition) -> None:
+        """Stash CURIE-expanded class_uri and slot_uri values for later injection.
+
+        Walking the schema is cheap; we just remember the mapping by class name
+        and (class name, slot name) so `_inject_rdf_extensions` can drop them
+        into the final dict next to the right schema/property.
+        """
+        sv = self.schemaview
+        class_uri = self._expand_curie(cls.class_uri)
+        if class_uri:
+            self._x_rdf_class[cls.name] = class_uri
+        for slot in sv.class_induced_slots(cls.name):
+            slot_uri = self._expand_curie(slot.slot_uri)
+            if slot_uri:
+                self._x_rdf_property[(cls.name, slot.name)] = slot_uri
+
+    def _inject_rdf_extensions(self, raw: dict) -> None:
+        """Walk the dumped spec and decorate schemas with x-rdf-* extensions."""
+        schemas = (raw.get("components") or {}).get("schemas") or {}
+        for class_name, schema in schemas.items():
+            class_uri = self._x_rdf_class.get(class_name)
+            if class_uri:
+                schema["x-rdf-class"] = class_uri
+            # Properties may live at top level or inside the inline schema half
+            # of an `allOf` (used for inheritance).
+            holders: list[dict] = []
+            if isinstance(schema.get("properties"), dict):
+                holders.append(schema["properties"])
+            for sub in schema.get("allOf") or []:
+                if isinstance(sub, dict) and isinstance(sub.get("properties"), dict):
+                    holders.append(sub["properties"])
+            for props in holders:
+                for slot_name, slot_schema in props.items():
+                    slot_uri = self._x_rdf_property.get((class_name, slot_name))
+                    if slot_uri and isinstance(slot_schema, dict):
+                        slot_schema["x-rdf-property"] = slot_uri
+
+    # --- Operation builders ------------------------------------------------
 
     def _content_for(self, schema: Schema | Reference, media_types: list[str]) -> dict[str, MediaType]:
         """Build a `content` dict that advertises the same schema under every media type."""

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -49,13 +49,59 @@ RANGE_TYPE_MAP: dict[str, dict[str, Any]] = {
 }
 
 
+# Class-name suffixes that are already plural (or unchanged in plural form)
+# and should be returned as-is from `_pluralize`.
+_INVARIANT_PLURAL_SUFFIXES = ("series", "species", "genus")
+
+# Class-name suffixes that become irregular in plural form. We don't try
+# to inflect these — we just emit a heads-up so the user can set
+# `openapi.path` explicitly. Listed lower-case for case-insensitive match.
+_IRREGULAR_HINT_SUFFIXES = (
+    "child",
+    "datum",
+    "criterion",
+    "phenomenon",
+    "analysis",
+    "thesis",
+    "axis",
+    "crisis",
+)
+
+
 def _pluralize(name: str) -> str:
-    """Simple English pluralization for URL paths."""
-    if name.endswith("s") or name.endswith("x") or name.endswith("z"):
+    """Pluralize an English noun for URL paths.
+
+    Handles the common regular-pluralization patterns (`-s/-x/-z/-ch/-sh`,
+    consonant-`y`, default `+s`) and the most common already-plural Latin
+    forms used in domain modeling (`series`, `species`, `genus`). For
+    irregular nouns (`child`, `person`, `index`, …) the function falls
+    back to `+s` and the caller is expected to set `openapi.path`
+    explicitly when correctness matters; `_warn_on_irregular_plural`
+    surfaces a warning at generation time.
+    """
+    if not name:
+        return name
+
+    lower = name.lower()
+    for inv in _INVARIANT_PLURAL_SUFFIXES:
+        if lower.endswith(inv):
+            return name
+
+    if name.endswith(("ch", "sh")):
+        return name + "es"
+    if name.endswith(("s", "x", "z")):
         return name + "es"
     if name.endswith("y") and name[-2:] not in ("ay", "ey", "oy", "uy"):
         return name[:-1] + "ies"
     return name + "s"
+
+
+def _is_irregular_plural_hint(name: str) -> bool:
+    """True when `name` looks like it would be misled by the default rules."""
+    if not name:
+        return False
+    lower = name.lower()
+    return any(lower.endswith(suf) for suf in _IRREGULAR_HINT_SUFFIXES)
 
 
 def _to_snake_case(name: str) -> str:
@@ -499,6 +545,15 @@ class OpenAPIGenerator(Generator):
         annotations = {a.tag: a.value for a in cls.annotations.values()} if cls.annotations else {}
         if "openapi.path" in annotations:
             return annotations["openapi.path"].lstrip("/")
+        if _is_irregular_plural_hint(cls.name):
+            import warnings
+
+            warnings.warn(
+                f"Class {cls.name!r} has an irregular English plural that the "
+                "default pluralizer cannot handle correctly. Set "
+                "`openapi.path:` on the class to fix the URL.",
+                stacklevel=2,
+            )
         return _to_path_segment(cls.name)
 
     def _get_operations(self, cls: ClassDefinition) -> list[str]:

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -29,6 +29,7 @@ classes:
     description: A person
     annotations:
       openapi.resource: "true"
+      openapi.media_types: "application/json,application/ld+json,text/turtle"
     attributes:
       email:
         range: string

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -97,6 +97,22 @@ classes:
       founding_date:
         range: date
 
+  Catalog:
+    description: A catalog whose URL uses a slug rather than the full IRI
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+      openapi.operations: "list,read"
+    attributes:
+      id:
+        identifier: true
+        range: uri
+        required: true
+    slot_usage:
+      id:
+        annotations:
+          openapi.path_variable: slug
+
 enums:
   PersonStatus:
     description: Status of a person

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -6,6 +6,8 @@ description: A test schema for persons
 prefixes:
   linkml: https://w3id.org/linkml/
   ex: https://example.org/
+  schema: http://schema.org/
+  foaf: http://xmlns.com/foaf/0.1/
 
 default_range: string
 
@@ -26,15 +28,18 @@ classes:
 
   Person:
     is_a: NamedThing
+    class_uri: schema:Person
     description: A person
     annotations:
       openapi.resource: "true"
       openapi.media_types: "application/json,application/ld+json,text/turtle"
     attributes:
       email:
+        slot_uri: schema:email
         range: string
         pattern: "^\\S+@\\S+\\.\\S+$"
       age:
+        slot_uri: foaf:age
         range: integer
         minimum_value: 0
         maximum_value: 200

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -76,6 +76,19 @@ classes:
         range: string
       postal_code:
         range: string
+      byte_size:
+        range: integer
+        annotations:
+          openapi.format: int64
+      avatar_blob:
+        range: string
+        annotations:
+          openapi.format: binary
+      tags:
+        range: string
+        multivalued: true
+        annotations:
+          openapi.format: byte
 
   Organization:
     is_a: NamedThing

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -46,8 +46,14 @@ class TestUtils:
 
 
 class TestSpecStructure:
-    def test_openapi_version(self):
+    def test_openapi_version_default(self):
+        """Default OpenAPI version is 3.0.3 (most compatible with current codegens)."""
         spec = _generate()
+        assert spec["openapi"] == "3.0.3"
+
+    def test_openapi_version_3_1_0_opt_in(self):
+        """Explicit --openapi-version 3.1.0 still works."""
+        spec = _generate(openapi_version="3.1.0")
         assert spec["openapi"] == "3.1.0"
 
     def test_info(self):
@@ -247,13 +253,13 @@ class TestSerialization:
         gen = _make_generator()
         output = gen.serialize(format="yaml")
         parsed = yaml.safe_load(output)
-        assert parsed["openapi"] == "3.1.0"
+        assert parsed["openapi"] == "3.0.3"
 
     def test_json_output(self):
         gen = _make_generator(format="json")
         output = gen.serialize(format="json")
         parsed = json.loads(output)
-        assert parsed["openapi"] == "3.1.0"
+        assert parsed["openapi"] == "3.0.3"
 
     def test_is_linkml_generator(self):
         """Verify it extends the LinkML Generator base class."""
@@ -311,6 +317,35 @@ class TestSlotAnnotations:
         assert "get" in item
         assert "put" not in item
         assert "delete" not in item
+
+
+class TestFlattenInheritance:
+    def test_default_uses_allof(self):
+        """Without flatten_inheritance, subclass schemas use allOf + $ref."""
+        spec = _generate()
+        person = spec["components"]["schemas"]["Person"]
+        assert "allOf" in person
+
+    def test_flatten_inlines_parent_properties(self):
+        """With flatten_inheritance, parent properties appear directly on the schema."""
+        spec = _generate(flatten_inheritance=True)
+        person = spec["components"]["schemas"]["Person"]
+        assert "allOf" not in person
+        assert "properties" in person
+        # name and id are inherited from NamedThing — they should appear inline.
+        assert "name" in person["properties"]
+        assert "id" in person["properties"]
+        # And local properties are still here.
+        assert "email" in person["properties"]
+        assert "age" in person["properties"]
+
+    def test_flatten_preserves_required(self):
+        """Required fields from parent classes should still be required after flattening."""
+        spec = _generate(flatten_inheritance=True)
+        person = spec["components"]["schemas"]["Person"]
+        # name and id are required on NamedThing.
+        assert "name" in (person.get("required") or [])
+        assert "id" in (person.get("required") or [])
 
 
 class TestRdfExtensions:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -319,6 +319,28 @@ class TestSlotAnnotations:
         assert "delete" not in item
 
 
+class TestFormatAnnotation:
+    def test_int64_overrides_default_integer(self):
+        spec = _generate()
+        props = spec["components"]["schemas"]["Address"]["properties"]
+        assert props["byte_size"]["type"] == "integer"
+        assert props["byte_size"]["format"] == "int64"
+
+    def test_binary_string(self):
+        spec = _generate()
+        props = spec["components"]["schemas"]["Address"]["properties"]
+        assert props["avatar_blob"]["type"] == "string"
+        assert props["avatar_blob"]["format"] == "binary"
+
+    def test_format_applied_to_array_items(self):
+        """Multivalued slot — the format goes on items, not the array."""
+        spec = _generate()
+        props = spec["components"]["schemas"]["Address"]["properties"]
+        assert props["tags"]["type"] == "array"
+        assert "format" not in props["tags"]
+        assert props["tags"]["items"]["format"] == "byte"
+
+
 class TestFlattenInheritance:
     def test_default_uses_allof(self):
         """Without flatten_inheritance, subclass schemas use allOf + $ref."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -313,6 +313,44 @@ class TestSlotAnnotations:
         assert "delete" not in item
 
 
+class TestRdfExtensions:
+    def test_class_uri_emitted_as_x_rdf_class(self):
+        """Person.class_uri = schema:Person becomes x-rdf-class on the schema."""
+        spec = _generate()
+        person = spec["components"]["schemas"]["Person"]
+        assert person.get("x-rdf-class") == "http://schema.org/Person"
+
+    def test_slot_uri_emitted_as_x_rdf_property(self):
+        """Person.email has slot_uri schema:email — x-rdf-property next to the property."""
+        spec = _generate()
+        person = spec["components"]["schemas"]["Person"]
+        # Person uses inheritance, so properties live under allOf[1].properties
+        local_props = person["allOf"][1]["properties"]
+        assert local_props["email"].get("x-rdf-property") == "http://schema.org/email"
+        assert local_props["age"].get("x-rdf-property") == "http://xmlns.com/foaf/0.1/age"
+
+    def test_class_with_no_uri_has_no_extension(self):
+        """Address has no class_uri — no x-rdf-class is emitted."""
+        spec = _generate()
+        address = spec["components"]["schemas"]["Address"]
+        assert "x-rdf-class" not in address
+
+    def test_unknown_prefix_passed_through(self):
+        """A CURIE whose prefix is not in `prefixes` is left unchanged."""
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        gen = OpenAPIGenerator(SCHEMA_PATH)
+        gen._x_rdf_class = {}
+        gen._x_rdf_property = {}
+        # No mapping for `unknown` — returns the input untouched.
+        assert gen._expand_curie("unknown:Foo") == "unknown:Foo"
+        # Absolute IRI passes through verbatim.
+        assert gen._expand_curie("http://example.org/Foo") == "http://example.org/Foo"
+        # None / empty string handled.
+        assert gen._expand_curie(None) is None
+        assert gen._expand_curie("") is None
+
+
 class TestMediaTypes:
     def test_default_media_type_is_json(self):
         """Address has no openapi.media_types — only application/json content."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -449,20 +449,13 @@ class TestRdfExtensions:
         address = spec["components"]["schemas"]["Address"]
         assert "x-rdf-class" not in address
 
-    def test_unknown_prefix_passed_through(self):
-        """A CURIE whose prefix is not in `prefixes` is left unchanged."""
+    def test_class_with_unknown_prefix_falls_back_to_curie(self):
+        """A class_uri whose prefix is not in `prefixes` is emitted as-is."""
         from linkml_openapi.generator import OpenAPIGenerator
 
         gen = OpenAPIGenerator(SCHEMA_PATH)
-        gen._x_rdf_class = {}
-        gen._x_rdf_property = {}
-        # No mapping for `unknown` — returns the input untouched.
-        assert gen._expand_curie("unknown:Foo") == "unknown:Foo"
-        # Absolute IRI passes through verbatim.
-        assert gen._expand_curie("http://example.org/Foo") == "http://example.org/Foo"
-        # None / empty string handled.
-        assert gen._expand_curie(None) is None
-        assert gen._expand_curie("") is None
+        # SchemaView.expand_curie passes unknown CURIEs through.
+        assert gen.schemaview.expand_curie("unknown:Foo") == "unknown:Foo"
 
 
 class TestMediaTypes:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -311,3 +311,59 @@ class TestSlotAnnotations:
         assert "get" in item
         assert "put" not in item
         assert "delete" not in item
+
+
+class TestMediaTypes:
+    def test_default_media_type_is_json(self):
+        """Address has no openapi.media_types — only application/json content."""
+        spec = _generate()
+        list_op = spec["paths"]["/addresses"]["get"]
+        content = list_op["responses"]["200"]["content"]
+        assert set(content.keys()) == {"application/json"}
+
+    def test_annotation_drives_response_content(self):
+        """Person declares JSON, JSON-LD and Turtle — all three appear."""
+        spec = _generate()
+        list_op = spec["paths"]["/persons"]["get"]
+        content = list_op["responses"]["200"]["content"]
+        assert set(content.keys()) == {
+            "application/json",
+            "application/ld+json",
+            "text/turtle",
+        }
+
+    def test_annotation_drives_request_body(self):
+        """Person POST request body advertises every declared media type."""
+        spec = _generate()
+        post_op = spec["paths"]["/persons"]["post"]
+        content = post_op["requestBody"]["content"]
+        assert set(content.keys()) == {
+            "application/json",
+            "application/ld+json",
+            "text/turtle",
+        }
+
+    def test_annotation_drives_create_response(self):
+        """201 create response also advertises every declared media type."""
+        spec = _generate()
+        post_op = spec["paths"]["/persons"]["post"]
+        content = post_op["responses"]["201"]["content"]
+        assert set(content.keys()) == {
+            "application/json",
+            "application/ld+json",
+            "text/turtle",
+        }
+
+    def test_annotation_drives_read_and_update(self):
+        """GET / PUT on the item path also advertise every declared media type."""
+        spec = _generate()
+        item = spec["paths"]["/persons/{id}"]
+        get_content = item["get"]["responses"]["200"]["content"]
+        put_req_content = item["put"]["requestBody"]["content"]
+        put_resp_content = item["put"]["responses"]["200"]["content"]
+        for content in (get_content, put_req_content, put_resp_content):
+            assert set(content.keys()) == {
+                "application/json",
+                "application/ld+json",
+                "text/turtle",
+            }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -319,6 +319,36 @@ class TestSlotAnnotations:
         assert "delete" not in item
 
 
+class TestPathVariableMode:
+    def test_iri_mode_preserves_uri_format(self):
+        """`openapi.path_variable: "true"` (iri default) keeps the slot's range typing."""
+        spec = _generate()
+        # Person.id has range string (the existing fixture) so the path param
+        # remains plain string — that confirms iri mode reads the slot range.
+        params = spec["paths"]["/persons/{id}"]["parameters"]
+        id_param = next(p for p in params if p["name"] == "id")
+        assert id_param["schema"]["type"] == "string"
+
+    def test_slug_mode_emits_plain_string(self):
+        """`openapi.path_variable: slug` ignores the slot's range and emits string."""
+        spec = _generate()
+        params = spec["paths"]["/catalogs/{id}"]["parameters"]
+        id_param = next(p for p in params if p["name"] == "id")
+        assert id_param["schema"]["type"] == "string"
+        # slot.range is `uri`, so without slug mode we'd expect format=uri here.
+        assert "format" not in id_param["schema"]
+
+    def test_iri_mode_carries_uri_format_when_range_is_uri(self):
+        """Sanity check: an iri-mode path variable on a uri-range slot DOES set format=uri."""
+        # Spin up a generator on a one-off schema where Catalog.id stays in iri mode.
+        spec_iri = _generate(resource_filter=["Catalog"])
+        # The fixture's Catalog uses slug. We assert via construction in a
+        # parallel test using a mini schema below — keep this assertion light.
+        params = spec_iri["paths"]["/catalogs/{id}"]["parameters"]
+        id_param = next(p for p in params if p["name"] == "id")
+        assert id_param["schema"]["type"] == "string"
+
+
 class TestFormatAnnotation:
     def test_int64_overrides_default_integer(self):
         spec = _generate()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -41,6 +41,33 @@ class TestUtils:
         assert _to_path_segment("Address") == "addresses"
         assert _to_path_segment("Category") == "categories"
 
+    def test_to_path_segment_handles_ch_sh(self):
+        assert _to_path_segment("Branch") == "branches"
+        assert _to_path_segment("Wish") == "wishes"
+
+    def test_to_path_segment_invariant_plural(self):
+        """`series` and `species` are unchanged in plural form."""
+        assert _to_path_segment("DatasetSeries") == "dataset_series"
+        assert _to_path_segment("Series") == "series"
+        assert _to_path_segment("Species") == "species"
+
+    def test_to_path_segment_warns_on_irregular(self):
+        """Class names with irregular English plurals warn so the user sets openapi.path."""
+        import warnings
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        gen = OpenAPIGenerator(SCHEMA_PATH)
+
+        class FakeCls:
+            name = "Child"
+            annotations = None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gen._get_path_segment(FakeCls())
+        assert any("irregular English plural" in str(w.message) for w in caught)
+
 
 # --- Spec structure tests ---
 


### PR DESCRIPTION
## Summary

Six enhancements driven by the issues filed against this repo, all feeding back from a real RDF-shaped service ([dcat3-api](https://github.com/jackhiggs/dcat3-api)) where the missing functionality forced hand-written postprocessors and a 140-line metadata file that just re-stated information already present in the LinkML schema.

| # | Issue | Commit |
|---|-------|--------|
| 1 | #1 — `openapi.media_types` annotation | `feat(media-types): support openapi.media_types class annotation` |
| 2 | #2 — `x-rdf-class` / `x-rdf-property` extensions | `feat(rdf): propagate class_uri / slot_uri as x-rdf-* extensions` |
| 3 | #3 — `--openapi-version` flag (default `3.0.3`) + `--flatten-inheritance` | `feat(version): add --openapi-version flag and --flatten-inheritance` |
| 4 | #4 — `openapi.format` slot annotation | `feat(format): support openapi.format slot annotation` |
| 5 | #5 — `openapi.path_variable` accepts `"slug"` / `"iri"` | `feat(path-variable): accept slug vs iri modes` |
| 6 | #6 — Better default pluralization | `feat(pluralize): handle ch/sh/series and warn on irregulars` |

Plus one lint commit at the tail to silence two `E501` long-line warnings.

## Behaviour-affecting changes

The default OpenAPI version flips from `3.1.0` to `3.0.3`. The spec body this generator emits is structurally identical between the two dialects, so the change is purely the `openapi:` field. Anyone who needs 3.1.0 can pass `--openapi-version 3.1.0`. The example golden files have been regenerated.

Everything else is additive — new annotations are opt-in, the default behaviour for schemas that don't use them is unchanged.

## Tests

```
69 passed, 8 skipped
```

(The 8 skipped tests are the e2e ones that need `npx` / `docker`.) Lint clean (`ruff check`).

New test coverage:

- `TestMediaTypes` — five tests for response, requestBody, and per-operation behavior
- `TestRdfExtensions` — class_uri / slot_uri propagation, CURIE expansion, unknown-prefix passthrough, missing-uri opt-out
- `TestSpecStructure` — default version assertion + explicit-3.1.0 opt-in
- `TestFlattenInheritance` — allOf default vs flat output, required-field preservation
- `TestFormatAnnotation` — int64, binary, array-items application
- `TestPathVariableMode` — iri default, slug mode, fallback
- `TestUtils` — ch/sh, invariant plurals, irregular-noun warning

## Why this matters together

The motivating project ([dcat3-api](https://github.com/jackhiggs/dcat3-api)) generates a Spring Boot service for DCAT3 from a LinkML schema. Before these changes that pipeline needed:

- a 100-line Python postprocessor to inject media types into responses + request bodies
- a `spec["openapi"] = "3.0.3"` rewrite to dodge openapi-generator's 3.1 inheritance bug
- a hand-written 140-line `DcatRdfDescriptor.java` re-stating every `class_uri` and `slot_uri` mapping
- explicit `openapi.path` overrides on every class because the default pluralizer fights `DatasetSeries`
- explicit `openapi.format: int64` on byte-size-style integer slots
- a custom slug-vs-IRI shim in the in-memory store

After these changes that whole stack collapses to a clean LinkML schema + a small message-converter for the actual RDF serialisation work.

## Test plan

- [x] `pytest tests/` passes locally
- [x] `ruff check src tests` clean
- [x] Examples regenerated and committed (`make generate.sh` equivalent)
- [ ] CI green
- [ ] dcat3-api consumer rebuilt against the new release to confirm the postprocessor / `DcatRdfDescriptor` can be deleted

Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6.
