### PR TITLE
feat: sort and comparison operators in openapi.query_param (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,32 +593,59 @@ When no slots are annotated as path variables, the generator falls back to the c
 
 #### `openapi.query_param`
 
-Marks a slot as a query parameter on the `list` operation.
+Marks a slot as a query parameter on the `list` operation. Accepts a
+comma-separated set of capability tokens:
 
-| Value | Behaviour |
-|-------|-----------|
-| `"true"` | Slot appears as an optional query parameter on the collection `GET` |
+| Token | Effect |
+|-------|--------|
+| `"true"` / `"equality"` | `?slot=value` exact-match filter (today's behaviour) |
+| `"comparable"` | adds `?slot__gte=` / `?slot__lte=` / `?slot__gt=` / `?slot__lt=`. Implies equality. |
+| `"sortable"` | slot becomes a valid token in a single `?sort=` array parameter. Implies equality. |
 | omitted | Slot is not a query parameter |
 
-All annotated query parameters are generated as optional (`required: false`). The parameter schema type is derived from the slot's `range`.
-
-When no slots are annotated with `openapi.query_param`, the generator auto-infers query parameters from all non-multivalued, non-identifier slots with `string`, `integer`, `boolean`, or enum ranges (backwards compatible).
-
-`limit` and `offset` pagination parameters are always included on list endpoints regardless of annotations.
+`comparable` and `sortable` imply `equality` — most APIs that filter by
+range or sort by a field also accept exact-match.
 
 ```yaml
   Person:
     annotations:
       openapi.resource: "true"
-      openapi.path: people
     slot_usage:
       name:
         annotations:
-          openapi.query_param: "true"     # GET /people?name=Alice
-      age_in_years:
+          openapi.query_param: sortable               # ?name=Alice and ?sort=name,-name
+      age:
         annotations:
-          openapi.query_param: "true"     # GET /people?age_in_years=30
+          openapi.query_param: comparable,sortable    # ?age=, ?age__gte=, ?age__lte=, sort
 ```
+
+emits these query params on `GET /persons` (in addition to `limit` / `offset`):
+
+```
+?name=                ?age=
+?age__gte=            ?age__lte=            ?age__gt=            ?age__lt=
+?sort=  (array, comma-separated, enum: [name, -name, age, -age])
+```
+
+The `?sort=` parameter uses `style: form, explode: false`, so multiple
+sort tokens round-trip as `?sort=name,-age`.
+
+**Validation:**
+
+- `comparable` is only well-defined for ordered ranges (`integer`,
+  `float`, `double`, `decimal`, `date`, `datetime`). Setting it on a
+  string slot warns at generation time — lex comparison is rarely the
+  intent.
+- `sortable` on a multivalued slot is a generation error — sort order
+  over a set isn't well-defined.
+
+When no slots are annotated with `openapi.query_param`, the generator
+auto-infers equality-only query parameters from all non-multivalued,
+non-identifier slots with `string`, `integer`, `boolean`, or enum
+ranges (backwards compatible).
+
+`limit` and `offset` pagination parameters are always included on list
+endpoints regardless of annotations.
 
 ### Annotation summary
 

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1470,10 +1470,42 @@ class OpenAPIGenerator(Generator):
         )
         paths[item_path] = item
 
+    # Slot ranges over which `comparable` operators (>=, <=, >, <) are
+    # well-defined. String ranges are technically lex-comparable but the
+    # intent is almost always "numeric / temporal range" — warn if asked.
+    _COMPARABLE_RANGES = frozenset({"integer", "float", "double", "decimal", "date", "datetime"})
+
+    def _query_param_capabilities(self, cls: ClassDefinition, slot_name: str) -> set[str] | None:
+        """Parse the slot's `openapi.query_param` annotation into a capability set.
+
+        Accepted tokens (comma-separated):
+
+          ``"true"`` / ``"equality"``  — exact-match query param (today's behaviour)
+          ``"comparable"``             — equality + ``__gte`` / ``__lte`` / ``__gt`` / ``__lt``
+          ``"sortable"``               — equality + token in ``?sort=`` array
+
+        ``comparable`` and ``sortable`` imply ``equality`` (most APIs that filter
+        by range also filter by exact match). Returns ``None`` when the
+        annotation is absent or explicitly false.
+        """
+        raw = self._get_slot_annotation(cls, slot_name, "openapi.query_param")
+        if raw is None:
+            return None
+        tokens = {t.strip().lower() for t in str(raw).split(",") if t.strip()}
+        if not tokens or tokens == {"false"}:
+            return None
+        if "true" in tokens:
+            tokens.add("equality")
+            tokens.discard("true")
+        if "comparable" in tokens or "sortable" in tokens:
+            tokens.add("equality")
+        valid = tokens & {"equality", "comparable", "sortable"}
+        return valid or None
+
     def _make_query_params(self, cls: ClassDefinition) -> list[Parameter]:
-        """Generate query parameters for list endpoint filtering."""
+        """Generate query parameters for list endpoint filtering, sorting, paginating."""
         sv = self.schemaview
-        params = [
+        params: list[Parameter] = [
             Parameter(
                 name="limit",
                 param_in=ParameterLocation.QUERY,
@@ -1486,25 +1518,81 @@ class OpenAPIGenerator(Generator):
             ),
         ]
 
-        # Check if any slot has openapi.query_param annotation
-        annotated_params = []
+        annotated_params: list[Parameter] = []
+        sort_tokens: list[str] = []
+        any_annotated = False
+
         for slot in sv.class_induced_slots(cls.name):
-            val = self._get_slot_annotation(cls, slot.name, "openapi.query_param")
-            if val and _is_truthy(val):
+            caps = self._query_param_capabilities(cls, slot.name)
+            if caps is None:
+                continue
+            any_annotated = True
+            slot_schema = self._slot_to_schema(slot)
+            range_name = slot.range or "string"
+
+            if "equality" in caps:
                 annotated_params.append(
                     Parameter(
                         name=slot.name,
                         param_in=ParameterLocation.QUERY,
                         required=False,
-                        param_schema=self._slot_to_schema(slot),
+                        param_schema=slot_schema,
                     )
                 )
 
-        if annotated_params:
+            if "comparable" in caps:
+                if range_name not in self._COMPARABLE_RANGES:
+                    import warnings
+
+                    warnings.warn(
+                        f"Slot {cls.name}.{slot.name!r} marked `comparable` but "
+                        f"range {range_name!r} is not a numeric or temporal type; "
+                        "comparison operators may behave unexpectedly.",
+                        stacklevel=2,
+                    )
+                for op in ("gte", "lte", "gt", "lt"):
+                    annotated_params.append(
+                        Parameter(
+                            name=f"{slot.name}__{op}",
+                            param_in=ParameterLocation.QUERY,
+                            required=False,
+                            param_schema=self._slot_to_schema(slot),
+                        )
+                    )
+
+            if "sortable" in caps:
+                if slot.multivalued:
+                    raise ValueError(
+                        f"Slot {cls.name}.{slot.name!r} is multivalued; sort "
+                        "order over a set is not well-defined. Remove `sortable` "
+                        "or change the slot to single-valued."
+                    )
+                sort_tokens.extend([slot.name, f"-{slot.name}"])
+
+        if sort_tokens:
+            annotated_params.append(
+                Parameter(
+                    name="sort",
+                    param_in=ParameterLocation.QUERY,
+                    required=False,
+                    description=(
+                        "Comma-separated list of slot names to sort by. "
+                        "Prefix a name with `-` for descending."
+                    ),
+                    style="form",
+                    explode=False,
+                    param_schema=Schema(
+                        type=DataType.ARRAY,
+                        items=Schema(type=DataType.STRING, enum=sort_tokens),
+                    ),
+                )
+            )
+
+        if any_annotated:
             params.extend(annotated_params)
             return params
 
-        # Fall back to auto-inference
+        # Fall back to auto-inference (unchanged from the legacy default).
         for slot in sv.class_induced_slots(cls.name):
             if not slot.multivalued and not slot.identifier:
                 range_name = slot.range or "string"

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -58,10 +58,10 @@ classes:
           openapi.path_variable: "true"
       name:
         annotations:
-          openapi.query_param: "true"
+          openapi.query_param: sortable
       age:
         annotations:
-          openapi.query_param: "true"
+          openapi.query_param: comparable,sortable
       knows:
         annotations:
           openapi.nested: "false"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -301,6 +301,126 @@ class TestSerialization:
 # --- Slot annotation tests ---
 
 
+class TestQueryOperators:
+    """Coverage for issue #15 — sort and comparison operators."""
+
+    def test_equality_param_emitted_when_sortable(self):
+        """`sortable` implies equality — bare `?name=` still works."""
+        spec = _generate()
+        params = spec["paths"]["/persons"]["get"]["parameters"]
+        names = {p["name"] for p in params}
+        assert "name" in names
+
+    def test_comparison_operators_emitted_for_comparable_slot(self):
+        """`comparable` adds __gte / __lte / __gt / __lt for ordered ranges."""
+        spec = _generate()
+        names = {p["name"] for p in spec["paths"]["/persons"]["get"]["parameters"]}
+        assert "age__gte" in names
+        assert "age__lte" in names
+        assert "age__gt" in names
+        assert "age__lt" in names
+
+    def test_no_comparison_operators_on_non_comparable(self):
+        """Slots without `comparable` don't get __gte etc."""
+        spec = _generate()
+        names = {p["name"] for p in spec["paths"]["/persons"]["get"]["parameters"]}
+        # name is sortable but not comparable.
+        assert "name__gte" not in names
+
+    def test_sort_param_emitted_with_enum(self):
+        """A single `?sort=` array param lists every sortable slot + its negation."""
+        spec = _generate()
+        params = spec["paths"]["/persons"]["get"]["parameters"]
+        sort_param = next((p for p in params if p["name"] == "sort"), None)
+        assert sort_param is not None
+        assert sort_param["schema"]["type"] == "array"
+        enum = set(sort_param["schema"]["items"]["enum"])
+        assert {"name", "-name", "age", "-age"} == enum
+
+    def test_sort_param_uses_form_explode_false(self):
+        """For `?sort=name,-age` to round-trip, the array uses `style: form, explode: false`."""
+        spec = _generate()
+        params = spec["paths"]["/persons"]["get"]["parameters"]
+        sort_param = next(p for p in params if p["name"] == "sort")
+        assert sort_param.get("style") == "form"
+        assert sort_param.get("explode") is False
+
+    def test_no_sort_param_without_sortable_slots(self):
+        """A class with only equality query params gets no `?sort=`."""
+        # Address has only auto-inferred equality params; no slot is `sortable`.
+        spec = _generate()
+        list_params = spec["paths"]["/addresses"]["get"]["parameters"]
+        assert not any(p["name"] == "sort" for p in list_params)
+
+    def test_comparable_on_string_warns(self):
+        """`comparable` on a string range warns; lex comparison is rarely the intent."""
+        import tempfile
+        import warnings
+
+        schema_yaml = """
+id: https://example.org/lexcompare
+name: lexcompare
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+classes:
+  Item:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      label:
+        range: string
+    slot_usage:
+      label:
+        annotations:
+          openapi.query_param: comparable
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                gen.serialize(format="yaml")
+            assert any("not a numeric or temporal" in str(w.message) for w in caught)
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_sortable_on_multivalued_raises(self):
+        """`sortable` on a multivalued slot is a generation-time error."""
+        import tempfile
+
+        import pytest
+
+        schema_yaml = """
+id: https://example.org/multisort
+name: multisort
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+classes:
+  Item:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      tags:
+        range: string
+        multivalued: true
+    slot_usage:
+      tags:
+        annotations:
+          openapi.query_param: sortable
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="multivalued"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestSlotAnnotations:
     def test_path_variable_from_annotation(self):
         """Person.id is annotated as path variable."""


### PR DESCRIPTION
## Summary

Closes #15. Extends `openapi.query_param` from a binary toggle to a comma-separated set of capability tokens.

## Behaviour

| Token | Effect |
|-------|--------|
| `"true"` / `"equality"` | `?slot=value` exact-match filter (today's behaviour) |
| `"comparable"` | adds `?slot__gte=` / `?slot__lte=` / `?slot__gt=` / `?slot__lt=`. Implies equality. |
| `"sortable"` | slot becomes a valid token in a single `?sort=` array parameter. Implies equality. |
| omitted | slot is not a query parameter |

`comparable` and `sortable` imply `equality` — most APIs that filter by range or sort by a field also accept exact-match. The legacy `"true"` keeps working unchanged.

## Generated output

```yaml
Person:
  slot_usage:
    name:
      annotations:
        openapi.query_param: sortable
    age:
      annotations:
        openapi.query_param: comparable,sortable
```

emits on `GET /persons` (alongside `limit` / `offset`):

```
?name=                                 # equality
?age=                                  # equality
?age__gte=  ?age__lte=  ?age__gt=  ?age__lt=
?sort=  (array, style=form, explode=false, items.enum=[name, -name, age, -age])
```

## Decisions implemented

- **`?sort=` is a single array parameter** rather than per-slot booleans. With `style: form, explode: false` it round-trips as `?sort=name,-age`. The item `enum` lists every sortable slot plus its `-`-prefixed negation, giving clients a precise allow-list.
- **`comparable` / `sortable` imply `equality`.** A user can still write `equality,comparable` or `equality,sortable` for explicitness, but it doesn't add anything.
- **`comparable` on a non-ordered range warns.** Strings are technically lex-comparable but the intent is almost always numeric / temporal range.
- **`sortable` on a multivalued slot raises** — sort order over a set isn't well-defined.
- **Cursor pagination (the issue body's `openapi.pagination: "cursor"`)** is intentionally out of scope. `Link` headers, opaque cursors, and the related response-side machinery are a separate concern; file a follow-up if the demand surfaces.
- **No "query profile" sugar layer** — the issue body called this out as deferrable. The primitives ship; the named-bundle abstraction can come later if it turns out to be repetitive in practice.

## Tests

```
121 passed, 8 skipped (e2e)
```

New `TestQueryOperators` covers:
- equality emitted from `sortable` (the implication)
- `__gte` / `__lte` / `__gt` / `__lt` emitted from `comparable`
- non-comparable slots don't get the operators
- `?sort=` array parameter with the right enum
- `?sort=` uses `style: form, explode: false`
- a class with no sortable slots gets no `?sort=`
- `comparable` on a string slot warns
- `sortable` on a multivalued slot raises

## Test plan

- [x] `pytest tests/` — 121 passed, 8 skipped
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] Examples regenerated (no diff — none use the new tokens)
- [ ] CI green
