### PR TITLE
feat(query-params): layered opt-out for auto-inferred filters (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## Unreleased
+
+### Added
+
+- **Layered opt-out for auto-inferred query parameters**
+  ([#34](https://github.com/jackhiggs/linkml-openapi/issues/34)). Lean
+  classes still get one auto-inferred query parameter per scalar slot;
+  catalog-shaped classes with 30+ slots can now suppress the bloat with
+  one annotation:
+
+  - **Schema-level** ``openapi.auto_query_params: "false"`` flips the
+    default for the whole spec.
+  - **Class-level** ``openapi.auto_query_params: "false" | "true"``
+    overrides the schema-level setting per class (so a single noisy
+    class can opt out, or — when the schema-level default is off — a
+    single class can opt back in).
+  - **Slot-level** ``openapi.query_param: "false"`` excludes one slot
+    from auto-inference even when auto is enabled.
+
+  Default remains ``"true"``, so schemas without any of the new
+  annotations regenerate byte-identically. ``limit`` / ``offset``
+  always emit on list endpoints regardless of the setting.
+
 ## [0.4.0] — 2026-04-27
 
 Dependency-surface release: cuts the install tree down to `linkml-runtime`

--- a/README.md
+++ b/README.md
@@ -695,8 +695,63 @@ auto-infers equality-only query parameters from all non-multivalued,
 non-identifier slots with `string`, `integer`, `boolean`, or enum
 ranges (backwards compatible).
 
+For catalog-shaped classes with 30+ slots, that auto-inference produces
+unusably noisy list endpoints. Three layered annotations let you turn
+it off at whichever level matches your intent.
+
+##### `openapi.auto_query_params` — schema or class level
+
+Defaults to `"true"`. Set to `"false"` to suppress the auto-inference
+entirely; only `limit`, `offset`, and explicitly annotated slots emit
+as query parameters.
+
+```yaml
+# Schema-level: every class in the spec opts out of auto-inference.
+annotations:
+  openapi.auto_query_params: "false"
+
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"          # → /datasets?limit=&offset= only
+    slot_usage:
+      title:
+        annotations: { openapi.query_param: equality }
+      created:
+        annotations: { openapi.query_param: comparable,sortable }
+```
+
+Class-level wins over schema-level, so a single class can opt back in
+when the schema-level default is off:
+
+```yaml
+annotations:
+  openapi.auto_query_params: "false"
+
+classes:
+  Tag:
+    annotations:
+      openapi.resource: "true"
+      openapi.auto_query_params: "true"   # this class keeps auto-inference
+```
+
+##### `openapi.query_param: "false"` — slot level
+
+Removes one slot from auto-inference even when auto is enabled — for
+oversized strings, free-text descriptions, or fields you never want
+to filter on:
+
+```yaml
+classes:
+  Article:
+    slot_usage:
+      raw_blob:
+        annotations:
+          openapi.query_param: "false"   # excluded from /articles?... params
+```
+
 `limit` and `offset` pagination parameters are always included on list
-endpoints regardless of annotations.
+endpoints regardless of any of these annotations.
 
 ### Annotation summary
 
@@ -706,8 +761,9 @@ endpoints regardless of annotations.
 | `openapi.path` | class | path segment string | Auto-pluralized snake_case of class name |
 | `openapi.operations` | class | comma-separated list | `list,create,read,update,delete` |
 | `openapi.media_types` | class | comma-separated list | `application/json` |
+| `openapi.auto_query_params` | schema or class | `"true"` / `"false"` | `"true"` (auto-infer scalar slots) |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
-| `openapi.query_param` | slot (via `slot_usage`) | `"true"` | Auto-inferred from slot type |
+| `openapi.query_param` | slot (via `slot_usage`) | `"true"` / token list / `"false"` | Auto-inferred from slot type |
 | `openapi.format` | slot | format string | derived from slot range |
 
 ## Type Mapping

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1697,12 +1697,32 @@ class OpenAPIGenerator(Generator):
         valid = tokens & self._QUERY_PARAM_TOKENS
         return valid or None
 
+    def _auto_query_params_enabled(self, cls: ClassDefinition) -> bool:
+        """Whether auto-inferred query parameters are emitted for this class.
+
+        Class-level ``openapi.auto_query_params`` wins over the schema-level
+        annotation; default is ``True`` so existing schemas keep their
+        current behaviour. Set to ``"false"`` at either level to suppress
+        the auto-inferred filter parameters on a class with many slots.
+        """
+        class_value = self._class_annotation(cls, "openapi.auto_query_params")
+        if class_value is not None:
+            return _is_truthy(class_value)
+        schema_value = self._schema_annotation("openapi.auto_query_params")
+        if schema_value is not None:
+            return _is_truthy(schema_value)
+        return True
+
     def _make_query_params(self, cls: ClassDefinition) -> list[Parameter]:
         """Generate query parameters for the list endpoint.
 
         Annotated slots win when any are present on the class; otherwise
-        the legacy auto-inference picks scalar non-identifier slots. Both
-        paths walk induced slots once.
+        the auto-inference path picks scalar non-identifier slots — unless
+        ``openapi.auto_query_params: "false"`` is set at the class or
+        schema level, in which case only ``limit`` / ``offset`` emit.
+        Slots annotated ``openapi.query_param: "false"`` are excluded from
+        auto-inference even when it is enabled. Both paths walk induced
+        slots once.
         """
         sv = self.schemaview
         params: list[Parameter] = [
@@ -1718,6 +1738,8 @@ class OpenAPIGenerator(Generator):
             ),
         ]
 
+        auto_enabled = self._auto_query_params_enabled(cls)
+
         annotated_params: list[Parameter] = []
         inferred_params: list[Parameter] = []
         sort_tokens: list[str] = []
@@ -1728,6 +1750,15 @@ class OpenAPIGenerator(Generator):
             caps = self._query_param_capabilities(cls, slot.name)
             if caps is not None:
                 self._add_annotated_query_params(cls, slot, caps, annotated_params, sort_tokens)
+                continue
+            if not auto_enabled:
+                continue
+            # Slot-level explicit opt-out: `openapi.query_param: "false"`
+            # makes ``_query_param_capabilities`` return ``None``, but the
+            # raw annotation tells us the user explicitly removed this slot
+            # from auto-inference (vs. being silent about it).
+            raw = self._get_slot_annotation(cls, slot.name, "openapi.query_param")
+            if raw is not None and set(_parse_csv(raw, lowercase=True)) == {"false"}:
                 continue
             if (
                 not slot.multivalued

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -231,6 +231,52 @@ classes:
   Cat:
     is_a: Animal
 
+  # --- Layered opt-out for auto-inferred query params (issue #34) ---
+  # `BigCatalogItem` opts out of auto-inference at the class level so that
+  # only `limit` / `offset` emit on its list endpoint, regardless of how
+  # many scalar slots it carries. `RegularItem` keeps the default and the
+  # `secret_field` slot opts out per-slot.
+  BigCatalogItem:
+    description: A class with many slots that don't all make sense as filters.
+    annotations:
+      openapi.resource: "true"
+      openapi.auto_query_params: "false"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      title:
+        range: string
+      description:
+        range: string
+      created:
+        range: datetime
+      updated:
+        range: datetime
+      ten:
+        range: integer
+      eleven:
+        range: integer
+      twelve:
+        range: integer
+
+  RegularItem:
+    description: A class that keeps default auto-inference but opts out of one slot.
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      title:
+        range: string
+      secret_field:
+        range: string
+        annotations:
+          openapi.query_param: "false"
+
 enums:
   PersonStatus:
     description: Status of a person

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -506,6 +506,160 @@ class TestPathVariableMode:
         assert id_param["schema"]["type"] == "string"
 
 
+class TestAutoQueryParamsOptOut:
+    """Coverage for issue #34 — layered opt-out for auto-inferred query params."""
+
+    def test_class_level_disables_auto_inference(self):
+        """`openapi.auto_query_params: "false"` on the class drops every auto-inferred filter."""
+        spec = _generate()
+        params = spec["paths"]["/big_catalog_items"]["get"]["parameters"]
+        names = [p["name"] for p in params]
+        # Only pagination remains.
+        assert names == ["limit", "offset"]
+
+    def test_slot_level_false_excludes_one_slot_from_auto_inference(self):
+        """`openapi.query_param: "false"` on a slot opts that slot out of auto-inference."""
+        spec = _generate()
+        names = {p["name"] for p in spec["paths"]["/regular_items"]["get"]["parameters"]}
+        # `title` remains auto-inferred; `secret_field` was annotated false.
+        assert "title" in names
+        assert "secret_field" not in names
+        # And pagination still emits.
+        assert {"limit", "offset"} <= names
+
+    def test_default_behaviour_unchanged_when_no_annotations(self):
+        """Without any new annotation, query params are auto-inferred as before."""
+        spec = _generate(resource_filter=["Organization"])
+        names = {p["name"] for p in spec["paths"]["/organizations"]["get"]["parameters"]}
+        # Inherited slots from NamedThing — both auto-inferred (default true).
+        assert {"name", "description"} <= names
+
+    def test_schema_level_disables_auto_inference(self):
+        """`openapi.auto_query_params: "false"` at schema level suppresses every class's auto."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/schema-off
+name: schema_off
+default_range: string
+annotations:
+  openapi.auto_query_params: "false"
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      title:
+        range: string
+      colour:
+        range: string
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            spec = yaml.safe_load(gen.serialize(format="yaml"))
+            names = [p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]]
+            assert names == ["limit", "offset"]
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_class_level_overrides_schema_level(self):
+        """When the schema-level default is off, class-level "true" re-enables for one class."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/schema-mixed
+name: schema_mixed
+default_range: string
+annotations:
+  openapi.auto_query_params: "false"
+classes:
+  Quiet:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      title:
+        range: string
+  Loud:
+    annotations:
+      openapi.resource: "true"
+      openapi.auto_query_params: "true"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      title:
+        range: string
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            spec = yaml.safe_load(gen.serialize(format="yaml"))
+            quiet = {p["name"] for p in spec["paths"]["/quiets"]["get"]["parameters"]}
+            loud = {p["name"] for p in spec["paths"]["/louds"]["get"]["parameters"]}
+            assert quiet == {"limit", "offset"}
+            assert loud == {"limit", "offset", "title"}
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_explicitly_annotated_slots_still_emit_when_auto_off(self):
+        """Auto off doesn't suppress slots that have a truthy `openapi.query_param`."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/schema-mixed-slots
+name: schema_mixed_slots
+default_range: string
+classes:
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.auto_query_params: "false"
+    attributes:
+      id:
+        identifier: true
+        required: true
+      title:
+        range: string
+        annotations:
+          openapi.query_param: "true"
+      ignored:
+        range: string
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            gen = OpenAPIGenerator(tmp)
+            spec = yaml.safe_load(gen.serialize(format="yaml"))
+            names = {p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]}
+            # Annotated slot still emits; the un-annotated one does not.
+            assert "title" in names
+            assert "ignored" not in names
+            assert {"limit", "offset"} <= names
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestFormatAnnotation:
     def test_int64_overrides_default_integer(self):
         spec = _generate()


### PR DESCRIPTION
Closes #34.

## Summary

Add three layered opt-outs for the auto-inferred query parameters that today turn `GET /<collection>` into a 30+ parameter wall on catalog-shaped classes:

* **Schema-level** `openapi.auto_query_params: "false"` flips the default for the whole spec.
* **Class-level** `openapi.auto_query_params: "true" | "false"` overrides the schema-level setting per class. A single noisy class can opt out, or (when the schema-level default is off) a single class can opt back in.
* **Slot-level** `openapi.query_param: "false"` excludes one slot from auto-inference even when auto is enabled.

Default remains `"true"`. Resolution order: class > schema > `"true"`. `limit` / `offset` always emit. Explicitly annotated slots (`openapi.query_param: "true"` / token list) still emit even when auto is off.

## Worked example

```yaml
annotations:
  openapi.auto_query_params: "false"          # schema-level default off

classes:
  Dataset:
    annotations:
      openapi.resource: "true"                # /datasets?limit=&offset= only
    slot_usage:
      title:
        annotations: { openapi.query_param: equality }       # ← only filter
      created:
        annotations: { openapi.query_param: comparable,sortable }

  Tag:
    annotations:
      openapi.resource: "true"
      openapi.auto_query_params: "true"       # this class keeps auto-inference
```

## What stays the same

* Default behaviour. Existing schemas regenerate byte-identically — confirmed against `bookstore`, `petstore`, and `minimal`.
* The whitelist behaviour: when any slot has a truthy `openapi.query_param`, only those slots filter (no auto-inference for that class).
* `limit` / `offset` on every list endpoint.
* Profile drift detection still triggers when an excluded slot was annotated `openapi.query_param: "true"`.

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 137 / 137 pass (6 new in `TestAutoQueryParamsOptOut`)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — no diff
- [x] Tests cover: class-level off, slot-level false, default unchanged when no annotations, schema-level off, class re-enable over schema-level off, annotated slots still emit when auto off

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_