### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(while pre-1.0, minor bumps may carry visible behaviour changes).
+
+## [0.2.0] — 2026-04-25
+
+### Added
+
+- `openapi.media_types` class annotation: every operation generated for a
+  class advertises every listed media type on its responses and request
+  bodies. Default is `application/json`. ([#1](https://github.com/jackhiggs/linkml-openapi/issues/1))
+- `x-rdf-class` and `x-rdf-property` extensions: LinkML's `class_uri` and
+  `slot_uri` are propagated into the generated OpenAPI as standard `x-`
+  extensions, with CURIEs expanded against the schema's `prefixes` map.
+  RDF-aware downstream tooling can now consume the OpenAPI spec directly
+  without re-parsing the LinkML schema. ([#2](https://github.com/jackhiggs/linkml-openapi/issues/2))
+- `--openapi-version` flag (`3.0.3` / `3.1.0`) and `--flatten-inheritance`
+  flag for downstream-codegen friendliness. ([#3](https://github.com/jackhiggs/linkml-openapi/issues/3))
+- `openapi.format` slot annotation overrides the OpenAPI `format` string
+  per slot — for `int64`, `binary`, `byte`, `password`, etc. ([#4](https://github.com/jackhiggs/linkml-openapi/issues/4))
+- `openapi.path_variable` accepts `"slug"` / `"iri"` (`"true"` is an alias
+  for `"iri"`). `"slug"` emits `string` regardless of slot range. ([#5](https://github.com/jackhiggs/linkml-openapi/issues/5))
+- Pluralization handles `-ch` / `-sh` and treats `series` / `species` /
+  `genus` as invariant. Warns at generation time for irregular Latin /
+  Greek loanwords (`Datum`, `Criterion`, `Analysis`, …) so the user can
+  set `openapi.path` explicitly. ([#6](https://github.com/jackhiggs/linkml-openapi/issues/6))
+- `.github/dependabot.yml` for weekly pip + github-actions updates.
+
+### Changed
+
+- **Default `openapi:` version flipped from `3.1.0` to `3.0.3`.** The
+  spec body is structurally identical between the two dialects in this
+  generator's output; the change is purely the version string. Pass
+  `--openapi-version 3.1.0` to opt back into the newer dialect once
+  downstream tooling catches up. The motivating issue is
+  `openapi-generator`'s Spring codegen, which mishandles 3.1 + `allOf`
+  inheritance and synthesises spurious duplicate schemas.
+- `generatorversion`, `cli --version`, `__version__`, and
+  `pyproject.toml`'s `version` are now sourced from a single place.
+
+## [0.1.2] — 2026-02-16
+
+Initial public release.
+
+[0.2.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.2.0
+[0.1.2]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.1.2"
+version = "0.2.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -3,6 +3,7 @@
 import click
 from linkml.utils.generator import shared_arguments
 
+from linkml_openapi import __version__
 from linkml_openapi.generator import OpenAPIGenerator
 
 
@@ -35,7 +36,7 @@ from linkml_openapi.generator import OpenAPIGenerator
     default=False,
     help="Inline parent properties into subclass schemas instead of using allOf.",
 )
-@click.version_option("0.1.0", "-V", "--version")
+@click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, resource_filter=(), **kwargs):
     """Generate an OpenAPI specification from a LinkML schema."""
     resource_filter = list(resource_filter) if resource_filter else None

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -32,6 +32,8 @@ from openapi_pydantic import (
     Server,
 )
 
+from linkml_openapi import __version__
+
 # LinkML range → OpenAPI DataType mapping
 RANGE_TYPE_MAP: dict[str, dict[str, Any]] = {
     "string": {"type": DataType.STRING},
@@ -128,7 +130,7 @@ class OpenAPIGenerator(Generator):
 
     # ClassVar overrides
     generatorname: ClassVar[str] = os.path.basename(__file__)
-    generatorversion: ClassVar[str] = "0.1.0"
+    generatorversion: ClassVar[str] = __version__
     valid_formats: ClassVar[list[str]] = ["yaml", "json"]
     uses_schemaloader: ClassVar[bool] = False
     file_extension: ClassVar[str] = "openapi.yaml"


### PR DESCRIPTION
## Summary

Cuts `0.2.0`. Bumps the version, consolidates the four version sites onto a single `__version__` source, and adds a `CHANGELOG.md`.

## Version sites — now consolidated

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `0.1.2` | `0.2.0` |
| `src/linkml_openapi/__init__.py` | `0.1.2` | `0.2.0` |
| `src/linkml_openapi/cli.py` (`--version`) | `0.1.0` (drift) | `__version__` |
| `src/linkml_openapi/generator.py` (`generatorversion`) | `0.1.0` (drift) | `__version__` |

`cli.py` and `generator.py` now read `__version__` from `__init__.py`, so future bumps need only one edit.

## What's in 0.2.0

Six features (PR #7) plus Dependabot (PR #8):

- `openapi.media_types` class annotation drives `produces`/`consumes` (#1)
- `x-rdf-class` / `x-rdf-property` extensions emitted from `class_uri` / `slot_uri` (#2)
- `--openapi-version` flag (defaults to **3.0.3**) and `--flatten-inheritance` (#3)
- `openapi.format` slot annotation (#4)
- `openapi.path_variable` accepts `"slug"` / `"iri"` (#5)
- Smarter pluralization (#6)
- Dependabot config: weekly pip + github-actions, `linkml`+`linkml-runtime` grouped

## One user-visible behaviour change

The default `openapi:` version flips from `3.1.0` to `3.0.3`. The spec body is structurally identical between the two dialects in this generator's output. Anyone who needs 3.1 can pass `--openapi-version 3.1.0`. Reasoning is documented in the CHANGELOG and `--openapi-version`'s docstring.

## Release plan after merge

1. Tag `v0.2.0` on `main`
2. Create the GitHub release (the `publish.yml` workflow auto-publishes to PyPI on `release: published` via OIDC trusted publishing)
3. Verify the PyPI listing

## Test plan

- [x] All four version sites read `0.2.0` (`__version__`, `OpenAPIGenerator.generatorversion`, `gen-openapi --version`, `pyproject.toml`)
- [x] `pytest tests/` — 69 passed, 8 skipped (e2e)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [ ] CI green
