### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## Unreleased
+## [0.4.0] — 2026-04-27
+
+Dependency-surface release: cuts the install tree down to `linkml-runtime`
+and a handful of small, permissively-licensed transitives so the package
+clears strict corporate licence-scanning policies. No behaviour change —
+generated specs are byte-identical against every committed example, and
+the public Python and CLI surfaces are unchanged apart from the removal
+of seven CLI flags that were always no-ops in this generator.
 
 ### Changed
 
@@ -141,6 +148,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.4.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.4.0
 [0.3.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.3.0
 [0.2.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.2.0
 [0.1.2]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.3.0"
+version = "0.4.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary

Cuts v0.4.0. Single change since v0.3.0: PR #30 dropped the `linkml`
runtime dependency in favour of `linkml-runtime` alone, clearing four
transitives that strict corporate licence-scanning tools flag on
install (`rfc3987` / `docutils` / `greenlet` / `jsonpointer`).

* `pyproject.toml`: `0.3.0` → `0.4.0`
* `src/linkml_openapi/__init__.py`: `__version__ = "0.4.0"`
* `CHANGELOG.md`: promote the `Unreleased` block under a `[0.4.0] —
  2026-04-27` heading with a one-paragraph release summary; add the
  v0.4.0 anchor.

## Why a minor bump (not 0.3.1)

* The CHANGELOG header explicitly notes that pre-1.0 minor bumps can
  carry visible behaviour changes.
* Seven CLI flags were removed (`--useuris`, `--importmap`,
  `--mergeimports`, `--log_level`, `--verbose`, `--stacktrace`,
  `--metadata`). They were always no-ops in this generator's path,
  but their disappearance from `gen-openapi --help` is user-visible.
* Direct dependency `linkml` was removed from the install tree, which
  changes what `pip install linkml-openapi` brings down.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (caught the format-only fix in PR #30 retroactively)
- [x] `pytest tests/ -m "not e2e"` — 131 / 131 pass
- [x] `gen-openapi --version` reports `0.4.0`
- [ ] Merge → tag `v0.4.0` → publish workflow uploads to PyPI

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_