### PR TITLE
feat: openapi.operations supports patch with JSON Merge Patch (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,19 @@ Comma-separated list of CRUD operations to generate. Controls which HTTP methods
 | `create` | `POST` | `/{path}` | Create a new instance |
 | `read` | `GET` | `/{path}/{vars}` | Get a single instance by ID |
 | `update` | `PUT` | `/{path}/{vars}` | Replace an instance |
+| `patch` | `PATCH` | `/{path}/{vars}` | Partial update via JSON Merge Patch (RFC 7396) |
 | `delete` | `DELETE` | `/{path}/{vars}` | Delete an instance |
 
-Default when omitted: all five operations (`list,create,read,update,delete`).
+Default when omitted: all CRUD operations except `patch` (`list,create,read,update,delete`). PATCH is opt-in.
+
+When `patch` is included, the generator also emits a `<Class>Patch` schema in
+`components.schemas`: a flat schema with every induced slot present and
+optional, identifier excluded, `additionalProperties: false`, and
+`x-rdf-class` / `x-rdf-property` extensions preserved. The PATCH request
+body media type is fixed at `application/merge-patch+json` (RFC 7396 is
+JSON-specific); the 200 response uses the class's `openapi.media_types` as
+usual. Multivalued slots replace wholesale per RFC 7396 — that is the
+spec's behaviour, not a generator quirk.
 
 ```yaml
   Person:

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -283,6 +283,9 @@ class OpenAPIGenerator(Generator):
                     item.get = self._make_read_operation(cls, class_name)
                 if "update" in operations:
                     item.put = self._make_update_operation(cls, class_name)
+                if "patch" in operations:
+                    item.patch = self._make_patch_operation(cls, class_name)
+                    schemas[f"{class_name}Patch"] = self._build_patch_schema(class_name, cls)
                 if "delete" in operations:
                     item.delete = self._make_delete_operation(cls, class_name)
                 paths[item_path] = item
@@ -823,6 +826,78 @@ class OpenAPIGenerator(Generator):
                 "404": self._error_response("Not found"),
             },
         )
+
+    # --- PATCH (issue #16) -------------------------------------------------
+
+    def _make_patch_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        """Emit a PATCH item operation using JSON Merge Patch (RFC 7396).
+
+        Request body media type is fixed at ``application/merge-patch+json``
+        — RFC 7396 is JSON-specific, so the class's ``openapi.media_types``
+        do not apply to the request side. The 200 response uses the full
+        class schema and honours ``openapi.media_types`` as usual.
+        """
+        media_types = self._get_media_types(cls)
+        full_ref = Reference(ref=f"#/components/schemas/{class_name}")
+        patch_ref = Reference(ref=f"#/components/schemas/{class_name}Patch")
+        return Operation(
+            summary=f"Patch a {class_name}",
+            operationId=f"patch_{_to_snake_case(class_name)}",
+            tags=[class_name],
+            requestBody=RequestBody(
+                required=True,
+                content={
+                    "application/merge-patch+json": MediaType(media_type_schema=patch_ref),
+                },
+                description=(
+                    "Partial update per RFC 7396. Omit fields you don't want to change. "
+                    "Sending null clears the field; sending a value sets it."
+                ),
+            ),
+            responses={
+                "200": Response(
+                    description=f"{class_name} patched",
+                    content=self._content_for(full_ref, media_types),
+                ),
+                "404": self._error_response("Not found"),
+                "422": self._error_response("Validation error"),
+            },
+        )
+
+    def _build_patch_schema(self, class_name: str, cls: ClassDefinition) -> Schema:
+        """Build a ``<Class>Patch`` schema: every induced slot, all optional.
+
+        Identifier slots are excluded — the path already names the
+        resource and merge-patch can't cleanly express "leave id alone"
+        on a non-nullable string.
+
+        ``x-rdf-class`` and ``x-rdf-property`` mappings are recorded so
+        downstream RDF tooling that reads the spec can apply patches as
+        named-graph mutations.
+        """
+        sv = self.schemaview
+        patch_name = f"{class_name}Patch"
+        if cls.class_uri:
+            self._x_rdf_class[patch_name] = sv.expand_curie(cls.class_uri)
+
+        properties: dict[str, Schema | Reference] = {}
+        for slot in sv.class_induced_slots(class_name):
+            if slot.identifier:
+                continue
+            properties[slot.name] = self._slot_to_schema(slot)
+            if slot.slot_uri:
+                self._x_rdf_property[(patch_name, slot.name)] = sv.expand_curie(slot.slot_uri)
+
+        schema = Schema(type=DataType.OBJECT, additionalProperties=False)
+        schema.title = patch_name
+        schema.description = (
+            f"Partial update for {class_name}. All fields optional; semantics "
+            "per RFC 7396 (JSON Merge Patch). The identifier is excluded — "
+            "the path already names the resource."
+        )
+        if properties:
+            schema.properties = properties
+        return schema
 
     # --- Composition vs reference (issue #18) ------------------------------
 

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -32,6 +32,7 @@ classes:
     description: A person
     annotations:
       openapi.resource: "true"
+      openapi.operations: "list,create,read,update,patch,delete"
       openapi.media_types: "application/json,application/ld+json,text/turtle"
     attributes:
       email:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -576,6 +576,78 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestPatchOperations:
+    """Coverage for issue #16 — PATCH operations via JSON Merge Patch."""
+
+    def test_patch_method_emitted_when_in_operations(self):
+        """`openapi.operations: ...patch...` adds PATCH to the item path."""
+        spec = _generate()
+        item = spec["paths"]["/persons/{id}"]
+        assert "patch" in item
+
+    def test_patch_request_body_uses_merge_patch_json(self):
+        """The request body media type is application/merge-patch+json (RFC 7396)."""
+        spec = _generate()
+        body = spec["paths"]["/persons/{id}"]["patch"]["requestBody"]
+        assert "application/merge-patch+json" in body["content"]
+        # Patch is JSON-specific — class media types like text/turtle don't apply
+        # to the request side.
+        assert "text/turtle" not in body["content"]
+
+    def test_patch_request_body_references_patch_schema(self):
+        spec = _generate()
+        body = spec["paths"]["/persons/{id}"]["patch"]["requestBody"]
+        ref = body["content"]["application/merge-patch+json"]["schema"]
+        assert ref == {"$ref": "#/components/schemas/PersonPatch"}
+
+    def test_patch_response_uses_full_class_and_class_media_types(self):
+        """200 response uses the full class schema and honours openapi.media_types."""
+        spec = _generate()
+        ok = spec["paths"]["/persons/{id}"]["patch"]["responses"]["200"]
+        for mt in ("application/json", "application/ld+json", "text/turtle"):
+            assert ok["content"][mt]["schema"] == {"$ref": "#/components/schemas/Person"}
+
+    def test_patch_component_schema_emitted(self):
+        """`<Class>Patch` lands in components.schemas with all slots optional."""
+        spec = _generate()
+        patch = spec["components"]["schemas"].get("PersonPatch")
+        assert patch is not None
+        assert patch["additionalProperties"] is False
+        assert "required" not in patch  # everything optional
+
+    def test_patch_schema_excludes_identifier(self):
+        """The path already names the resource — id has no place in the patch body."""
+        spec = _generate()
+        patch_props = spec["components"]["schemas"]["PersonPatch"]["properties"]
+        assert "id" not in patch_props
+
+    def test_patch_schema_includes_inherited_slots(self):
+        """Person inherits `name` and `description` from NamedThing — both appear."""
+        spec = _generate()
+        patch_props = spec["components"]["schemas"]["PersonPatch"]["properties"]
+        assert "name" in patch_props
+        assert "description" in patch_props
+        # And local slots, of course.
+        assert "email" in patch_props
+        assert "age" in patch_props
+
+    def test_patch_schema_preserves_x_rdf_extensions(self):
+        """Patch properties carry the same x-rdf-property as the canonical Person."""
+        spec = _generate()
+        patch = spec["components"]["schemas"]["PersonPatch"]
+        assert patch.get("x-rdf-class") == "http://schema.org/Person"
+        assert patch["properties"]["email"].get("x-rdf-property") == "http://schema.org/email"
+        assert patch["properties"]["age"].get("x-rdf-property") == "http://xmlns.com/foaf/0.1/age"
+
+    def test_patch_not_emitted_when_not_in_operations(self):
+        """A class without `patch` in openapi.operations gets no PATCH and no Patch schema."""
+        spec = _generate()
+        # Address has openapi.operations: "list,read" — no PATCH.
+        item = spec["paths"]["/addresses/{id}"]
+        assert "patch" not in item
+        assert "AddressPatch" not in spec["components"]["schemas"]
+
+
 class TestErrorModel:
     def test_problem_schema_emitted_by_default(self):
         """A Problem component schema is added when error_schema is on (the default)."""


### PR DESCRIPTION
## Summary

Closes #16. Adds `patch` to the set of valid tokens in `openapi.operations`. When present, the generator emits a PATCH method on the item path with a JSON Merge Patch (RFC 7396) request body, plus a synthesised `<Class>Patch` component schema.

## Behaviour

```yaml
classes:
  Person:
    annotations:
      openapi.resource: "true"
      openapi.operations: "list,create,read,update,patch,delete"
```

emits

```yaml
paths:
  /persons/{id}:
    patch:
      summary: Patch a Person
      operationId: patch_person
      requestBody:
        required: true
        content:
          application/merge-patch+json:
            schema: { $ref: '#/components/schemas/PersonPatch' }
      responses:
        '200':
          description: Person patched
          content:
            application/json:    { schema: { $ref: '#/components/schemas/Person' }}
            application/ld+json: { schema: { $ref: '#/components/schemas/Person' }}
            text/turtle:         { schema: { $ref: '#/components/schemas/Person' }}
        '404': { ... Problem reference ... }
        '422': { ... Problem reference ... }

components:
  schemas:
    PersonPatch:
      type: object
      additionalProperties: false
      title: PersonPatch
      x-rdf-class: http://schema.org/Person
      properties:
        email: { type: string, x-rdf-property: http://schema.org/email, ... }
        age:   { type: integer, x-rdf-property: http://xmlns.com/foaf/0.1/age, ... }
        name:  { type: string }
        # ... all induced slots, identifier excluded, no `required` array
```

## Decisions implemented

- **PATCH is opt-in.** The default operations list stays `list,create,read,update,delete`. Users add `patch` explicitly.
- **Request body media type fixed at `application/merge-patch+json`.** RFC 7396 is JSON-specific; the class's `openapi.media_types` (Turtle / RDF/XML / etc.) apply to the *response* only.
- **Identifier slot excluded** from the Patch schema — the path already names the resource, and merge-patch can't cleanly express "leave the id alone" on a non-nullable string.
- **All inherited slots included**, flat — no `allOf` chain. A Patch schema is conceptually "any subset of the full class's properties," and flatness expresses that more directly than allOf-with-everything-optional.
- **`x-rdf-class` and `x-rdf-property` preserved** on the Patch schema so RDF tooling can apply patches as named-graph mutations.
- **Multivalued slots replace wholesale per RFC 7396** — call this out in the README; it's the spec's behaviour, not a generator quirk.
- **JSON Patch (RFC 6902) intentionally not emitted in v1.** Harder to derive cleanly from a class schema; uncommon in practice; can layer in later if anyone asks.

## Tests

```
100 passed, 8 skipped (e2e)
```

New `TestPatchOperations` covers:
- PATCH method emitted when `patch` is in operations
- request body media type is `application/merge-patch+json` only (no class media types on the request side)
- request body references `PersonPatch`
- response uses the class media types and the full `Person` schema
- `<Class>Patch` lands in `components.schemas` with `additionalProperties: false` and no `required`
- identifier excluded from Patch properties
- inherited slots (`name`, `description` from `NamedThing`) present
- `x-rdf-class` and `x-rdf-property` extensions preserved
- a class without `patch` in operations gets neither the method nor the Patch schema

## Test plan

- [x] `pytest tests/` — 100 passed, 8 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] Examples regenerated (no diff — none of the example schemas use `patch` yet)
- [ ] CI green

Independent of all currently-open PRs (#22 already merged; #23 still open). Lands cleanly on top of `main`.
