### PR TITLE
ci: enable Dependabot for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  # Python runtime + dev dependencies declared in pyproject.toml
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      # Bundle linkml + linkml-runtime — they release in lockstep and
+      # nearly always need to upgrade together to stay compatible.
+      linkml:
+        patterns:
+          - linkml
+          - linkml-runtime
+      # Group dev-tooling churn so it doesn't dominate the PR queue.
+      dev-tooling:
+        dependency-type: development
+        patterns:
+          - pytest*
+          - ruff
+          - openapi-spec-validator
+
+  # Pinned action SHAs in .github/workflows/*.yml
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so version updates land as PRs automatically.

## Configuration

| Ecosystem | What it watches | Cadence | PR limit |
|-----------|-----------------|---------|----------|
| `pip` | `pyproject.toml` runtime + dev dependencies | Weekly, Monday 09:00 Europe/London | 5 |
| `github-actions` | Pinned action versions in `.github/workflows/*.yml` | Weekly, Monday 09:00 Europe/London | 5 |

## Grouping

To keep the PR queue manageable, related updates ride in a single PR:

- **`linkml` + `linkml-runtime`** → grouped, since they release in lockstep and need to upgrade together to stay compatible.
- **dev tooling** (`pytest*`, `ruff`, `openapi-spec-validator`) → grouped, so churn there doesn't dominate review.

Everything else lands as individual PRs (most importantly `openapi-pydantic`, which is the one runtime dep most likely to ship breaking changes).

## Labels & commit messages

- pip PRs: labelled `dependencies`, `python`; commit prefix `deps:`
- actions PRs: labelled `dependencies`, `github-actions`; commit prefix `ci:`

## Test plan

- [x] YAML validates as Dependabot config (matches the v2 schema)
- [ ] First Dependabot scan runs after merge (visible in the repo's "Insights → Dependency graph → Dependabot" tab)
- [ ] First batch of update PRs lands within 24 hours of merge

Independent of #7 — can land in either order.
