### PR TITLE
feat (B): inverse-direction nested paths from LinkML inverse: (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,55 @@ say otherwise.
 operations (`read`/`update`/`delete`) but no identifier slot raises at
 generation time with an exact remediation message.
 
+##### Inverse direction via LinkML's `inverse:`
+
+LinkML slots are unidirectional. To get the reverse-direction nested
+path *without* declaring a real slot on the other side, use LinkML's
+existing `inverse:` field:
+
+```yaml
+classes:
+  Article:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      doi: { identifier: true, range: string, required: true }
+      reviewers:
+        range: Reviewer
+        multivalued: true
+        inverse: Reviewer.articles      # ← Reviewer has no real `articles` slot
+  Reviewer:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      reviewer_id: { identifier: true, range: string, required: true }
+```
+
+emits both directions:
+
+```
+GET    /articles/{doi}/reviewers                  # forward (real slot)
+POST   /articles/{doi}/reviewers
+DELETE /articles/{doi}/reviewers/{reviewer_id}
+
+GET    /reviewers/{reviewer_id}/articles          # reverse (synthesised from inverse:)
+POST   /reviewers/{reviewer_id}/articles
+DELETE /reviewers/{reviewer_id}/articles/{article_id}
+```
+
+The synthesised reverse direction is always reference-shaped: it uses
+the same `ResourceLink` attach / detach body as a real reference slot
+would. Composition can't be inverted (a composed child has no
+independent IRI to reference, so there's nothing to attach to from
+the other side).
+
+If both sides declare real slots that point at each other via
+`inverse:`, no synthesis happens — each side emits naturally from its
+own slot walk. The `inverse:` declaration is only the load-bearing
+signal when one side wants the path without paying for a real slot.
+
+**No name-based inference.** Without an `inverse:` declaration, the
+generator never guesses that `Article.reviewers` implies a path on
+`Reviewer`. That's a parallel-vocabulary trap.
+
 ### Slot-level annotations
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1234,6 +1234,55 @@ class OpenAPIGenerator(Generator):
                     parent_path_params,
                 )
 
+        # Synthetic inverse paths — emitted for `inverse:` declarations
+        # whose target slot doesn't actually exist on this class. Always
+        # reference-shaped (composition can't be inverted: a composed
+        # child has no independent identity to put on the wire).
+        for synth_name, source_class in self._synthetic_inverses_for(parent_class_name):
+            collection_path = f"/{parent_path_segment}/{parent_var_suffix}/{synth_name}"
+            target_id_slot = self._identifier_slot(source_class)
+            fake_slot = SlotDefinition(name=synth_name, range=source_class, multivalued=True)
+            self._needs_resource_link = True
+            self._add_reference_paths(
+                out,
+                collection_path,
+                parent_class_name,
+                fake_slot,
+                source_class,
+                target_id_slot,
+                parent_path_params,
+            )
+
+        return out
+
+    def _synthetic_inverses_for(self, target_class_name: str) -> list[tuple[str, str]]:
+        """Inverse declarations that name a slot not present on ``target_class_name``.
+
+        For each ``inverse: target_class_name.slot_name`` declaration on
+        another class's slot, if ``slot_name`` isn't already a real slot on
+        ``target_class_name``, we synthesise the reverse-direction path.
+
+        Both sides declaring the inverse needs no special handling — when
+        both sides have real slots, each emits naturally; when only one
+        side has a real slot, the other side's path is synthesised here.
+        """
+        sv = self.schemaview
+        target_slot_names = {s.name for s in sv.class_induced_slots(target_class_name)}
+        out: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for src_class_name in sv.all_classes():
+            for slot in sv.class_induced_slots(src_class_name):
+                if not slot.inverse or "." not in str(slot.inverse):
+                    continue
+                tgt_class, tgt_slot_name = str(slot.inverse).split(".", 1)
+                if tgt_class != target_class_name:
+                    continue
+                if tgt_slot_name in target_slot_names:
+                    continue  # naturally emitted from the target's own walk
+                if tgt_slot_name in seen:
+                    continue  # already synthesised from another source
+                seen.add(tgt_slot_name)
+                out.append((tgt_slot_name, src_class_name))
         return out
 
     def _add_composition_paths(

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -175,6 +175,36 @@ classes:
       artist:
         range: string
 
+  # --- Inverse-direction nested paths (issue #19) ---
+  # Article.reviewers declares `inverse: Reviewer.articles` — Reviewer
+  # has no explicit `articles` slot, so the generator synthesises the
+  # reverse-direction path `/reviewers/{id}/articles`.
+  Article:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      doi:
+        identifier: true
+        range: string
+        required: true
+      title:
+        range: string
+      reviewers:
+        range: Reviewer
+        multivalued: true
+        inverse: Reviewer.articles
+
+  Reviewer:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      reviewer_id:
+        identifier: true
+        range: string
+        required: true
+      full_name:
+        range: string
+
   # --- Discriminator: LinkML-native designates_type ---
   Animal:
     abstract: true

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -576,6 +576,52 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestInverseDirection:
+    """Coverage for issue #19 — inverse-direction nested paths from `inverse:`."""
+
+    def test_forward_path_emitted(self):
+        """Article.reviewers (a multivalued class slot) emits /articles/{id}/reviewers."""
+        spec = _generate()
+        assert "/articles/{doi}/reviewers" in spec["paths"]
+        assert "/articles/{doi}/reviewers/{reviewer_id}" in spec["paths"]
+
+    def test_inverse_path_synthesised_from_inverse_declaration(self):
+        """Article.reviewers `inverse: Reviewer.articles` synthesises the reverse path."""
+        spec = _generate()
+        assert "/reviewers/{reviewer_id}/articles" in spec["paths"]
+        assert "/reviewers/{reviewer_id}/articles/{article_id}" in spec["paths"]
+
+    def test_synthesised_inverse_is_reference_shaped(self):
+        """Synthesised inverse paths are always attach/detach, never composition."""
+        spec = _generate()
+        coll = spec["paths"]["/reviewers/{reviewer_id}/articles"]
+        # Reference: GET (list attached) and POST (attach via ResourceLink).
+        assert "get" in coll
+        assert "post" in coll
+        # No PUT — to mutate an Article, hit /articles/{doi}.
+        assert "put" not in coll
+        # Item path: only DELETE (detach).
+        item = spec["paths"]["/reviewers/{reviewer_id}/articles/{article_id}"]
+        assert "delete" in item
+        assert "get" not in item
+        assert "put" not in item
+
+    def test_no_inverse_path_without_declaration(self):
+        """Without `inverse:` declared, no reverse path is synthesised — no name guessing."""
+        spec = _generate()
+        # Person.addresses (no `inverse:`) doesn't synthesise /addresses/{id}/persons.
+        assert "/addresses/{id}/persons" not in spec["paths"]
+        assert "/addresses/{id}/people" not in spec["paths"]
+
+    def test_inverse_attach_body_is_resourcelink(self):
+        """Synthesised inverse uses the same ResourceLink attach body as forward references."""
+        spec = _generate()
+        attach = spec["paths"]["/reviewers/{reviewer_id}/articles"]["post"]
+        body = attach["requestBody"]["content"]["application/json"]["schema"]
+        refs = [s.get("$ref") for s in body.get("oneOf", []) if "$ref" in s]
+        assert "#/components/schemas/ResourceLink" in refs
+
+
 class TestPatchOperations:
     """Coverage for issue #16 — PATCH operations via JSON Merge Patch."""
 


### PR DESCRIPTION
## Summary

Closes #19. Reads LinkML's `inverse:` slot field. When a slot says `inverse: TargetClass.target_slot` and `target_slot` doesn't actually exist on `TargetClass`, the generator now synthesises a reference-shaped nested path on `TargetClass` for the reverse direction.

No new annotations. The whole feature reads off `inverse:` — LinkML already has the signal.

## Behaviour

```yaml
classes:
  Article:
    annotations: { openapi.resource: "true" }
    attributes:
      doi: { identifier: true, range: string, required: true }
      reviewers:
        range: Reviewer
        multivalued: true
        inverse: Reviewer.articles      # Reviewer has no real `articles` slot
  Reviewer:
    annotations: { openapi.resource: "true" }
    attributes:
      reviewer_id: { identifier: true, range: string, required: true }
```

emits both directions:

```
GET    /articles/{doi}/reviewers                  # forward (real slot)
POST   /articles/{doi}/reviewers
DELETE /articles/{doi}/reviewers/{reviewer_id}

GET    /reviewers/{reviewer_id}/articles          # reverse (synthesised)
POST   /reviewers/{reviewer_id}/articles
DELETE /reviewers/{reviewer_id}/articles/{article_id}
```

## Decisions implemented

- **Synthesised reverse is always reference-shaped.** Composition can't be inverted — a composed child has no independent IRI to reference, so there's nothing to attach to from the other side. Falls out naturally from the issue body's reasoning.
- **Both sides with real slots: no synthesis.** Each side emits from its own walk. The `inverse:` declaration is only load-bearing when one side wants the path without paying for a real slot.
- **No name-based inference.** Without `inverse:`, the generator never guesses that `Article.reviewers` implies a path on `Reviewer`.
- **`openapi.inverse` annotation: deferred.** The principle "read what LinkML says" makes the niche "I want the path but don't want to declare the inverse field" case rare enough to wait for a real user to ask.
- Each side dedupes by slot name before synthesis, so multiple inverse declarations targeting the same target slot don't double-emit.

## Tests

```
113 passed, 8 skipped (e2e)
```

New `TestInverseDirection` covers:
- forward path emitted from `Article.reviewers`
- reverse path synthesised from the `inverse: Reviewer.articles` declaration
- synthesised reverse is reference-shaped (GET, POST attach, DELETE detach; no PUT)
- no inverse path is synthesised when `inverse:` isn't declared (no name guessing)
- attach body uses the same `ResourceLink` schema as forward references

## Sequence

PR (B) of three from issues #18 / #19 / #20:

- ✅ #22 (#18 composition vs reference) — merged
- ✅ #23 (#20 discriminator + polymorphism) — merged
- 👉 **this PR** (#19 inverse-direction)

## Test plan

- [x] `pytest tests/` — 113 passed, 8 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] Examples regenerated (no diff — none use `inverse:`)
- [ ] CI green
