### PR TITLE
feat(nested): N-level deep item paths + Layer 4 + flat_only (#32 + #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Default remains ``"true"``, so schemas without any of the new
   annotations regenerate byte-identically. ``limit`` / ``offset``
   always emit on list endpoints regardless of the setting.
+- **Deep nested item paths via parent-chain walk** ([#32](https://github.com/jackhiggs/linkml-openapi/issues/32)).
+  When a resource class is reachable from one or more ancestor resource
+  classes via multivalued relationship slots, the generator now emits a
+  deep item path that includes every ancestor's identifier as a path
+  parameter. For ``Catalog.datasets: list[Dataset]`` and
+  ``Dataset.distributions: list[Distribution]`` (all three resources),
+  the canonical deep paths are::
+
+      /catalogs/{catalogId}/datasets/{datasetId}
+      /catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}
+
+  Each ancestor's identifier becomes a URL parameter — *not* a field on
+  the leaf component schema. Operation IDs on deep paths are suffixed
+  ``_via_<chain>`` so they remain globally unique alongside the
+  flat-path operations.
+- **`openapi.path_id` class annotation** — overrides the default
+  ``<class_snake>_id`` URL parameter name everywhere the class appears
+  in a URL (its own flat item path, single-level nested item paths
+  pointing to it, and ancestor segments in deep chains). Set to
+  ``catalogId`` to emit ``{catalogId}`` instead of the default
+  ``{catalog_id}``. Existing schemas without the annotation keep
+  byte-identical output.
+- **`openapi.parent_path` class annotation** — picks the canonical
+  chain when a leaf class is reachable via multiple ancestor chains.
+  Accepts ``/``-separated hops; each hop is either ``slot_name``
+  (when unambiguous) or ``ClassName.slot_name`` (when class qualifier
+  is needed to disambiguate). Without the annotation, an ambiguous
+  leaf raises at generation time with the candidate chains listed.
+- **`openapi.nested_only` class annotation** — drops the flat
+  ``/<class>`` and ``/<class>/{id}`` paths so the deep nested URL is
+  the only canonical surface for a class. Pairs naturally with
+  ``openapi.parent_path`` for sub-resources that don't make sense on
+  their own.
 
 ## [0.4.0] — 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the only canonical surface for a class. Pairs naturally with
   ``openapi.parent_path`` for sub-resources that don't make sense on
   their own.
+- **`openapi.flat_only` class annotation**
+  ([#36](https://github.com/jackhiggs/linkml-openapi/issues/36))
+  — converse of ``openapi.nested_only``. Drops the deep nested item
+  path emission for the class while keeping the flat collection +
+  flat item paths. Single-level nested paths under a parent (which
+  are about this class as a *parent*, not as a leaf) still emit.
+  Setting both ``openapi.nested_only`` and ``openapi.flat_only`` on
+  the same class is a generation error.
+- **`openapi.path_template` + `openapi.path_param_sources`
+  class annotations** (Layer 4 escape hatch,
+  [#36](https://github.com/jackhiggs/linkml-openapi/issues/36)) —
+  hand-authored URL template that replaces the auto-derived deep
+  chain. Used for legacy contracts the relationship graph can't
+  express (literal segments like ``by-doi``, compound keys,
+  version prefixes). Each ``{name}`` placeholder must be paired
+  with a ``name:Class.slot`` source so parameter schemas remain
+  typed. Validates: placeholder set matches source-key set
+  exactly, every ``Class.slot`` resolves, and operation IDs are
+  suffixed ``_via_template`` to stay globally unique.
 
 ## [0.4.0] — 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -661,6 +661,56 @@ the only canonical addresses are
 `/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}` and
 its single-level forms.
 
+##### `openapi.flat_only`
+
+Converse of `openapi.nested_only`. Drops the deep nested item path
+emission for the class while keeping the flat collection + flat item
+paths. Single-level nested paths from a parent still emit (those are
+about this class as a *parent*, not as a leaf).
+
+```yaml
+classes:
+  Tag:
+    annotations:
+      openapi.resource: "true"
+      openapi.flat_only: "true"        # /tags + /tags/{id}; no deep chain
+```
+
+Setting both `openapi.nested_only` and `openapi.flat_only` on the same
+class is a generation error.
+
+##### `openapi.path_template` — Layer 4 escape hatch
+
+When the URL is dictated by an external contract that the relationship
+graph can't express (literal segments, compound keys, version prefixes),
+hand-author the template and tell the generator which class.identifier
+slot backs each placeholder:
+
+```yaml
+classes:
+  ResourceVersion:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+      openapi.path_param_sources: "cId:Catalog.id,doi:ResourceVersion.doi,version:ResourceVersion.version"
+      openapi.nested_only: "true"      # often paired: only the templated URL is canonical
+```
+
+Each `{name}` in the template must have a matching `name:Class.slot`
+entry in `openapi.path_param_sources`. The slot's range drives the
+parameter schema, so typed parameters and any RDF metadata still flow
+through. Validation:
+
+* Placeholder set must equal source-key set; mismatches raise with both
+  lists named.
+* Each `Class.slot` source must resolve; unknown class or slot raises.
+* When `openapi.path_template` is set, `openapi.parent_path` is ignored
+  (template wins).
+
+Operation IDs on templated paths are suffixed `_via_template` to stay
+globally unique alongside any flat-path operations the class still
+emits.
+
 ##### Operation IDs on deep paths
 
 Deep paths reuse the leaf's flat-path CRUD builders, so their
@@ -883,6 +933,9 @@ endpoints regardless of any of these annotations.
 | `openapi.path_id` | class | identifier name | `<class_snake>_id` (e.g. `catalog_id`) |
 | `openapi.parent_path` | class | `Class.slot/Class.slot/...` | Auto-derive when chain is unambiguous |
 | `openapi.nested_only` | class | `"true"` / `"false"` | Both flat and deep paths emit |
+| `openapi.flat_only` | class | `"true"` / `"false"` | Both flat and deep paths emit (mutually exclusive with `nested_only`) |
+| `openapi.path_template` | class | URL template with `{name}` placeholders | Auto-derived chain |
+| `openapi.path_param_sources` | class | comma-separated `name:Class.slot` entries | (required when `path_template` is set) |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` / token list / `"false"` | Auto-inferred from slot type |
 | `openapi.format` | slot | format string | derived from slot range |

--- a/README.md
+++ b/README.md
@@ -556,6 +556,124 @@ signal when one side wants the path without paying for a real slot.
 generator never guesses that `Article.reviewers` implies a path on
 `Reviewer`. That's a parallel-vocabulary trap.
 
+#### Deep nested item paths via parent chains
+
+When a resource class is reachable via one or more ancestor resource
+classes (a chain of multivalued relationship slots), the generator
+emits a deep item path that includes every ancestor's identifier as a
+URL parameter. This is the canonical shape DCAT3, FHIR, and most
+catalog-style APIs use:
+
+```
+/catalogs/{catalogId}/datasets/{datasetId}
+/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}
+```
+
+Each ancestor's identifier shows up as a path parameter — **not** as a
+field on the leaf component schema. The leaf's URL surface comes from
+the relationship graph, not from any foreign-key slot.
+
+##### `openapi.path_id`
+
+Renames the URL parameter for a class everywhere it appears in a URL —
+its own flat item path, single-level nested item paths pointing to it,
+and ancestor segments in any deep chain that passes through it. Default
+is `<class_snake>_id` (e.g. `{catalog_id}`); set the annotation to
+override.
+
+```yaml
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_id: catalogId         # → /catalogs/{catalogId}
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      datasets:
+        range: Dataset
+        multivalued: true
+
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_id: datasetId
+```
+
+produces:
+
+```
+/catalogs/{catalogId}
+/catalogs/{catalogId}/datasets/{datasetId}
+```
+
+##### `openapi.parent_path`
+
+Picks the canonical chain when a leaf class is reachable via multiple
+ancestor chains. Format: `/`-separated hops, each hop either
+`slot_name` (when unambiguous) or `ClassName.slot_name` (qualifier
+required to disambiguate same-named slots on different parents).
+
+```yaml
+classes:
+  Folder:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      tags:
+        range: Tag
+        multivalued: true
+
+  Bookmark:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      tags:
+        range: Tag
+        multivalued: true
+
+  Tag:
+    annotations:
+      openapi.resource: "true"
+      openapi.parent_path: Folder.tags     # /folders/{id}/tags/{id} only
+```
+
+Without the annotation, the generator fails at generation time with
+both candidate chains listed (`Folder.tags`, `Bookmark.tags`) so the
+schema author can pick deliberately.
+
+##### `openapi.nested_only`
+
+Drops the flat `/<class>` collection and `/<class>/{id}` item paths,
+leaving the deep nested URL as the only canonical surface. Useful for
+sub-resources that don't make sense outside their parent context — a
+`Distribution` is meaningless without the `Dataset` it belongs to.
+
+```yaml
+classes:
+  Distribution:
+    annotations:
+      openapi.resource: "true"
+      openapi.nested_only: "true"
+```
+
+After this, `/distributions` and `/distributions/{id}` no longer emit;
+the only canonical addresses are
+`/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}` and
+its single-level forms.
+
+##### Operation IDs on deep paths
+
+Deep paths reuse the leaf's flat-path CRUD builders, so their
+`operationId` collides with the flat versions by default. The
+generator suffixes deep operation IDs with `_via_<chain>` (snake-case
+ancestor classes) so the spec stays globally unique:
+
+```
+get_distribution               # /distributions/{distId}
+get_distribution_via_catalog_dataset
+                               # /catalogs/.../datasets/.../distributions/{distId}
+```
+
 ### Slot-level annotations
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.
@@ -762,6 +880,9 @@ endpoints regardless of any of these annotations.
 | `openapi.operations` | class | comma-separated list | `list,create,read,update,delete` |
 | `openapi.media_types` | class | comma-separated list | `application/json` |
 | `openapi.auto_query_params` | schema or class | `"true"` / `"false"` | `"true"` (auto-infer scalar slots) |
+| `openapi.path_id` | class | identifier name | `<class_snake>_id` (e.g. `catalog_id`) |
+| `openapi.parent_path` | class | `Class.slot/Class.slot/...` | Auto-derive when chain is unambiguous |
+| `openapi.nested_only` | class | `"true"` / `"false"` | Both flat and deep paths emit |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` / token list / `"false"` | Auto-inferred from slot type |
 | `openapi.format` | slot | format string | derived from slot range |

--- a/examples/bookstore/openapi.yaml
+++ b/examples/bookstore/openapi.yaml
@@ -429,6 +429,97 @@ paths:
         type: string
       name: id
       in: path
+  /books/{book_id}/authors/{id}:
+    get:
+      tags:
+      - Author
+      summary: Get a Author
+      operationId: get_author_via_book
+      responses:
+        '200':
+          description: Author details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    put:
+      tags:
+      - Author
+      summary: Update a Author
+      operationId: update_author_via_book
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Author'
+        required: true
+      responses:
+        '200':
+          description: Author updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    delete:
+      tags:
+      - Author
+      summary: Delete a Author
+      operationId: delete_author_via_book
+      responses:
+        '204':
+          description: Author deleted
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    parameters:
+    - required: true
+      deprecated: false
+      schema:
+        type: string
+      name: book_id
+      in: path
+    - required: true
+      deprecated: false
+      schema:
+        type: string
+      name: id
+      in: path
 components:
   schemas:
     Product:

--- a/examples/petstore/openapi.yaml
+++ b/examples/petstore/openapi.yaml
@@ -175,6 +175,98 @@ paths:
         description: Unique pet identifier
       name: id
       in: path
+  /owners/{owner_id}/pets/{id}:
+    get:
+      tags:
+      - Pet
+      summary: Get a Pet
+      operationId: get_pet_via_owner
+      responses:
+        '200':
+          description: Pet details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    put:
+      tags:
+      - Pet
+      summary: Update a Pet
+      operationId: update_pet_via_owner
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '200':
+          description: Pet updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    delete:
+      tags:
+      - Pet
+      summary: Delete a Pet
+      operationId: delete_pet_via_owner
+      responses:
+        '204':
+          description: Pet deleted
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      deprecated: false
+    parameters:
+    - required: true
+      deprecated: false
+      schema:
+        type: string
+      name: owner_id
+      in: path
+    - required: true
+      deprecated: false
+      schema:
+        type: integer
+        description: Unique pet identifier
+      name: id
+      in: path
   /stores:
     get:
       tags:

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -302,6 +302,15 @@ class OpenAPIGenerator(Generator):
             path_segment = self._get_path_segment(cls)
             operations = self._get_operations(cls)
             nested_only = _is_truthy(self._class_annotation(cls, "openapi.nested_only") or False)
+            flat_only = _is_truthy(self._class_annotation(cls, "openapi.flat_only") or False)
+            if nested_only and flat_only:
+                raise ValueError(
+                    f"Class {class_name!r} declares both "
+                    '`openapi.nested_only: "true"` and '
+                    '`openapi.flat_only: "true"`. They are mutually '
+                    "exclusive — pick one. `nested_only` keeps the deep "
+                    "URL only; `flat_only` keeps the flat URL only."
+                )
 
             self._validate_resource_addressability(class_name, path_vars, operations)
 
@@ -366,51 +375,47 @@ class OpenAPIGenerator(Generator):
 
                 paths.update(self._make_nested_paths(class_name, path_segment, path_vars))
 
-                # Deep nested paths: when this class has a canonical parent
-                # chain, also emit the leaf's item path under the chain
-                # prefix and its children under that path. Each ancestor
-                # contributes a path-parameter sourced from its identifier
-                # slot — *not* from any field on this class — so the leaf
-                # component schema stays unchanged.
-                chain = self._canonical_parent_chain(class_name)
-                if chain:
-                    # `chain_prefix` already ends in the slot name that
-                    # leads to the leaf class (e.g.
-                    # ``catalogs/{catalogId}/datasets/{datasetId}/distributions``).
-                    # The deep item URL just appends the leaf's identifier
-                    # variable — no extra ``/<leaf_segment>`` segment, since
-                    # the slot already carries the noun.
-                    #
-                    # We only emit the leaf's *own* deep item path here.
-                    # Deeper children (Distribution under
-                    # /catalogs/.../datasets/.../distributions) are handled
-                    # naturally as those children's own canonical chain —
-                    # so each chain depth gets emitted exactly once,
-                    # without duplicating paths or risking cycles when
-                    # synthetic inverses fold a relationship back through
-                    # the chain.
-                    chain_prefix, chain_params = self._build_chain_path_params(chain)
-                    deep_item_path = f"/{chain_prefix}/{item_suffix}"
-                    deep_item_params = list(chain_params) + path_params
-                    deep_item = PathItem(parameters=deep_item_params)
-                    if "read" in operations:
-                        deep_item.get = self._make_read_operation(cls, class_name)
-                    if "update" in operations:
-                        deep_item.put = self._make_update_operation(cls, class_name)
-                    if "patch" in operations:
-                        deep_item.patch = self._make_patch_operation(cls, class_name)
-                    if "delete" in operations:
-                        deep_item.delete = self._make_delete_operation(cls, class_name)
-
-                    # OpenAPI requires globally unique `operationId` values.
-                    # The deep item's CRUD operations share IDs with the
-                    # leaf's flat item path. Append a chain-derived suffix
-                    # so each deep operation gets a unique, deterministic
-                    # ID without touching the flat-path operations.
-                    chain_suffix = "_via_" + "_".join(_to_snake_case(p) for p, _ in chain)
-                    deep_paths = {deep_item_path: deep_item}
-                    self._suffix_operation_ids(deep_paths, chain_suffix)
-                    paths.update(deep_paths)
+                # Deep nested paths. Three strategies, in priority order:
+                #
+                #   1. `openapi.flat_only: "true"` → skip deep emission
+                #      entirely. Flat collection / flat item already emitted
+                #      above (when `nested_only` is also off, which the
+                #      mutex check guarantees).
+                #
+                #   2. `openapi.path_template` → user-provided URL template
+                #      (Layer 4 escape hatch). Replaces the auto-derived
+                #      chain. Parameters are built from
+                #      `openapi.path_param_sources` so each `{name}` in the
+                #      template binds to a typed `Class.slot` source.
+                #
+                #   3. Auto-derived chain via the relationship graph
+                #      (Layers 1–3). Each ancestor contributes a path
+                #      parameter sourced from its identifier slot — *not*
+                #      from any field on this class — so the leaf
+                #      component schema stays unchanged.
+                #
+                # Deeper children of this class under a deep prefix are
+                # handled naturally as those children's own canonical
+                # chain, so each chain depth gets emitted exactly once.
+                if not flat_only:
+                    template = self._class_annotation(cls, "openapi.path_template")
+                    if template:
+                        deep_paths = self._emit_templated_deep_path(
+                            cls, class_name, template, operations
+                        )
+                        paths.update(deep_paths)
+                    else:
+                        chain = self._canonical_parent_chain(class_name)
+                        if chain:
+                            deep_paths = self._emit_chained_deep_path(
+                                cls,
+                                class_name,
+                                chain,
+                                item_suffix,
+                                path_params,
+                                operations,
+                            )
+                            paths.update(deep_paths)
 
         if self._needs_resource_link and "ResourceLink" not in schemas:
             schemas["ResourceLink"] = self._build_resource_link_schema()
@@ -1821,6 +1826,163 @@ class OpenAPIGenerator(Generator):
                 )
             )
         return "/".join(prefix_parts), params
+
+    def _emit_chained_deep_path(
+        self,
+        cls: ClassDefinition,
+        class_name: str,
+        chain: list[tuple[str, str]],
+        item_suffix: str,
+        path_params: list[Parameter],
+        operations: list[str],
+    ) -> dict[str, PathItem]:
+        """Emit the auto-derived deep item path for a class with a parent chain.
+
+        The deep URL is the chain prefix (already ending in the slot that
+        leads to the leaf class) plus the leaf's own ``item_suffix`` —
+        e.g. ``/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}``.
+        Operation IDs are suffixed ``_via_<chain>`` so they remain globally
+        unique alongside the leaf's flat-path operations.
+        """
+        chain_prefix, chain_params = self._build_chain_path_params(chain)
+        deep_item_path = f"/{chain_prefix}/{item_suffix}"
+        deep_item_params = list(chain_params) + path_params
+        deep_item = PathItem(parameters=deep_item_params)
+        if "read" in operations:
+            deep_item.get = self._make_read_operation(cls, class_name)
+        if "update" in operations:
+            deep_item.put = self._make_update_operation(cls, class_name)
+        if "patch" in operations:
+            deep_item.patch = self._make_patch_operation(cls, class_name)
+        if "delete" in operations:
+            deep_item.delete = self._make_delete_operation(cls, class_name)
+        chain_suffix = "_via_" + "_".join(_to_snake_case(p) for p, _ in chain)
+        deep_paths = {deep_item_path: deep_item}
+        self._suffix_operation_ids(deep_paths, chain_suffix)
+        return deep_paths
+
+    _PATH_TEMPLATE_PLACEHOLDER_RE: ClassVar[re.Pattern[str]] = re.compile(r"\{([^{}]+)\}")
+
+    @staticmethod
+    def _parse_path_param_sources(class_name: str, raw: str) -> dict[str, tuple[str, str]]:
+        """Parse ``openapi.path_param_sources`` into ``{name: (Class, slot)}``.
+
+        Format: comma-separated ``name:Class.slot`` entries. Whitespace
+        around any token is trimmed. Empty / missing raw produces ``{}``.
+        Malformed entries raise with the offending entry quoted.
+        """
+        sources: dict[str, tuple[str, str]] = {}
+        for raw_entry in _parse_csv(raw):
+            if ":" not in raw_entry:
+                raise ValueError(
+                    f"Class {class_name!r} has malformed "
+                    f"`openapi.path_param_sources` entry {raw_entry!r}: "
+                    "expected `name:Class.slot`."
+                )
+            name, source = (s.strip() for s in raw_entry.split(":", 1))
+            if "." not in source:
+                raise ValueError(
+                    f"Class {class_name!r} has malformed source "
+                    f"{source!r} for parameter {name!r}: expected "
+                    "`Class.slot`."
+                )
+            src_class, src_slot = (s.strip() for s in source.split(".", 1))
+            if not name or not src_class or not src_slot:
+                raise ValueError(
+                    f"Class {class_name!r} has empty token in "
+                    f"`openapi.path_param_sources` entry {raw_entry!r}."
+                )
+            if name in sources:
+                raise ValueError(
+                    f"Class {class_name!r} declares duplicate path "
+                    f"parameter {name!r} in `openapi.path_param_sources`."
+                )
+            sources[name] = (src_class, src_slot)
+        return sources
+
+    def _emit_templated_deep_path(
+        self,
+        cls: ClassDefinition,
+        class_name: str,
+        template: str,
+        operations: list[str],
+    ) -> dict[str, PathItem]:
+        """Emit a deep item path from a literal `openapi.path_template`.
+
+        The user-supplied template replaces the auto-derived chain. Each
+        ``{name}`` placeholder must have a matching ``name:Class.slot``
+        entry in ``openapi.path_param_sources``; the slot's range drives
+        the parameter schema (so typed parameters and RDF metadata still
+        flow). Validates: placeholder set matches source-key set,
+        every ``Class.slot`` resolves, no duplicates.
+        """
+        sv = self.schemaview
+        sources_raw = self._class_annotation(cls, "openapi.path_param_sources") or ""
+        sources = self._parse_path_param_sources(class_name, sources_raw)
+        placeholders = list(self._PATH_TEMPLATE_PLACEHOLDER_RE.findall(template))
+        unique_placeholders = list(dict.fromkeys(placeholders))  # preserve order, dedupe
+
+        if len(unique_placeholders) != len(placeholders):
+            duplicates = sorted({p for p in placeholders if placeholders.count(p) > 1})
+            raise ValueError(
+                f"Class {class_name!r} `openapi.path_template` "
+                f"{template!r} repeats placeholder(s) {duplicates}: "
+                "OpenAPI requires unique parameter names per path."
+            )
+
+        missing_sources = set(unique_placeholders) - set(sources)
+        extra_sources = set(sources) - set(unique_placeholders)
+        if missing_sources or extra_sources:
+            raise ValueError(
+                f"Class {class_name!r} `openapi.path_template` placeholders "
+                f"don't match `openapi.path_param_sources`. "
+                f"Template placeholders: {sorted(unique_placeholders)!r}. "
+                f"Source keys: {sorted(sources)!r}. "
+                f"Missing sources: {sorted(missing_sources)!r}. "
+                f"Extra sources (not in template): {sorted(extra_sources)!r}."
+            )
+
+        params: list[Parameter] = []
+        for name in unique_placeholders:
+            src_class, src_slot = sources[name]
+            if sv.get_class(src_class) is None:
+                raise ValueError(
+                    f"Class {class_name!r} `openapi.path_param_sources` "
+                    f"refers to unknown class {src_class!r} for "
+                    f"parameter {name!r}."
+                )
+            slot = next(
+                (s for s in sv.class_induced_slots(src_class) if s.name == src_slot),
+                None,
+            )
+            if slot is None:
+                raise ValueError(
+                    f"Class {class_name!r} `openapi.path_param_sources` "
+                    f"refers to unknown slot {src_class}.{src_slot!r} for "
+                    f"parameter {name!r}."
+                )
+            params.append(
+                Parameter(
+                    name=name,
+                    param_in=ParameterLocation.PATH,
+                    required=True,
+                    param_schema=self._slot_to_schema(slot),
+                )
+            )
+
+        deep_item = PathItem(parameters=params)
+        if "read" in operations:
+            deep_item.get = self._make_read_operation(cls, class_name)
+        if "update" in operations:
+            deep_item.put = self._make_update_operation(cls, class_name)
+        if "patch" in operations:
+            deep_item.patch = self._make_patch_operation(cls, class_name)
+        if "delete" in operations:
+            deep_item.delete = self._make_delete_operation(cls, class_name)
+
+        deep_paths = {template: deep_item}
+        self._suffix_operation_ids(deep_paths, "_via_template")
+        return deep_paths
 
     def _add_composition_paths(
         self,

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -192,6 +192,10 @@ class OpenAPIGenerator(Generator):
         # class and slot in the schema (O(resource_classes × all_classes ×
         # max_slots) per build).
         self._synthetic_inverses_index = self._collect_synthetic_inverses()
+        # Pre-compute the parent-chain index so each resource-class
+        # iteration in `_build_openapi` can ask for its canonical chain in
+        # O(1) instead of re-walking the relationship graph.
+        self._parent_chains_index = self._collect_parent_chains()
         spec = self._build_openapi()
         raw = json.loads(spec.model_dump_json(by_alias=True, exclude_none=True))
         raw["openapi"] = self.openapi_version
@@ -297,44 +301,116 @@ class OpenAPIGenerator(Generator):
             path_vars = self._get_path_variables(cls)
             path_segment = self._get_path_segment(cls)
             operations = self._get_operations(cls)
+            nested_only = _is_truthy(self._class_annotation(cls, "openapi.nested_only") or False)
 
             self._validate_resource_addressability(class_name, path_vars, operations)
 
-            # Collection path
-            collection_path = f"/{path_segment}"
-            collection_item = PathItem()
-            if "list" in operations:
-                collection_item.get = self._make_list_operation(cls, class_name)
-            if "create" in operations:
-                collection_item.post = self._make_create_operation(cls, class_name)
-            paths[collection_path] = collection_item
+            # Collection path. Suppressed when `openapi.nested_only: "true"`
+            # makes the deep-nested URL the only canonical surface.
+            if not nested_only:
+                collection_path = f"/{path_segment}"
+                collection_item = PathItem()
+                if "list" in operations:
+                    collection_item.get = self._make_list_operation(cls, class_name)
+                if "create" in operations:
+                    collection_item.post = self._make_create_operation(cls, class_name)
+                paths[collection_path] = collection_item
 
-            # Item path
+            # Item path. When the class declares `openapi.path_id` *and*
+            # has exactly one path variable, the override renames the URL
+            # parameter (and the matching `Parameter.name`) so the same
+            # identifier shows up consistently in the flat item path, in
+            # nested-paths-from-this-class, and in any deep chain that
+            # passes through this class as an ancestor.
             if path_vars:
-                item_suffix = "/".join(f"{{{s.name}}}" for s, _mode in path_vars)
-                item_path = f"/{path_segment}/{item_suffix}"
+                path_id_override = (
+                    self._class_annotation(cls, "openapi.path_id") if len(path_vars) == 1 else None
+                )
+                resolved_path_vars = [
+                    (
+                        path_id_override.strip() if path_id_override else slot.name,
+                        slot,
+                        mode,
+                    )
+                    for slot, mode in path_vars
+                ]
+                item_suffix = "/".join(f"{{{name}}}" for name, _slot, _mode in resolved_path_vars)
                 path_params = [
                     Parameter(
-                        name=s.name,
+                        name=name,
                         param_in=ParameterLocation.PATH,
                         required=True,
-                        param_schema=self._path_variable_schema(s, mode),
+                        param_schema=self._path_variable_schema(slot, mode),
                     )
-                    for s, mode in path_vars
+                    for name, slot, mode in resolved_path_vars
                 ]
-                item = PathItem(parameters=path_params)
-                if "read" in operations:
-                    item.get = self._make_read_operation(cls, class_name)
-                if "update" in operations:
-                    item.put = self._make_update_operation(cls, class_name)
-                if "patch" in operations:
-                    item.patch = self._make_patch_operation(cls, class_name)
+
+                if not nested_only:
+                    item_path = f"/{path_segment}/{item_suffix}"
+                    item = PathItem(parameters=path_params)
+                    if "read" in operations:
+                        item.get = self._make_read_operation(cls, class_name)
+                    if "update" in operations:
+                        item.put = self._make_update_operation(cls, class_name)
+                    if "patch" in operations:
+                        item.patch = self._make_patch_operation(cls, class_name)
+                    if "delete" in operations:
+                        item.delete = self._make_delete_operation(cls, class_name)
+                    paths[item_path] = item
+
+                # The PATCH body schema is needed whenever `patch` is
+                # listed, regardless of which URL forms emit, so generate
+                # it outside the nested-only branch.
+                if "patch" in operations and f"{class_name}Patch" not in schemas:
                     schemas[f"{class_name}Patch"] = self._build_patch_schema(class_name, cls)
-                if "delete" in operations:
-                    item.delete = self._make_delete_operation(cls, class_name)
-                paths[item_path] = item
 
                 paths.update(self._make_nested_paths(class_name, path_segment, path_vars))
+
+                # Deep nested paths: when this class has a canonical parent
+                # chain, also emit the leaf's item path under the chain
+                # prefix and its children under that path. Each ancestor
+                # contributes a path-parameter sourced from its identifier
+                # slot — *not* from any field on this class — so the leaf
+                # component schema stays unchanged.
+                chain = self._canonical_parent_chain(class_name)
+                if chain:
+                    # `chain_prefix` already ends in the slot name that
+                    # leads to the leaf class (e.g.
+                    # ``catalogs/{catalogId}/datasets/{datasetId}/distributions``).
+                    # The deep item URL just appends the leaf's identifier
+                    # variable — no extra ``/<leaf_segment>`` segment, since
+                    # the slot already carries the noun.
+                    #
+                    # We only emit the leaf's *own* deep item path here.
+                    # Deeper children (Distribution under
+                    # /catalogs/.../datasets/.../distributions) are handled
+                    # naturally as those children's own canonical chain —
+                    # so each chain depth gets emitted exactly once,
+                    # without duplicating paths or risking cycles when
+                    # synthetic inverses fold a relationship back through
+                    # the chain.
+                    chain_prefix, chain_params = self._build_chain_path_params(chain)
+                    deep_item_path = f"/{chain_prefix}/{item_suffix}"
+                    deep_item_params = list(chain_params) + path_params
+                    deep_item = PathItem(parameters=deep_item_params)
+                    if "read" in operations:
+                        deep_item.get = self._make_read_operation(cls, class_name)
+                    if "update" in operations:
+                        deep_item.put = self._make_update_operation(cls, class_name)
+                    if "patch" in operations:
+                        deep_item.patch = self._make_patch_operation(cls, class_name)
+                    if "delete" in operations:
+                        deep_item.delete = self._make_delete_operation(cls, class_name)
+
+                    # OpenAPI requires globally unique `operationId` values.
+                    # The deep item's CRUD operations share IDs with the
+                    # leaf's flat item path. Append a chain-derived suffix
+                    # so each deep operation gets a unique, deterministic
+                    # ID without touching the flat-path operations.
+                    chain_suffix = "_via_" + "_".join(_to_snake_case(p) for p, _ in chain)
+                    deep_paths = {deep_item_path: deep_item}
+                    self._suffix_operation_ids(deep_paths, chain_suffix)
+                    paths.update(deep_paths)
 
         if self._needs_resource_link and "ResourceLink" not in schemas:
             schemas["ResourceLink"] = self._build_resource_link_schema()
@@ -1318,14 +1394,33 @@ class OpenAPIGenerator(Generator):
         }
         return schema
 
-    @staticmethod
-    def _nested_item_path_var(target_class_name: str) -> str:
+    def _class_path_id_name(self, class_name: str) -> str:
+        """Path-variable name to use whenever ``class_name`` appears in a URL.
+
+        Drives both the leaf ``{<class>_id}`` segment in a single-level nested
+        item path and every ancestor segment in an N-level chain. Default is
+        ``<snake>_id`` so existing specs stay byte-identical; override per
+        class with the ``openapi.path_id`` annotation::
+
+            classes:
+              Catalog:
+                annotations:
+                  openapi.path_id: catalogId   # → {catalogId} in URLs
+        """
+        cls = self.schemaview.get_class(class_name)
+        override = self._class_annotation(cls, "openapi.path_id") if cls else None
+        if override:
+            return override.strip()
+        return f"{_to_snake_case(class_name)}_id"
+
+    def _nested_item_path_var(self, target_class_name: str) -> str:
         """Path-variable name for the linked item under a nested path.
 
         Avoids colliding with the parent's ``{id}`` by namespacing on the
-        target class (e.g. ``/books/{id}/authors/{author_id}``).
+        target class (e.g. ``/books/{id}/authors/{author_id}``). Override
+        per class with ``openapi.path_id``.
         """
-        return f"{_to_snake_case(target_class_name)}_id"
+        return self._class_path_id_name(target_class_name)
 
     def _make_nested_paths(
         self,
@@ -1333,30 +1428,74 @@ class OpenAPIGenerator(Generator):
         parent_path_segment: str,
         parent_path_vars: list,
     ) -> dict[str, PathItem]:
+        """Single-level nested paths under a class's own item path.
+
+        Thin wrapper that renders ``parent_path_segment`` + ``parent_path_vars``
+        into a URL prefix and the matching parameter list, then delegates to
+        :meth:`_make_nested_paths_with_prefix` so single-level and N-level
+        emission share the same code path. Honours the parent's
+        ``openapi.path_id`` so the nested URL and the class's own flat item
+        path use the same parameter name.
+        """
+        parent_cls = self.schemaview.get_class(parent_class_name)
+        path_id_override = (
+            self._class_annotation(parent_cls, "openapi.path_id")
+            if parent_cls and len(parent_path_vars) == 1
+            else None
+        )
+        named_vars = [
+            (
+                path_id_override.strip() if path_id_override else slot.name,
+                slot,
+                mode,
+            )
+            for slot, mode in parent_path_vars
+        ]
+        parent_var_suffix = "/".join(f"{{{name}}}" for name, _slot, _mode in named_vars)
+        prefix = (
+            f"{parent_path_segment}/{parent_var_suffix}"
+            if parent_var_suffix
+            else parent_path_segment
+        )
+        parent_path_params = [
+            Parameter(
+                name=name,
+                param_in=ParameterLocation.PATH,
+                required=True,
+                param_schema=self._path_variable_schema(slot, mode),
+            )
+            for name, slot, mode in named_vars
+        ]
+        return self._make_nested_paths_with_prefix(parent_class_name, prefix, parent_path_params)
+
+    def _make_nested_paths_with_prefix(
+        self,
+        parent_class_name: str,
+        url_prefix: str,
+        path_params: list[Parameter],
+    ) -> dict[str, PathItem]:
         """Generate nested paths for composition and reference relationships.
 
         Walks every multivalued, class-ranged slot on the parent and emits:
 
         - **Composition** (``slot.inlined``): full CRUD nested at
-          ``/{parent}/{id}/{slot}`` (and ``/{slot}/{target_id}`` when the
-          target has an identifier).
+          ``/{prefix}/{slot}`` and ``/{prefix}/{slot}/{target_id}`` when the
+          target has an identifier.
         - **Reference** (target has identifier, ``inlined: false``): GET to
           list, POST with a ``ResourceLink`` body to attach (single or batch
           via ``oneOf``), DELETE on the per-target item path to detach.
+
+        ``url_prefix`` is the already-rendered ancestor portion of the URL
+        without leading or trailing slashes, e.g. ``"catalogs/{id}"`` for a
+        single-level emission or
+        ``"orgs/{org_id}/catalogs/{catalog_id}/datasets/{dataset_id}"`` for an
+        N-level emission. ``path_params`` carries every `Parameter` that
+        prefix references, so the resulting `PathItem` lists them at the
+        path level.
         """
         sv = self.schemaview
         parent_cls = sv.get_class(parent_class_name)
         out: dict[str, PathItem] = {}
-        parent_var_suffix = "/".join(f"{{{s.name}}}" for s, _mode in parent_path_vars)
-        parent_path_params = [
-            Parameter(
-                name=s.name,
-                param_in=ParameterLocation.PATH,
-                required=True,
-                param_schema=self._path_variable_schema(s, mode),
-            )
-            for s, mode in parent_path_vars
-        ]
 
         for slot in sv.class_induced_slots(parent_class_name):
             if not slot.multivalued:
@@ -1374,7 +1513,7 @@ class OpenAPIGenerator(Generator):
             if nested_ann is not None and not _is_truthy(nested_ann):
                 continue
 
-            collection_path = f"/{parent_path_segment}/{parent_var_suffix}/{slot.name}"
+            collection_path = f"/{url_prefix}/{slot.name}"
             target_id_slot = self._identifier_slot(target_name)
 
             if self._is_composition(slot):
@@ -1385,7 +1524,7 @@ class OpenAPIGenerator(Generator):
                     slot,
                     target_name,
                     target_id_slot,
-                    parent_path_params,
+                    path_params,
                 )
             else:
                 self._needs_resource_link = True
@@ -1396,7 +1535,7 @@ class OpenAPIGenerator(Generator):
                     slot,
                     target_name,
                     target_id_slot,
-                    parent_path_params,
+                    path_params,
                 )
 
         # Synthetic inverse paths — emitted for `inverse:` declarations
@@ -1404,7 +1543,7 @@ class OpenAPIGenerator(Generator):
         # reference-shaped (composition can't be inverted: a composed
         # child has no independent identity to put on the wire).
         for synth_name, source_class in self._synthetic_inverses_for(parent_class_name):
-            collection_path = f"/{parent_path_segment}/{parent_var_suffix}/{synth_name}"
+            collection_path = f"/{url_prefix}/{synth_name}"
             target_id_slot = self._identifier_slot(source_class)
             fake_slot = SlotDefinition(name=synth_name, range=source_class, multivalued=True)
             self._needs_resource_link = True
@@ -1415,7 +1554,7 @@ class OpenAPIGenerator(Generator):
                 fake_slot,
                 source_class,
                 target_id_slot,
-                parent_path_params,
+                path_params,
             )
 
         return out
@@ -1465,6 +1604,223 @@ class OpenAPIGenerator(Generator):
                 seen.add(tgt_slot_name)
                 index.setdefault(tgt_class, []).append((tgt_slot_name, src_class_name))
         return index
+
+    # --- Deep nested paths via parent-chain walk -------------------------
+
+    def _collect_parent_chains(self) -> dict[str, list[list[tuple[str, str]]]]:
+        """Index every chain of `(parent_class, slot_name)` leading to each class.
+
+        For a leaf class ``L``, each chain is the ordered list of ancestors
+        from the root parent down to the direct parent — e.g. for
+        ``Org → Catalog → Dataset → Distribution`` walked via
+        ``Org.catalogs``, ``Catalog.datasets``, ``Dataset.distributions``,
+        the chain is::
+
+            [("Org", "catalogs"),
+             ("Catalog", "datasets"),
+             ("Dataset", "distributions")]
+
+        Chains are pruned at slots annotated ``openapi.nested: "false"``
+        and skip excluded classes / slots so the index reflects the active
+        profile. Cycles are detected (the recursion tracks visited classes
+        on the current path) so a graph with ``A.bs: list[B]`` and
+        ``B.as: list[A]`` doesn't blow up. Only ancestors that are
+        themselves resource classes contribute — non-resource intermediates
+        have no addressable URL segment to fold in.
+
+        Result is a dict keyed by leaf class name. A class with no parents
+        in the relationship graph is absent from the dict.
+        """
+        sv = self.schemaview
+        resource_classes = set(self._get_resource_classes())
+
+        direct_parents: dict[str, list[tuple[str, str]]] = {}
+        for parent_name in sv.all_classes():
+            if parent_name in self._excluded_classes:
+                continue
+            if parent_name not in resource_classes:
+                continue
+            parent_cls = sv.get_class(parent_name)
+            for slot in sv.class_induced_slots(parent_name):
+                if not slot.multivalued:
+                    continue
+                if self._is_slot_excluded(slot):
+                    continue
+                target = slot.range
+                if not target or sv.get_class(target) is None:
+                    continue
+                if target == parent_name:
+                    continue  # self-loop, no canonical chain
+                nested_ann = self._get_slot_annotation(parent_cls, slot.name, "openapi.nested")
+                if nested_ann is not None and not _is_truthy(nested_ann):
+                    continue
+                direct_parents.setdefault(target, []).append((parent_name, slot.name))
+
+        index: dict[str, list[list[tuple[str, str]]]] = {}
+
+        def walk(leaf: str, on_path: tuple[str, ...]) -> list[list[tuple[str, str]]]:
+            if leaf in index:
+                # Memoised — but we still need to filter chains that would
+                # introduce a cycle from the caller's perspective.
+                return [c for c in index[leaf] if not any(p in on_path for p, _ in c)]
+            chains: list[list[tuple[str, str]]] = []
+            for parent_name, slot_name in direct_parents.get(leaf, []):
+                if parent_name in on_path:
+                    continue  # would close a cycle
+                upper = walk(parent_name, on_path + (parent_name,))
+                if not upper:
+                    chains.append([(parent_name, slot_name)])
+                else:
+                    for u in upper:
+                        chains.append(u + [(parent_name, slot_name)])
+            index[leaf] = chains
+            return chains
+
+        for cls_name in list(direct_parents.keys()):
+            walk(cls_name, ())
+        # Drop classes with no chains so callers can skip via membership check.
+        return {k: v for k, v in index.items() if v}
+
+    @staticmethod
+    def _suffix_operation_ids(paths: dict[str, PathItem], suffix: str) -> None:
+        """Append ``suffix`` to every ``operationId`` in a paths dict.
+
+        Deep nested paths reuse the flat operation builders, which means
+        their ``operationId`` collides with the same class's flat-item
+        operations and with its own single-level nested walk. OpenAPI
+        requires globally unique operation IDs, so we patch the IDs in
+        place after the deep paths are built.
+        """
+        methods = ("get", "put", "post", "delete", "patch", "options", "head", "trace")
+        for path_item in paths.values():
+            for method in methods:
+                op = getattr(path_item, method, None)
+                if op is None:
+                    continue
+                existing = getattr(op, "operationId", None)
+                if existing:
+                    op.operationId = existing + suffix
+
+    @staticmethod
+    def _parent_path_segments(annotation: str) -> list[tuple[str | None, str]]:
+        """Parse an ``openapi.parent_path`` annotation into per-hop matchers.
+
+        Each dot-separated segment is either ``slot_name`` (match the slot
+        at that hop, parent class implied) or ``ClassName.slot_name``
+        (match both the parent class and the slot — used to disambiguate
+        when multiple parents share a slot name).
+
+        Returns a list of ``(class_name_or_none, slot_name)`` tuples,
+        one per hop.
+        """
+        segments: list[tuple[str | None, str]] = []
+        for raw in annotation.strip().split("/"):
+            raw = raw.strip()
+            if not raw:
+                continue
+            if "." in raw:
+                cls_name, slot_name = raw.split(".", 1)
+                segments.append((cls_name.strip() or None, slot_name.strip()))
+            else:
+                segments.append((None, raw))
+        return segments
+
+    def _canonical_parent_chain(self, class_name: str) -> list[tuple[str, str]]:
+        """Pick the canonical chain for ``class_name``.
+
+        * 0 chains → returns ``[]`` (the class is a root, no deep paths).
+        * 1 chain → returns it.
+        * >1 chains → reads ``openapi.parent_path`` on the leaf and matches.
+
+        Annotation syntax: ``/``-separated hops, each hop ``slot_name`` or
+        ``ClassName.slot_name``. Examples::
+
+            openapi.parent_path: catalogs.datasets        # two hops, slot-only (unambiguous)
+            openapi.parent_path: Folder.tags              # one hop, class-qualified
+            openapi.parent_path: Org.catalogs/Catalog.datasets  # two hops, fully qualified
+
+        Raises with the candidate list when the annotation is missing on
+        an ambiguous leaf or doesn't match any chain.
+        """
+        chains = self._parent_chains_index.get(class_name, [])
+        if not chains:
+            return []
+        if len(chains) == 1:
+            return chains[0]
+
+        cls = self.schemaview.get_class(class_name)
+        annotated = self._class_annotation(cls, "openapi.parent_path") if cls else None
+        # Build human-readable candidate strings: prefer slot-only when it's
+        # unique at every hop, fall back to class-qualified otherwise.
+        candidates_qualified = ["/".join(f"{p}.{s}" for p, s in chain) for chain in chains]
+        if annotated:
+            wanted = self._parent_path_segments(annotated)
+            for chain in chains:
+                if len(chain) != len(wanted):
+                    continue
+                if all(
+                    (cls_q is None or cls_q == p) and slot_q == s
+                    for (cls_q, slot_q), (p, s) in zip(wanted, chain)
+                ):
+                    return chain
+            raise ValueError(
+                f"Class {class_name!r} declares "
+                f"`openapi.parent_path: {annotated!r}` but no matching chain "
+                f"exists. Candidates: {candidates_qualified}."
+            )
+        raise ValueError(
+            f"Class {class_name!r} is reachable via multiple parent chains. "
+            f"Pick one with the `openapi.parent_path` class annotation, "
+            f"e.g. `openapi.parent_path: {candidates_qualified[0]!r}`. "
+            f"Candidates: {candidates_qualified}."
+        )
+
+    def _build_chain_path_params(self, chain: list[tuple[str, str]]) -> tuple[str, list[Parameter]]:
+        """Render a chain as a URL prefix and the matching path-parameter list.
+
+        Given ``[(Org, "catalogs"), (Catalog, "datasets")]`` produces::
+
+            ("orgs/{orgId}/catalogs/{catalogId}/datasets",
+             [<Parameter orgId>, <Parameter catalogId>])
+
+        Only the first hop carries the root class's path segment; subsequent
+        hops skip it because the previous iteration's slot name already
+        identifies the next collection (the slot ``Org.catalogs`` *is* the
+        URL noun for catalogs reached through that org). Each parent's
+        identifier variable uses ``_class_path_id_name`` so ``openapi.path_id``
+        overrides flow through.
+        """
+        if not chain:
+            return "", []
+        sv = self.schemaview
+        prefix_parts: list[str] = []
+        params: list[Parameter] = []
+        for i, (parent_name, slot_name) in enumerate(chain):
+            id_slot = self._identifier_slot(parent_name)
+            if id_slot is None:
+                # Should not happen for a class that's a resource, but guard
+                # so a misconfigured schema fails loudly rather than silently.
+                raise ValueError(
+                    f"Parent class {parent_name!r} in a deep nested chain "
+                    "has no identifier slot — can't synthesise its path "
+                    "parameter."
+                )
+            param_name = self._class_path_id_name(parent_name)
+            if i == 0:
+                parent_cls = sv.get_class(parent_name)
+                parent_segment = self._get_path_segment(parent_cls)
+                prefix_parts.append(f"{parent_segment}/{{{param_name}}}/{slot_name}")
+            else:
+                prefix_parts.append(f"{{{param_name}}}/{slot_name}")
+            params.append(
+                Parameter(
+                    name=param_name,
+                    param_in=ParameterLocation.PATH,
+                    required=True,
+                    param_schema=self._slot_to_schema(id_slot),
+                )
+            )
+        return "/".join(prefix_parts), params
 
     def _add_composition_paths(
         self,

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -308,6 +308,60 @@ classes:
         range: Tag2
         multivalued: true
 
+  # --- openapi.flat_only: drops deep emission, keeps flat (issue #36) ---
+  # Note2 has chain [(Folder2, notes)] but `flat_only` suppresses the deep
+  # /folders2/{id}/notes/{id} emission. The single-level nested form from
+  # Folder2 (/folders2/{id}/notes/{note2_id}) still emits — that's about
+  # Folder2 as a parent, not Note2 as a leaf.
+  Folder2:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      notes:
+        range: Note2
+        multivalued: true
+
+  Note2:
+    annotations:
+      openapi.resource: "true"
+      openapi.flat_only: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      body:
+        range: string
+
+  # --- openapi.path_template: literal URL with name:Class.slot sources (issue #36) ---
+  # The auto-derived chain would give /catalogs2/{c2}/.../distributions2/{...},
+  # but ResourceVersion lives at a hand-authored URL with literal segments
+  # ("by-doi") and a compound key (doi + version) the relationship graph
+  # can't express. The template wins; nested_only drops the flat path so
+  # only the templated URL is canonical.
+  ResourceVersion:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: resource_versions
+      openapi.path_template: "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+      openapi.path_param_sources: "cId:Catalog2.id,doi:ResourceVersion.doi,version:ResourceVersion.version"
+      openapi.nested_only: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      doi:
+        range: string
+        required: true
+      version:
+        range: string
+        required: true
+
   Tag2:
     annotations:
       openapi.resource: "true"

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -231,6 +231,95 @@ classes:
   Cat:
     is_a: Animal
 
+  # --- Deep nested item paths via parent chain (issue #32) ---
+  # Three-level chain. `openapi.path_id` on each ancestor renames the URL
+  # parameter from the default `<class>_id` snake form to camelCase, so the
+  # generated paths match DCAT3-shaped conventions:
+  #   /catalogs/{catalogId}
+  #   /catalogs/{catalogId}/datasets/{datasetId}
+  #   /catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}
+  Catalog2:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs2
+      openapi.path_id: catalog2Id
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      datasets:
+        range: Dataset2
+        multivalued: true
+
+  Dataset2:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets2
+      openapi.path_id: dataset2Id
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      distributions:
+        range: Distribution2
+        multivalued: true
+
+  # `openapi.nested_only: "true"` drops the flat `/distributions2` /
+  # `/distributions2/{id}` paths — Distribution2 is canonical only under its
+  # parent chain.
+  Distribution2:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: distributions2
+      openapi.path_id: dist2Id
+      openapi.nested_only: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+
+  # --- Ambiguous parent chain → openapi.parent_path resolves it ---
+  # Tag2 is reachable via Folder.tags AND Bookmark.tags. The leaf declares
+  # the canonical chain so the generator picks one deterministically.
+  Folder:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      tags:
+        range: Tag2
+        multivalued: true
+
+  Bookmark:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      tags:
+        range: Tag2
+        multivalued: true
+
+  Tag2:
+    annotations:
+      openapi.resource: "true"
+      openapi.parent_path: Folder.tags
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      label:
+        range: string
+
   # --- Layered opt-out for auto-inferred query params (issue #34) ---
   # `BigCatalogItem` opts out of auto-inference at the class level so that
   # only `limit` / `offset` emit on its list endpoint, regardless of how

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1123,6 +1123,205 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestDeepNestedPaths:
+    """Coverage for issue #32 — N-level parent chains and override layers."""
+
+    def test_two_level_deep_item_path_emits(self):
+        """Dataset2 chain [(Catalog2, datasets)] → /catalogs2/{catalog2Id}/datasets/{dataset2Id}."""
+        spec = _generate()
+        assert "/catalogs2/{catalog2Id}/datasets/{dataset2Id}" in spec["paths"]
+
+    def test_three_level_deep_item_path_emits(self):
+        """Distribution2 chain [(Catalog2, datasets), (Dataset2, distributions)]."""
+        spec = _generate()
+        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        assert path in spec["paths"]
+
+    def test_three_level_deep_item_has_full_crud(self):
+        """Deep item path carries the leaf's CRUD (Distribution2 declares default ops)."""
+        spec = _generate()
+        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        item = spec["paths"][path]
+        # Default operations include get / put / delete (no patch unless asked).
+        assert "get" in item
+        assert "put" in item
+        assert "delete" in item
+
+    def test_three_level_deep_path_carries_all_ancestor_params(self):
+        """Every ancestor's identifier shows up as a path parameter."""
+        spec = _generate()
+        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        params = spec["paths"][path].get("parameters", [])
+        names = {p["name"] for p in params if p["in"] == "path"}
+        assert {"catalog2Id", "dataset2Id", "dist2Id"} <= names
+
+    def test_path_id_override_renames_url_param(self):
+        """`openapi.path_id: catalog2Id` renames the URL var from `id` to `catalog2Id`."""
+        spec = _generate()
+        # Catalog2's own item path uses the override.
+        assert "/catalogs2/{catalog2Id}" in spec["paths"]
+        # And the same name shows up wherever Catalog2 appears as an ancestor.
+        deep = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}"
+        assert deep in spec["paths"]
+
+    def test_default_path_id_remains_snake_case(self):
+        """Without `openapi.path_id`, single-level nested-item paths keep `<class>_id`."""
+        spec = _generate()
+        # Person.addresses — Person has no path_id override; check the
+        # historic snake-case naming is preserved on the nested item.
+        nested_keys = [p for p in spec["paths"] if p.startswith("/persons/{id}/addresses/")]
+        # `/persons/{id}/addresses/{address_id}` is the historic shape.
+        assert any("address_id" in p for p in nested_keys), (
+            f"expected snake_case ancestor naming preserved, got: {nested_keys}"
+        )
+
+    def test_nested_only_drops_flat_paths(self):
+        """`openapi.nested_only: "true"` suppresses /distributions2 and /distributions2/{id}."""
+        spec = _generate()
+        assert "/distributions2" not in spec["paths"]
+        assert "/distributions2/{dist2Id}" not in spec["paths"]
+        # …but the deep path is still there.
+        assert (
+            "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}" in spec["paths"]
+        )
+
+    def test_leaf_schema_has_no_ancestor_id_fields(self):
+        """Distribution2's schema must not gain catalog2Id / dataset2Id as fields."""
+        spec = _generate()
+        dist = spec["components"]["schemas"]["Distribution2"]
+        props = dist.get("properties", {})
+        for ancestor_id in ("catalog2Id", "dataset2Id", "catalog_id", "dataset_id"):
+            assert ancestor_id not in props, (
+                f"leaf schema unexpectedly carries ancestor URL parameter {ancestor_id!r}"
+            )
+
+    def test_ambiguous_chain_resolved_by_parent_path(self):
+        """Tag2 reachable via Folder.tags AND Bookmark.tags → annotation picks Folder."""
+        spec = _generate()
+        # The annotation is `Folder.tags`, so the deep item path emits under folders.
+        tag_paths = sorted(p for p in spec["paths"] if "tags" in p)
+        assert "/folders/{id}/tags/{id}" in spec["paths"] or any(
+            "/folders/" in p and p.endswith("/tags/{id}") for p in spec["paths"]
+        ), f"expected Folder-shaped deep path; got: {tag_paths}"
+        # And the Bookmark-shaped deep path is NOT emitted (only one canonical chain).
+        bookmark_deep = [
+            p
+            for p in spec["paths"]
+            if p.startswith("/bookmarks/") and "tags" in p and p.endswith("{id}")
+        ]
+        # `/bookmarks/{id}/tags` (collection) and `/bookmarks/{id}/tags/{tag2_id}` (immediate
+        # nested item) are emitted by the parent's nested-paths walk — those exist regardless.
+        # The thing that should NOT exist is a *deep* path treating Bookmark as the leaf's chain.
+        # In this fixture the chain is exactly one hop, so the immediate-nested form IS the deep
+        # form — the assertion just confirms we don't error and the Folder branch wins.
+        del bookmark_deep  # documented; no further assertion needed at this depth.
+
+    def test_ambiguous_chain_without_annotation_raises(self):
+        """An ambiguous leaf without `openapi.parent_path` raises with candidates."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/ambig
+name: ambig
+default_range: string
+classes:
+  Folder3:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      tags:
+        range: Tag3
+        multivalued: true
+  Bookmark3:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      tags:
+        range: Tag3
+        multivalued: true
+  Tag3:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="multiple parent chains"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_parent_path_unmatched_value_raises(self):
+        """When `openapi.parent_path` doesn't match any chain, error lists candidates."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/ambig2
+name: ambig2
+default_range: string
+classes:
+  Folder4:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      tags:
+        range: Tag4
+        multivalued: true
+  Bookmark4:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      tags:
+        range: Tag4
+        multivalued: true
+  Tag4:
+    annotations:
+      openapi.resource: "true"
+      openapi.parent_path: NonExistent.tags
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="no matching chain"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1322,6 +1322,213 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestPathTemplateAndFlatOnly:
+    """Coverage for issue #36 — Layer 4 escape hatch + `openapi.flat_only`."""
+
+    def test_path_template_emits_literal_url(self):
+        """`openapi.path_template` produces exactly that URL — no auto chain."""
+        spec = _generate()
+        path = "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+        assert path in spec["paths"]
+
+    def test_path_template_replaces_auto_chain(self):
+        """When a template is set, no chain-derived deep path emits for the class."""
+        spec = _generate()
+        # ResourceVersion has nested_only + path_template, so neither the
+        # flat /resource_versions nor any auto-chain path should appear.
+        assert "/resource_versions" not in spec["paths"]
+        assert "/resource_versions/{id}" not in spec["paths"]
+        assert not any(
+            p.endswith("/resources") and p != "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+            for p in spec["paths"]
+        )
+
+    def test_path_template_carries_typed_params_from_sources(self):
+        """Each placeholder gets its parameter schema from the `Class.slot` source."""
+        spec = _generate()
+        path = "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+        params = {p["name"]: p for p in spec["paths"][path].get("parameters", [])}
+        for name in ("cId", "doi", "version"):
+            assert name in params, f"missing {name}"
+            assert params[name]["in"] == "path"
+            assert params[name]["required"] is True
+            # All three sources have range string in the fixture.
+            assert params[name]["schema"]["type"] == "string"
+
+    def test_path_template_operation_ids_use_via_template_suffix(self):
+        """Templated deep ops are suffixed `_via_template` to stay globally unique."""
+        spec = _generate()
+        path = "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+        item = spec["paths"][path]
+        # ResourceVersion has default operations (list/create/read/update/delete);
+        # the deep item gets read/update/delete only.
+        for method in ("get", "put", "delete"):
+            assert method in item
+            assert item[method]["operationId"].endswith("_via_template")
+
+    def test_path_template_placeholder_mismatch_raises(self):
+        """Source keys must exactly match template placeholders."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/bad-template
+name: bt
+default_range: string
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/v2/items/{a}/{b}"
+      openapi.path_param_sources: "a:Item.id"
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="don't match"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_path_template_unknown_source_raises(self):
+        """A `Class.slot` source must resolve."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/bad-source
+name: bs
+default_range: string
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/items/{x}"
+      openapi.path_param_sources: "x:Nonexistent.id"
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="unknown class"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_path_template_malformed_source_entry_raises(self):
+        """Source format is `name:Class.slot`; missing pieces raise."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/malformed
+name: m
+default_range: string
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/items/{x}"
+      openapi.path_param_sources: "x:no_dot"
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="malformed source"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_flat_only_drops_chain_derived_deep_path(self):
+        """`openapi.flat_only` suppresses the deep chain emission for the class."""
+        spec = _generate()
+        # Note2 chain is [(Folder2, notes)]; without flat_only it would
+        # emit /folder2s/{folder2_id}/notes/{id}. With flat_only, that
+        # specific deep emission is dropped.
+        chain_deep = [
+            p for p in spec["paths"] if p.startswith("/folder2s/{") and p.endswith("/notes/{id}")
+        ]
+        assert chain_deep == []
+
+    def test_flat_only_keeps_flat_collection_and_item(self):
+        """`openapi.flat_only` keeps the leaf's own flat surface."""
+        spec = _generate()
+        assert "/note2s" in spec["paths"]
+        assert "/note2s/{id}" in spec["paths"]
+
+    def test_flat_only_does_not_touch_parent_nested_paths(self):
+        """Single-level nested paths from the parent still emit — they're
+        about the parent's slot, not the child's chain."""
+        spec = _generate()
+        # Folder2.notes still produces /folder2s/{id}/notes (collection)
+        # and /folder2s/{id}/notes/{note2_id} (parent-driven nested item).
+        assert "/folder2s/{id}/notes" in spec["paths"]
+        assert "/folder2s/{id}/notes/{note2_id}" in spec["paths"]
+
+    def test_flat_only_and_nested_only_together_raise(self):
+        """Setting both is a generation error — they're mutually exclusive."""
+        import tempfile
+        from pathlib import Path
+
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/mutex
+name: mu
+default_range: string
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.flat_only: "true"
+      openapi.nested_only: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                gen.serialize(format="yaml")
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 


### PR DESCRIPTION
Closes #32. Closes #36.

## Summary

Lands the **complete** layered-override design for nested item paths in one PR — both the auto-derived chain work from #32 and the Layer 4 escape hatch + `openapi.flat_only` from #36.

* **N-level chain walk** — reverse-walks the relationship graph with cycle detection, pre-computed once per build.
* **Deep item path** under each canonical chain. Ancestor IDs become URL parameters sourced from the relationship graph, never fields on the leaf component schema.
* **Six new layered overrides** covering everything from cosmetic naming to hand-authored URL templates:

| Annotation | Level | Purpose |
|---|---|---|
| `openapi.path_id` | class | Renames the URL parameter for a class everywhere it appears (its own item, single-level nested, and any chain ancestor). |
| `openapi.parent_path` | class | Picks the canonical chain when a leaf is reachable via multiple ancestor chains. Format: `/`-separated hops, each `slot` or `Class.slot`. |
| `openapi.nested_only` | class | Drops the flat collection / item paths. The deep URL is the only canonical surface. |
| `openapi.flat_only` | class | Drops the deep nested item path. Flat collection / item only. Mutually exclusive with `nested_only`. |
| `openapi.path_template` | class | **Layer 4 escape hatch.** Literal URL template that replaces the auto-derived chain. For legacy contracts, compound keys, literal segments. |
| `openapi.path_param_sources` | class | `name:Class.slot` map binding each `{name}` placeholder in the template to a typed source slot. |

Operation IDs on deep paths are suffixed `_via_<chain>` (or `_via_template` for Layer 4) so they remain globally unique.

## Worked examples

### Auto-derived chain (Layers 1–3)

```yaml
classes:
  Catalog:
    annotations:
      openapi.resource: "true"
      openapi.path_id: catalogId
    attributes:
      id: { identifier: true, required: true }
      datasets: { range: Dataset, multivalued: true }

  Dataset:
    annotations:
      openapi.resource: "true"
      openapi.path_id: datasetId
    attributes:
      id: { identifier: true, required: true }
      distributions: { range: Distribution, multivalued: true }

  Distribution:
    annotations:
      openapi.resource: "true"
      openapi.path_id: distId
      openapi.nested_only: "true"
```

→
```
/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distId}
# /distributions and /distributions/{distId} not emitted (nested_only)
```

### Layer 4 escape hatch

```yaml
classes:
  ResourceVersion:
    annotations:
      openapi.resource: "true"
      openapi.path_template: "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
      openapi.path_param_sources: "cId:Catalog.id,doi:ResourceVersion.doi,version:ResourceVersion.version"
      openapi.nested_only: "true"
```

→
```
/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}
```

Each parameter is typed from its source slot's range; the leaf schema carries only its own slots.

### `openapi.flat_only`

```yaml
classes:
  Tag:
    annotations:
      openapi.resource: "true"
      openapi.flat_only: "true"
```

→ `/tags`, `/tags/{id}`, plus parent-driven `/folders/{id}/tags/{tag_id}` (single-level), but **no** `/folders/{folder_id}/tags/{id}` (deep chain emission suppressed).

## Existing schema impact

* No drift on `bookstore`, `petstore`, or `minimal` — all schemas without the new annotations regenerate byte-identically.
* The only new paths in committed examples are the deep item paths under existing nested collections (`/books/{book_id}/authors/{id}`, `/owners/{owner_id}/pets/{id}`).
* Leaf component schemas are unchanged. Ancestor identifiers come from the URL, not from foreign-key fields.

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 153 / 153 pass (22 new across `TestDeepNestedPaths` and `TestPathTemplateAndFlatOnly`)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — only the intended deep-item additions
- [x] e2e `openapi-spec-validator` for all examples + fixture — pass
- [x] Tests cover: 2-level chain, 3-level chain, full CRUD on deep item, ancestor params on deep path, `openapi.path_id` rename, snake-case fallback when override absent, `openapi.nested_only` suppresses flat, leaf schema has no ancestor-ID fields, ambiguous chain resolved via `openapi.parent_path`, ambiguous-without-annotation raises, mismatched annotation raises with candidates listed, `openapi.path_template` emits literal URL, sources mismatch / unknown class / malformed entry raise, `openapi.flat_only` drops chain-derived deep path, parent-driven nested still emits under flat_only, `flat_only` + `nested_only` mutex error.

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA