### PR TITLE
feat (C): discriminator + polymorphism from designates_type (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,92 @@ spec's behaviour, not a generator quirk.
       openapi.operations: "list"        # Collection-only, no item endpoint
 ```
 
+#### Discriminator (polymorphism)
+
+The generator emits an OpenAPI `discriminator` block on a parent schema
+when either signal is present:
+
+1. **LinkML-native** — a slot with `designates_type: true`. The slot
+   becomes the discriminator field; concrete subclass instances default
+   to the class name (LinkML's own behaviour).
+
+   ```yaml
+   classes:
+     Animal:
+       abstract: true
+       attributes:
+         species:
+           designates_type: true
+           range: string
+     Dog:    { is_a: Animal }
+     Cat:    { is_a: Animal }
+   ```
+
+2. **Existing-system override** — `openapi.discriminator: <field>` on the
+   parent picks (or synthesizes) the field, and `openapi.type_value:
+   <string>` on each subclass pins the wire value. Use this when you're
+   adopting linkml-openapi against an existing API surface that already
+   has a fixed field name and fixed values you can't change.
+
+   ```yaml
+   classes:
+     Product:
+       abstract: true
+       annotations:
+         openapi.discriminator: kind     # synthesizes the field if needed
+       attributes:
+         sku: { identifier: true, range: string, required: true }
+     Book:
+       is_a: Product
+       annotations:
+         openapi.type_value: BOOK        # not "Book"
+       attributes:
+         title: { range: string }
+     Vinyl:
+       is_a: Product
+       annotations:
+         openapi.type_value: VINYL
+   ```
+
+   produces
+
+   ```yaml
+   Product:
+     properties:
+       kind: { type: string, enum: [BOOK, VINYL] }
+     required: [sku, kind]
+     discriminator:
+       propertyName: kind
+       mapping:
+         BOOK: '#/components/schemas/Book'
+         VINYL: '#/components/schemas/Vinyl'
+   Book:
+     allOf:
+       - $ref: '#/components/schemas/Product'
+       - properties:
+           kind: { type: string, enum: [BOOK], default: BOOK }
+         required: [kind]
+   ```
+
+| Annotation | Where | Purpose |
+|------------|-------|---------|
+| `openapi.discriminator: <field>` | parent class | Pick or synthesise the discriminator field. Errors if the class also has `designates_type`. |
+| `openapi.type_value: <string>` | concrete subclass | Override the default wire value (class name) for an existing-system match. |
+
+Validation:
+
+- `designates_type: true` and `openapi.discriminator` on the same class
+  → generation error (they say the same thing two ways).
+- Two subclasses with the same `openapi.type_value` in one discriminator
+  group → generation error.
+- Mixins are not part of the polymorphic mapping (they're trait
+  composition, not subtyping).
+
+Polymorphic endpoints fall out automatically: an abstract parent with
+`openapi.resource: "true"` gets standard CRUD paths whose request /
+response schemas `$ref` the parent — and the discriminator block on
+the parent does the polymorphic dispatch at codegen / runtime.
+
 #### `openapi.media_types`
 
 Comma-separated list of media types each operation generated for the class

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -18,6 +18,7 @@ from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 from openapi_pydantic import (
     Components,
     DataType,
+    Discriminator,
     Info,
     MediaType,
     OpenAPI,
@@ -241,6 +242,11 @@ class OpenAPIGenerator(Generator):
         # already exists in the schema.
         if self._error_class_name == "Problem" and "Problem" not in schemas:
             schemas["Problem"] = self._build_problem_schema()
+
+        # Apply discriminator blocks driven by `designates_type` or by
+        # `openapi.discriminator` annotations. Done after class schemas are
+        # built so we can patch the in-memory Schema models in place.
+        self._apply_discriminators(schemas)
 
         # Track whether any reference relationship is generated; if so the
         # shared ResourceLink component is added to the schema set below.
@@ -739,6 +745,198 @@ class OpenAPIGenerator(Generator):
                 "application/problem+json": MediaType(media_type_schema=ref),
             },
         )
+
+    # --- Discriminator / polymorphism (issue #20) --------------------------
+
+    def _designates_type_slot(self, class_name: str) -> SlotDefinition | None:
+        """Return the slot with `designates_type: true` on this class, or None."""
+        for slot in self.schemaview.class_induced_slots(class_name):
+            if getattr(slot, "designates_type", False):
+                return slot
+        return None
+
+    def _discriminator_field(self, cls: ClassDefinition) -> str | None:
+        """The discriminator field name for `cls`, or None.
+
+        Reads (in priority order):
+          1. ``openapi.discriminator: <field>`` class annotation
+          2. ``designates_type: true`` on a slot induced into the class
+
+        Setting both at once is a generation-time error — they say the
+        same thing two ways.
+        """
+        annotation_field = self._class_annotation(cls, "openapi.discriminator")
+        designates_slot = self._designates_type_slot(cls.name)
+        if annotation_field is not None and designates_slot is not None:
+            raise ValueError(
+                f"Class {cls.name!r} declares both designates_type "
+                f"(on slot {designates_slot.name!r}) and "
+                f"openapi.discriminator. Remove one — they describe the same "
+                "discriminator two different ways."
+            )
+        if annotation_field is not None:
+            return annotation_field.strip()
+        if designates_slot is not None:
+            return designates_slot.name
+        return None
+
+    def _is_discriminator_root(self, cls: ClassDefinition, field: str) -> bool:
+        """True when ``cls`` is the topmost class declaring ``field`` as discriminator.
+
+        ``designates_type`` and ``class_induced_slots`` propagate through the
+        ``is_a`` chain, so a concrete leaf naively reports the same
+        discriminator as its abstract parent. Only the root should emit the
+        ``discriminator`` block.
+        """
+        if not cls.is_a:
+            return True
+        parent_cls = self.schemaview.get_class(cls.is_a)
+        if parent_cls is None:
+            return True
+        parent_field = self._discriminator_field(parent_cls)
+        return parent_field != field
+
+    def _concrete_descendants_including_self(self, class_name: str) -> list[str]:
+        """Concrete (non-abstract, non-mixin) descendants plus self if concrete.
+
+        Mixins are excluded entirely from polymorphic mappings — they're
+        trait composition, not subtyping.
+        """
+        sv = self.schemaview
+        out: list[str] = []
+        for name in [class_name] + list(sv.class_descendants(class_name, reflexive=False)):
+            cls = sv.get_class(name)
+            if cls is None or cls.abstract or cls.mixin:
+                continue
+            out.append(name)
+        return out
+
+    def _type_value(self, cls: ClassDefinition) -> str:
+        """The discriminator value for a concrete subclass.
+
+        Defaults to the class name as-is, matching ``designates_type``'s
+        LinkML default. ``openapi.type_value`` overrides — used when an
+        existing system has a fixed value the schema needs to honour.
+        """
+        override = self._class_annotation(cls, "openapi.type_value")
+        return override.strip() if override else cls.name
+
+    def _apply_discriminators(self, schemas: dict[str, Schema | Reference]) -> None:
+        """Patch component schemas with OpenAPI ``discriminator`` blocks.
+
+        For each class that declares a discriminator (via ``designates_type``
+        or ``openapi.discriminator``), attaches:
+          - a ``discriminator`` block on the parent's component schema
+          - a ``required``-with-enum form of the discriminator field
+            (synthesizing the property if the LinkML side didn't declare it)
+          - a single-value enum + default on every concrete descendant's
+            local property block
+        """
+        sv = self.schemaview
+        for class_name in sv.all_classes():
+            cls = sv.get_class(class_name)
+            field = self._discriminator_field(cls)
+            if field is None:
+                continue
+            if not self._is_discriminator_root(cls, field):
+                continue
+            concrete = self._concrete_descendants_including_self(class_name)
+            if not concrete:
+                # Discriminator declared but nothing concrete to dispatch
+                # to — the parent is itself abstract and has no concrete
+                # subclasses. Skip silently; the schema is still valid.
+                continue
+
+            mapping: dict[str, str] = {}
+            seen: dict[str, str] = {}
+            for sub_name in concrete:
+                tv = self._type_value(sv.get_class(sub_name))
+                if tv in seen:
+                    raise ValueError(
+                        f"Duplicate openapi.type_value {tv!r} on classes "
+                        f"{seen[tv]!r} and {sub_name!r}; values must be unique "
+                        "across a discriminator group."
+                    )
+                seen[tv] = sub_name
+                mapping[tv] = f"#/components/schemas/{sub_name}"
+
+            self._inject_discriminator_on_parent(
+                schemas, class_name, field, list(mapping.keys()), mapping
+            )
+            for tv, sub_name in seen.items():
+                self._inject_subclass_type_value(schemas, sub_name, field, tv)
+
+    def _inject_discriminator_on_parent(
+        self,
+        schemas: dict[str, Schema | Reference],
+        class_name: str,
+        field: str,
+        type_values: list[str],
+        mapping: dict[str, str],
+    ) -> None:
+        schema = schemas.get(class_name)
+        if not isinstance(schema, Schema):
+            return  # Reference — nothing to patch
+
+        # The discriminator goes at the schema-object level so it applies to
+        # any $ref that resolves to this schema.
+        schema.discriminator = Discriminator(propertyName=field, mapping=mapping)
+
+        # Locate or synthesise the discriminator field. With `is_a`
+        # inheritance the local properties live under `allOf[1]`; for
+        # standalone classes they're at the top level.
+        local = self._writable_local_schema(schema)
+        properties = local.properties or {}
+        existing = properties.get(field)
+        if existing is None or not isinstance(existing, Schema):
+            properties[field] = Schema(type=DataType.STRING, enum=type_values)
+        else:
+            existing.type = DataType.STRING
+            existing.enum = type_values
+        local.properties = properties
+
+        required = list(local.required or [])
+        if field not in required:
+            required.append(field)
+        local.required = required
+
+    @staticmethod
+    def _writable_local_schema(schema: Schema) -> Schema:
+        """Return the Schema where local properties live (top-level or allOf[1])."""
+        if schema.allOf:
+            for part in schema.allOf:
+                if isinstance(part, Schema):
+                    return part
+            # No inline part — append one so we have somewhere to put properties
+            inline = Schema(type=DataType.OBJECT)
+            schema.allOf.append(inline)
+            return inline
+        return schema
+
+    def _inject_subclass_type_value(
+        self,
+        schemas: dict[str, Schema | Reference],
+        class_name: str,
+        field: str,
+        type_value: str,
+    ) -> None:
+        schema = schemas.get(class_name)
+        if not isinstance(schema, Schema):
+            return
+        local = self._writable_local_schema(schema)
+        properties = dict(local.properties or {})
+        # Single-value enum so a hand-written client reading the spec sees
+        # exactly what to send for this concrete subclass.
+        properties[field] = Schema(
+            type=DataType.STRING,
+            enum=[type_value],
+            default=type_value,
+        )
+        local.properties = properties
+        required = list(local.required or [])
+        if field not in required:
+            required.append(field)
+        local.required = required
 
     def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -147,6 +147,53 @@ classes:
       quantity:
         range: integer
 
+  # --- Discriminator: openapi.discriminator + openapi.type_value (existing-system case) ---
+  Product:
+    abstract: true
+    description: Polymorphic root using a custom field name and uppercase type values.
+    annotations:
+      openapi.discriminator: kind
+    attributes:
+      sku:
+        identifier: true
+        range: string
+        required: true
+
+  Book:
+    is_a: Product
+    annotations:
+      openapi.type_value: BOOK
+    attributes:
+      title:
+        range: string
+
+  Vinyl:
+    is_a: Product
+    annotations:
+      openapi.type_value: VINYL
+    attributes:
+      artist:
+        range: string
+
+  # --- Discriminator: LinkML-native designates_type ---
+  Animal:
+    abstract: true
+    description: Polymorphic root using LinkML's designates_type signal.
+    attributes:
+      species:
+        designates_type: true
+        range: string
+      tag:
+        identifier: true
+        range: string
+        required: true
+
+  Dog:
+    is_a: Animal
+
+  Cat:
+    is_a: Animal
+
 enums:
   PersonStatus:
     description: Status of a person

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -793,6 +793,137 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestDiscriminator:
+    """Coverage for issue #20 — discriminator + polymorphism."""
+
+    def test_explicit_discriminator_field_synthesised(self):
+        """`openapi.discriminator: kind` synthesises the field on the parent."""
+        spec = _generate()
+        product = spec["components"]["schemas"]["Product"]
+        assert "kind" in product["properties"]
+        assert product["properties"]["kind"]["type"] == "string"
+        assert "kind" in product["required"]
+
+    def test_explicit_discriminator_mapping_uses_type_value(self):
+        """Type values from `openapi.type_value` flow into the mapping."""
+        spec = _generate()
+        product = spec["components"]["schemas"]["Product"]
+        assert product["discriminator"]["propertyName"] == "kind"
+        assert product["discriminator"]["mapping"] == {
+            "BOOK": "#/components/schemas/Book",
+            "VINYL": "#/components/schemas/Vinyl",
+        }
+        assert set(product["properties"]["kind"]["enum"]) == {"BOOK", "VINYL"}
+
+    def test_subclass_redeclares_field_with_single_value_enum(self):
+        """A concrete subclass's local schema pins the discriminator to its value."""
+        spec = _generate()
+        book_local = spec["components"]["schemas"]["Book"]["allOf"][1]
+        assert book_local["properties"]["kind"]["enum"] == ["BOOK"]
+        assert book_local["properties"]["kind"]["default"] == "BOOK"
+        assert "kind" in book_local["required"]
+
+    def test_designates_type_drives_discriminator(self):
+        """LinkML's `designates_type: true` produces an OpenAPI discriminator block."""
+        spec = _generate()
+        animal = spec["components"]["schemas"]["Animal"]
+        assert animal["discriminator"]["propertyName"] == "species"
+        assert animal["discriminator"]["mapping"] == {
+            "Dog": "#/components/schemas/Dog",
+            "Cat": "#/components/schemas/Cat",
+        }
+
+    def test_designates_type_default_value_is_class_name_as_is(self):
+        """Without openapi.type_value, the default matches LinkML's `designates_type` behaviour."""
+        spec = _generate()
+        dog_local = spec["components"]["schemas"]["Dog"]["allOf"][1]
+        assert dog_local["properties"]["species"]["enum"] == ["Dog"]
+        assert dog_local["properties"]["species"]["default"] == "Dog"
+
+    def test_descendant_does_not_re_emit_discriminator(self):
+        """Only the root that declares the discriminator carries the block."""
+        spec = _generate()
+        book = spec["components"]["schemas"]["Book"]
+        assert "discriminator" not in book
+
+    def test_conflict_designates_type_and_openapi_discriminator_raises(self):
+        """Declaring both ways for the same class is a generation-time error."""
+        import tempfile
+
+        import pytest
+
+        schema_yaml = """
+id: https://example.org/conflict
+name: conflict
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+classes:
+  Item:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+    attributes:
+      type:
+        designates_type: true
+        range: string
+      sku:
+        identifier: true
+        range: string
+        required: true
+  Widget:
+    is_a: Item
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="designates_type"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_duplicate_type_values_raises(self):
+        """Two subclasses with the same openapi.type_value is a generation-time error."""
+        import tempfile
+
+        import pytest
+
+        schema_yaml = """
+id: https://example.org/dup-type-value
+name: dup_type_value
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+classes:
+  Item:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+    attributes:
+      sku:
+        identifier: true
+        range: string
+        required: true
+  Widget:
+    is_a: Item
+    annotations:
+      openapi.type_value: SAME
+  Gadget:
+    is_a: Item
+    annotations:
+      openapi.type_value: SAME
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="Duplicate"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestRdfExtensions:
     def test_class_uri_emitted_as_x_rdf_class(self):
         """Person.class_uri = schema:Person becomes x-rdf-class on the schema."""


### PR DESCRIPTION
## Summary

Closes #20. The generator now emits OpenAPI `discriminator` blocks driven by LinkML's existing `designates_type: true` (no annotation needed) and by two new annotations for cases LinkML can't express on its own — picking an alternate field name, and overriding the wire value per concrete subclass.

## Two paths in

### LinkML-native — `designates_type: true`

```yaml
Animal:
  abstract: true
  attributes:
    species: { designates_type: true, range: string }
Dog: { is_a: Animal }
Cat: { is_a: Animal }
```

emits

```yaml
Animal:
  properties:
    species: { type: string, enum: [Dog, Cat] }
  required: [species]
  discriminator:
    propertyName: species
    mapping:
      Dog: '#/components/schemas/Dog'
      Cat: '#/components/schemas/Cat'

Dog:
  allOf:
    - $ref: '#/components/schemas/Animal'
    - properties:
        species: { type: string, enum: [Dog], default: Dog }
      required: [species]
```

### Existing-system match — `openapi.discriminator` + `openapi.type_value`

For when you're adopting linkml-openapi against an existing API that already uses a fixed field name with fixed wire values (`BOOK` / `VINYL` / `DIGITAL` rather than `Book` / `Vinyl` / `Digital`):

```yaml
Product:
  abstract: true
  annotations:
    openapi.discriminator: kind        # synthesises the field if missing
  attributes:
    sku: { identifier: true, range: string, required: true }
Book:
  is_a: Product
  annotations: { openapi.type_value: BOOK }
Vinyl:
  is_a: Product
  annotations: { openapi.type_value: VINYL }
```

emits the right `kind` / `BOOK` / `VINYL` shape — no parallel field on the LinkML side, no schema gymnastics.

## Decisions implemented

- **Synthesise the discriminator field when missing** — the user shouldn't need to pad the LinkML schema with a slot that exists only for OpenAPI's benefit. The synthesised slot has no `slot_uri` and therefore no `x-rdf-property` extension (correct — the discriminator is OpenAPI infrastructure, not an RDF predicate; `rdf:type` per subclass is already covered by `x-rdf-class`).
- **Default `type_value` = class name as-is** — matches `designates_type`'s LinkML default. No name transformations the user didn't ask for.
- **Only the root emits the discriminator** — concrete leaves don't re-emit the block even though `designates_type` propagates through `class_induced_slots`.
- **Mixins are excluded from the mapping** — trait composition, not subtyping.
- **Conflict & duplicate detection** — both `designates_type` and `openapi.discriminator` on the same class is an error (says the same thing two ways); duplicate `openapi.type_value` in a discriminator group is an error.

## Polymorphic endpoints

Falls out for free. An abstract parent marked `openapi.resource: "true"` gets standard CRUD paths whose request / response schemas `$ref` the parent — and the `discriminator` block on the parent does the polymorphic dispatch at codegen / runtime. No operation-builder rewiring needed for the common case. (If demand arises for explicit `oneOf` schemas in operation responses, that's a follow-up.)

## Tests

```
85 passed, 8 skipped (e2e)
```

New `TestDiscriminator` covers:
- `openapi.discriminator` + `openapi.type_value` produce the right block
- `designates_type` produces the right block with class-name defaults
- subclass local schema redeclares the field with single-value enum + default
- descendants don't re-emit the discriminator block
- conflict between `designates_type` and `openapi.discriminator` raises
- duplicate `type_value` raises

## Sequence

This is PR (C) of three from issues #18 / #19 / #20. Independent of (A) and (B) — touches `_class_to_schema` and the schema-patching layer, not nested-path generation. Lands cleanly on either branch.

## Test plan

- [x] `pytest tests/` — 85 passed, 8 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] Examples regenerated and matching
- [ ] CI green
