### PR TITLE
chore: decouple from the linkml distribution to clear license flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## Unreleased
+
+### Changed
+
+- **Dropped `linkml` as a runtime dependency.** The package now relies on
+  `linkml-runtime` alone, with a minimal `linkml_openapi._base.Generator`
+  shim replacing the upstream `linkml.utils.generator.Generator` base
+  class. The OpenAPI generator only ever used the SchemaView-based
+  new-style path (`uses_schemaloader = False`); the SchemaLoader visitor
+  pattern, the legacy CLI options (`--useuris`, `--importmap`,
+  `--mergeimports`, `--log_level`, `--verbose`, `--stacktrace`,
+  `--metadata`), and the SchemaLoader-only fields (`base_dir`,
+  `namespaces`, `metamodel`) were never read.
+- **Effect on transitive dependencies.** Removing the `linkml`
+  distribution drops `pyshex` / `pyshexc` (which pulled in `rfc3987`,
+  GPL-licensed), `sphinx-click` (which pulled in `docutils`),
+  `SQLAlchemy` (which pulled in `greenlet`), and `linkml-dataops` /
+  `jsonpatch` (which pulled in `jsonpointer`) from the install tree.
+  Generated specs are byte-identical against every committed example.
+- The `linkml.generators` plugin entry point is preserved so users who
+  also have `linkml` installed can keep invoking the unified
+  `linkml`/`gen-linkml` CLIs against this generator.
+
 ## [0.3.0] — 2026-04-26
 
 This release adds the annotations and CLI surface needed to drive a

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install linkml-openapi
 gen-openapi schema.yaml > openapi.yaml
 
 # JSON output
-gen-openapi schema.yaml -f json -o openapi.json
+gen-openapi schema.yaml -f json > openapi.json
 
 # Custom title, version, server
 gen-openapi schema.yaml --api-title "My API" --api-version 2.0.0 --server-url https://api.example.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "linkml>=1.7.0",
     "linkml-runtime>=1.7.0",
     "openapi-pydantic>=0.5.0",
     "pyyaml>=6.0",
+    "click>=8.0",
 ]
 
 [project.urls]

--- a/src/linkml_openapi/_base.py
+++ b/src/linkml_openapi/_base.py
@@ -61,9 +61,7 @@ class Generator:
         if self.format is None:
             self.format = self.valid_formats[0]
         if self.format not in self.valid_formats:
-            raise ValueError(
-                f"Unrecognized format: {self.format!r}; known={self.valid_formats}"
-            )
+            raise ValueError(f"Unrecognized format: {self.format!r}; known={self.valid_formats}")
         # SchemaView already accepts the full union (path, YAML/JSON source,
         # SchemaDefinition, file-like) that the upstream Generator did, so
         # no wrapping is needed here.

--- a/src/linkml_openapi/_base.py
+++ b/src/linkml_openapi/_base.py
@@ -1,0 +1,70 @@
+"""Minimal Generator base used by ``linkml_openapi.generator.OpenAPIGenerator``.
+
+This shim replaces ``linkml.utils.generator.Generator`` so the package can
+depend on ``linkml-runtime`` alone. The full ``linkml`` distribution drags in
+``pyshex`` (``rfc3987``, GPL), ``sphinx-click`` (``docutils``), ``SQLAlchemy``
+(``greenlet``), and ``linkml-dataops``/``jsonpatch`` (``jsonpointer``) — none
+of which the OpenAPI generator exercises. Decoupling here clears those
+licence / dependency-scanning flags without changing any generator behaviour.
+
+The shim keeps the contract OpenAPIGenerator already relied on:
+
+* the dataclass declares ``schema``, ``format``, ``output`` as the first
+  three fields, so ``OpenAPIGenerator(yamlfile, format=…)`` keeps working;
+* ``__post_init__`` validates ``format`` against ``valid_formats`` and
+  builds ``self.schemaview`` from a ``SchemaView``;
+* ClassVars (``valid_formats``, ``file_extension``, ``generatorname``,
+  ``generatorversion``, ``uses_schemaloader``) match the upstream names so
+  the LinkML plugin entry point keeps resolving for users who still have
+  the linkml CLI installed.
+
+Legacy options (``importmap``, ``base_dir``, ``useuris``, ``mergeimports``,
+``log_level``, ``verbose``, ``stacktrace``, ``metadata``) are dropped — the
+OpenAPI generator never read them, and the SchemaLoader visitor pattern
+they steered was already disabled (``uses_schemaloader = False``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from linkml_runtime.utils.schemaview import SchemaView
+
+
+@dataclass
+class Generator:
+    """SchemaView-only Generator base for linkml-openapi."""
+
+    schema: str | None = None
+    """Path to a LinkML schema file, or YAML/JSON schema source."""
+
+    format: str | None = None
+    """Output format. Defaults to ``valid_formats[0]`` when unset."""
+
+    output: str | None = None
+    """Optional output path. The OpenAPI generator ignores this and lets the
+    CLI handle redirection — kept for parity with the upstream signature."""
+
+    valid_formats: ClassVar[list[str]] = []
+    file_extension: ClassVar[str] = ""
+    generatorname: ClassVar[str] = ""
+    generatorversion: ClassVar[str] = ""
+    uses_schemaloader: ClassVar[bool] = False
+
+    def __post_init__(self) -> None:
+        if not self.valid_formats:
+            raise ValueError(
+                f"{type(self).__name__} must declare valid_formats "
+                "(ClassVar[list[str]]) before instantiation"
+            )
+        if self.format is None:
+            self.format = self.valid_formats[0]
+        if self.format not in self.valid_formats:
+            raise ValueError(
+                f"Unrecognized format: {self.format!r}; known={self.valid_formats}"
+            )
+        # SchemaView already accepts the full union (path, YAML/JSON source,
+        # SchemaDefinition, file-like) that the upstream Generator did, so
+        # no wrapping is needed here.
+        self.schemaview: SchemaView = SchemaView(self.schema)

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -1,14 +1,21 @@
 """CLI for generating OpenAPI specs from LinkML schemas."""
 
 import click
-from linkml.utils.generator import shared_arguments
 
 from linkml_openapi import __version__
 from linkml_openapi.generator import OpenAPIGenerator
 
 
-@shared_arguments(OpenAPIGenerator)
 @click.command(name="gen-openapi")
+@click.argument("yamlfile", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--format",
+    "-f",
+    type=click.Choice(OpenAPIGenerator.valid_formats),
+    default=OpenAPIGenerator.valid_formats[0],
+    show_default=True,
+    help="Output format.",
+)
 @click.option("--api-title", help="API title (default: schema name)")
 @click.option("--api-version", default="1.0.0", show_default=True, help="API version")
 @click.option(

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 import yaml
-from linkml.utils.generator import Generator
 from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 from openapi_pydantic import (
     Components,
@@ -34,6 +33,7 @@ from openapi_pydantic import (
 )
 
 from linkml_openapi import __version__
+from linkml_openapi._base import Generator
 
 # LinkML range → OpenAPI DataType mapping
 RANGE_TYPE_MAP: dict[str, dict[str, Any]] = {

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -289,13 +289,23 @@ class TestSerialization:
         assert parsed["openapi"] == "3.0.3"
 
     def test_is_linkml_generator(self):
-        """Verify it extends the LinkML Generator base class."""
-        from linkml.utils.generator import Generator
+        """Verify it extends our minimal Generator shim and exposes a SchemaView.
+
+        The upstream `linkml.utils.generator.Generator` was dropped in favour
+        of `linkml_openapi._base.Generator` to remove the `linkml`
+        distribution as a runtime dependency (and with it `pyshex`,
+        `sphinx-click`, `SQLAlchemy`, and `linkml-dataops`). The contract the
+        OpenAPI generator depends on — `valid_formats`, `uses_schemaloader`,
+        `schemaview` — is preserved.
+        """
+        from linkml_runtime.utils.schemaview import SchemaView
+
+        from linkml_openapi._base import Generator
 
         gen = _make_generator()
         assert isinstance(gen, Generator)
         assert gen.uses_schemaloader is False
-        assert gen.schemaview is not None
+        assert isinstance(gen.schemaview, SchemaView)
 
 
 # --- Slot annotation tests ---


### PR DESCRIPTION
## Summary

Drops `linkml` (the heavy distribution) as a runtime dependency, keeping only
`linkml-runtime`. Clears four packages that corporate licence-scanning tools
flag on install:

| Package | Flag | Pulled in via | Used by us? |
|---|---|---|---|
| `rfc3987` | GPL (red) | `pyshex` / `pyshexc` ← `linkml` | **No** — never touch ShEx |
| `docutils` | metadata flag (red) | `sphinx-click` ← `linkml` | **No** — no Sphinx docs |
| `greenlet` | licence undetectable | `SQLAlchemy` ← `linkml` | **No** — no SQL paths |
| `jsonpointer` | licence undetectable | `jsonpatch` ← `linkml-dataops` ← `linkml` | **No** — no JSON Patch |

Empirical check: importing `linkml_openapi.generator` after this change loads
zero `linkml.*` modules and none of the four flagged transitives.

## Changes

* New `src/linkml_openapi/_base.py` — minimal `Generator` shim depending only
  on `linkml_runtime.utils.schemaview.SchemaView`. Preserves the contract the
  OpenAPI generator actually used: dataclass with `schema` / `format` /
  `output` as the first three fields, `__post_init__` validation against
  `valid_formats`, `self.schemaview` constructed from a `SchemaView`. ClassVar
  names match upstream so the `linkml.generators` plugin entry point keeps
  resolving for users who *also* have `linkml` installed.
* `generator.py` — import the shim instead of `linkml.utils.generator`.
* `cli.py` — replace `@shared_arguments(OpenAPIGenerator)` with explicit
  `@click.argument("yamlfile")` and `@click.option("--format", "-f")`. The
  legacy `shared_arguments` flags we never read (`--useuris`, `--importmap`,
  `--mergeimports`, `--log_level`, `--verbose`, `--stacktrace`, `--metadata`)
  are dropped from the surface.
* `pyproject.toml` — `linkml>=1.7.0` removed; `click>=8.0` added (it was a
  transitive of `linkml`, now becomes a direct dep since `cli.py` imports it).
* `tests/test_generator.py` — `test_is_linkml_generator` now asserts
  inheritance from the shim and that `gen.schemaview` is a `SchemaView`.
* README — fix a long-standing docs typo that referenced a non-existent
  `-o openapi.json` option (use shell redirection).

## What stays the same

* Public API (`OpenAPIGenerator(yamlfile, **kwargs)`, `gen.serialize()`).
* CLI surface (every option that did anything is still there).
* The `linkml.generators` plugin entry point in `pyproject.toml`.
* Every committed example spec — regenerated and byte-identical.

## Test plan

- [x] `pytest tests/` — 124 / 124 pass
- [x] `ruff check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — no diff
- [x] `gen-openapi --help`, `gen-openapi --version`, `gen-openapi <schema> -f json` smoke-tested
- [x] Import-time module audit: zero `linkml.*` modules loaded; no
  `rfc3987` / `docutils` / `greenlet` / `jsonpointer` / `jsonpatch` /
  `sqlalchemy` / `pyshex` / `sphinx`

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA