### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## Unreleased
+## [0.5.0] — 2026-04-28
+
+URL-shape and query-surface release: lets a single LinkML schema express
+the canonical URL hierarchies that catalog APIs (DCAT3, FHIR, etc.)
+expect, while giving lean control over which slots become list-endpoint
+filters. All additive — schemas without the new annotations regenerate
+byte-identically.
 
 ### Added
 
@@ -223,6 +229,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.5.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.5.0
 [0.4.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.4.0
 [0.3.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.3.0
 [0.2.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.4.0"
+version = "0.5.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

Cuts v0.5.0. Two feature changesets land since v0.4.0, both additive:

* **PR #35 (#34)** — layered opt-out for auto-inferred query parameters. Schema-level / class-level `openapi.auto_query_params: "false"` flips the default; slot-level `openapi.query_param: "false"` excludes one slot from auto-inference.
* **PR #33 (#32 + #36)** — N-level deep nested item paths via parent-chain walk, plus the full layered override surface: `openapi.path_id`, `openapi.parent_path`, `openapi.nested_only`, `openapi.flat_only`, and the `openapi.path_template` / `openapi.path_param_sources` Layer 4 escape hatch.

Bumps:
* `pyproject.toml`: `0.4.0` → `0.5.0`
* `src/linkml_openapi/__init__.py`: `__version__ = "0.5.0"`
* `CHANGELOG.md`: promote the `Unreleased` block under a `[0.5.0] — 2026-04-28` heading with a one-paragraph release summary; add the v0.5.0 anchor.

## Why a minor bump (not 0.4.1)

* Both feature changesets are **additive** (existing schemas regenerate byte-identically against bookstore, petstore, minimal), but they expose six new annotations + one new schema-level annotation — material new surface, not a patch.
* The CHANGELOG header notes pre-1.0 minor bumps may carry visible behaviour changes; this stays well within that envelope.
* Examples gain new paths (`/books/{book_id}/authors/{id}`, `/owners/{owner_id}/pets/{id}`) — observable to anyone diffing committed specs.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/ -m "not e2e"` — 159 / 159 pass
- [x] `gen-openapi --version` reports `0.5.0`
- [ ] Merge → cut `v0.5.0` GitHub release → publish workflow uploads to PyPI

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_