### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jackhiggs/linkml-openapi/security/code-scanning/2](https://github.com/jackhiggs/linkml-openapi/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (best single change), so it applies to all jobs unless overridden. For this workflow, `contents: read` is the least-privilege baseline and is sufficient for checkout and test/lint execution shown.

**File to edit:** `.github/workflows/ci.yml`  
**Change location:** after the `on:` trigger block and before `jobs:`.  
**Required additions:** YAML key:
- `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
