### PR TITLE
feat(path-style): kebab-case URL paths + per-slot path_segment (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## Unreleased
+
+### Added
+
+- **Kebab-case URL paths**
+  ([#38](https://github.com/jackhiggs/linkml-openapi/issues/38)).
+  LinkML slot names must be valid identifiers (snake_case), but most
+  REST APIs render URL segments in kebab-case. Two new annotations
+  bridge the gap without changing slot identifiers in the OpenAPI body:
+
+  - **Schema-level / CLI** ``openapi.path_style: "kebab-case"`` (or
+    ``--path-style kebab-case``) flips the convention for every
+    auto-derived URL segment in the spec — both class- and
+    slot-driven, including chain-prefix segments inside deep paths.
+    Default ``"snake_case"``.
+  - **Slot-level** ``openapi.path_segment: "<segment>"`` overrides the
+    rendered URL segment for one slot, taken verbatim regardless of
+    the active style. Useful for literal segments like ``data.services``
+    or legacy URL contracts.
+
+  Slot identifiers in the OpenAPI body, operation IDs, tags, JSON
+  property keys, ``x-rdf-property`` URIs, and path-template literals
+  are unaffected — only URL path segments change. Default behaviour
+  unchanged: schemas without the new annotations regenerate
+  byte-identically.
+
 ## [0.5.0] — 2026-04-28
 
 URL-shape and query-surface release: lets a single LinkML schema express

--- a/README.md
+++ b/README.md
@@ -163,6 +163,37 @@ a clear error.
 To opt out entirely (today's body-less responses), pass
 `--no-error-schema` on the CLI or `error_schema=False` to the Python API.
 
+#### `openapi.path_style`
+
+URL path-segment convention for the whole spec. Default `snake_case`
+(byte-identical to today). Set to `kebab-case` to render every
+auto-derived class- and slot-driven URL segment with `-` instead of
+`_` — the canonical shape for most public REST APIs.
+
+```yaml
+annotations:
+  openapi.path_style: kebab-case
+```
+
+Applies to:
+
+* Auto-derived class path segments (`DataService` → `data-services`)
+* Slot-driven nested segments (`/catalogs/{id}/data-services`)
+* Chain-prefix slot segments inside deep paths
+  (`/orgs/{orgId}/catalogs/{catalogId}/data-services/{distId}`)
+
+Does **not** apply to:
+
+* Slot identifiers in the OpenAPI body (JSON property keys stay snake)
+* Operation IDs, tags
+* `x-rdf-property` URIs
+* `openapi.path` overrides on a class (taken verbatim)
+* `openapi.path_segment` overrides on a slot (taken verbatim)
+* `openapi.path_template` URLs (taken verbatim)
+
+The Python API and CLI both expose a `path_style` / `--path-style`
+override that wins over the schema annotation.
+
 ### Class-level annotations
 
 Annotations are placed in the `annotations` block of a class definition.
@@ -765,6 +796,27 @@ schema, not the array itself (which has no `format` in OpenAPI).
 The annotation accepts any string; no allow-list is enforced, so vendor
 formats pass through unchanged.
 
+#### `openapi.path_segment`
+
+Per-slot override of the rendered URL segment. Taken verbatim — the
+schema-level `openapi.path_style` doesn't touch a slot that already
+declares its segment explicitly. Useful for literal acronyms, dotted
+segments, or one-off divergences from the global convention.
+
+```yaml
+classes:
+  Hub:
+    slot_usage:
+      web_resources:
+        annotations:
+          openapi.path_segment: "web-resources"
+```
+
+emits `/hubs/{id}/web-resources` while the slot identifier in the
+component schema, operation IDs, query parameters, and
+`x-rdf-property` extensions all keep using `web_resources`. Pair it
+with `openapi.path` on a class for fully-controlled URL shapes.
+
 #### `openapi.path_variable`
 
 Marks a slot as a path variable in the item endpoint URL.
@@ -929,6 +981,7 @@ endpoints regardless of any of these annotations.
 | `openapi.path` | class | path segment string | Auto-pluralized snake_case of class name |
 | `openapi.operations` | class | comma-separated list | `list,create,read,update,delete` |
 | `openapi.media_types` | class | comma-separated list | `application/json` |
+| `openapi.path_style` | schema | `snake_case` / `kebab-case` | `snake_case` |
 | `openapi.auto_query_params` | schema or class | `"true"` / `"false"` | `"true"` (auto-infer scalar slots) |
 | `openapi.path_id` | class | identifier name | `<class_snake>_id` (e.g. `catalog_id`) |
 | `openapi.parent_path` | class | `Class.slot/Class.slot/...` | Auto-derive when chain is unambiguous |
@@ -937,6 +990,7 @@ endpoints regardless of any of these annotations.
 | `openapi.path_template` | class | URL template with `{name}` placeholders | Auto-derived chain |
 | `openapi.path_param_sources` | class | comma-separated `name:Class.slot` entries | (required when `path_template` is set) |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
+| `openapi.path_segment` | slot (via `slot_usage`) | URL segment string | Slot name with active path-style applied |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` / token list / `"false"` | Auto-inferred from slot type |
 | `openapi.format` | slot | format string | derived from slot range |
 

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -66,6 +66,19 @@ from linkml_openapi.generator import OpenAPIGenerator
         "surfaces (internal, partner, external) from one LinkML schema."
     ),
 )
+@click.option(
+    "--path-style",
+    type=click.Choice(["snake_case", "kebab-case"]),
+    default=None,
+    help=(
+        "URL path-segment convention. Defaults to the schema-level "
+        "`openapi.path_style` annotation, or `snake_case` if neither is set "
+        "(byte-identical to today). `kebab-case` renders auto-derived "
+        "class- and slot-driven URL segments with `-` instead of `_`. Slot "
+        "identifiers in the OpenAPI body, operation IDs, and RDF extensions "
+        "are unaffected."
+    ),
+)
 @click.version_option(__version__, "-V", "--version")
 def cli(yamlfile, resource_filter=(), **kwargs):
     """Generate an OpenAPI specification from a LinkML schema."""

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -169,6 +169,13 @@ class OpenAPIGenerator(Generator):
     # profile lets a single LinkML schema drive multiple API surfaces
     # (internal / partner / external) by excluding classes or slots.
     profile: str | None = None
+    # URL path-segment convention. None falls back to the schema-level
+    # `openapi.path_style` annotation (default `"snake_case"`). Set to
+    # `"kebab-case"` here or in the schema to render slot- and
+    # class-derived path segments with `-` instead of `_`. Slot
+    # identifiers in the OpenAPI body, operation IDs, tags, and RDF
+    # extensions are unaffected — only the URL segment changes.
+    path_style: str | None = None
 
     def serialize(self, **kwargs) -> str:
         """Generate and serialize the OpenAPI spec."""
@@ -179,6 +186,11 @@ class OpenAPIGenerator(Generator):
         # None when error_schema is off. Cached per-build so each operation
         # builder doesn't re-resolve.
         self._error_class_name: str | None = self._resolve_error_class()
+        # Resolve the active path-style: CLI / Python kwarg wins over the
+        # schema-level annotation, which falls back to `"snake_case"`. We
+        # validate once here so per-call-site renderers can just check the
+        # cached value without re-parsing.
+        self._effective_path_style = self._resolve_path_style()
         # Resolve the active profile (or no-op when self.profile is None).
         # `_resolve_profile_filter` also runs drift detection — failing
         # loudly if an excluded slot is referenced by another annotation.
@@ -717,8 +729,71 @@ class OpenAPIGenerator(Generator):
         fallback = identifier_slot or id_named_slot
         return [(fallback, "iri")] if fallback else []
 
+    _SUPPORTED_PATH_STYLES: ClassVar[frozenset[str]] = frozenset({"snake_case", "kebab-case"})
+
+    def _resolve_path_style(self) -> str:
+        """Pick the effective URL path-segment convention for this build.
+
+        Resolution order: CLI / Python `path_style` kwarg, then the
+        schema-level `openapi.path_style` annotation, then the
+        backward-compatible default `"snake_case"`. Unknown values raise
+        with the supported list.
+        """
+        candidate = self.path_style
+        if candidate is None:
+            candidate = self._schema_annotation("openapi.path_style")
+        if candidate is None:
+            return "snake_case"
+        normalised = str(candidate).strip().lower()
+        if normalised not in self._SUPPORTED_PATH_STYLES:
+            raise ValueError(
+                f"Unsupported `openapi.path_style` {candidate!r}; "
+                f"expected one of {sorted(self._SUPPORTED_PATH_STYLES)!r}."
+            )
+        return normalised
+
+    def _apply_path_style(self, name: str) -> str:
+        """Apply the active path-style to an auto-derived URL segment.
+
+        ``snake_case`` returns the name unchanged (current behaviour);
+        ``kebab-case`` swaps every ``_`` for ``-``. Only operates on
+        segments derived from snake_case identifiers (slot names,
+        pluralised class names) — explicit overrides like
+        ``openapi.path`` and ``openapi.path_segment`` are taken verbatim
+        and never re-styled.
+
+        Falls back to ``"snake_case"`` when called before a full
+        ``serialize()`` build has cached the resolved style — keeps
+        helper methods safely callable from tests and ad-hoc scripts.
+        """
+        if getattr(self, "_effective_path_style", "snake_case") == "kebab-case":
+            return name.replace("_", "-")
+        return name
+
+    def _render_slot_segment(self, parent_cls: ClassDefinition | None, slot: SlotDefinition) -> str:
+        """Render the URL segment for a slot used in a nested path.
+
+        Honours the slot's `openapi.path_segment` annotation (verbatim)
+        when set; otherwise applies the active path-style to the slot
+        name. The slot identifier in the OpenAPI body, operation IDs,
+        tags, and `x-rdf-property` extensions are untouched — only the
+        URL segment changes.
+        """
+        if parent_cls is not None:
+            override = self._get_slot_annotation(parent_cls, slot.name, "openapi.path_segment")
+            if override:
+                return override.strip()
+        return self._apply_path_style(slot.name)
+
     def _get_path_segment(self, cls: ClassDefinition) -> str:
-        """Get the URL path segment for a class."""
+        """Get the URL path segment for a class.
+
+        `openapi.path` is the explicit override (taken verbatim); when
+        absent, the auto-derived snake-pluralised form is run through
+        the active path-style so a schema-level
+        ``openapi.path_style: "kebab-case"`` flips every auto-derived
+        class segment in one place.
+        """
         explicit = self._class_annotation(cls, "openapi.path")
         if explicit is not None:
             return explicit.lstrip("/")
@@ -731,7 +806,7 @@ class OpenAPIGenerator(Generator):
                 "`openapi.path:` on the class to fix the URL.",
                 stacklevel=2,
             )
-        return _to_path_segment(cls.name)
+        return self._apply_path_style(_to_path_segment(cls.name))
 
     def _get_operations(self, cls: ClassDefinition) -> list[str]:
         """Get the list of CRUD operations for a class."""
@@ -1518,7 +1593,7 @@ class OpenAPIGenerator(Generator):
             if nested_ann is not None and not _is_truthy(nested_ann):
                 continue
 
-            collection_path = f"/{url_prefix}/{slot.name}"
+            collection_path = f"/{url_prefix}/{self._render_slot_segment(parent_cls, slot)}"
             target_id_slot = self._identifier_slot(target_name)
 
             if self._is_composition(slot):
@@ -1548,7 +1623,10 @@ class OpenAPIGenerator(Generator):
         # reference-shaped (composition can't be inverted: a composed
         # child has no independent identity to put on the wire).
         for synth_name, source_class in self._synthetic_inverses_for(parent_class_name):
-            collection_path = f"/{url_prefix}/{synth_name}"
+            # Synthetic inverses have no real slot to look up an
+            # `openapi.path_segment` annotation on, so we just apply the
+            # active path-style to the synthesised name.
+            collection_path = f"/{url_prefix}/{self._apply_path_style(synth_name)}"
             target_id_slot = self._identifier_slot(source_class)
             fake_slot = SlotDefinition(name=synth_name, range=source_class, multivalued=True)
             self._needs_resource_link = True
@@ -1811,12 +1889,21 @@ class OpenAPIGenerator(Generator):
                     "parameter."
                 )
             param_name = self._class_path_id_name(parent_name)
+            parent_cls = sv.get_class(parent_name)
+            slot_def = next(
+                (s for s in sv.class_induced_slots(parent_name) if s.name == slot_name),
+                None,
+            )
+            slot_segment = (
+                self._render_slot_segment(parent_cls, slot_def)
+                if slot_def is not None
+                else self._apply_path_style(slot_name)
+            )
             if i == 0:
-                parent_cls = sv.get_class(parent_name)
                 parent_segment = self._get_path_segment(parent_cls)
-                prefix_parts.append(f"{parent_segment}/{{{param_name}}}/{slot_name}")
+                prefix_parts.append(f"{parent_segment}/{{{param_name}}}/{slot_segment}")
             else:
-                prefix_parts.append(f"{{{param_name}}}/{slot_name}")
+                prefix_parts.append(f"{{{param_name}}}/{slot_segment}")
             params.append(
                 Parameter(
                     name=param_name,

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -404,6 +404,36 @@ classes:
       twelve:
         range: integer
 
+  # --- Per-slot URL segment override (issue #38) ---
+  # `web_resources` is a snake_case slot identifier (LinkML grammar), but the
+  # public URL renders the segment as `web-resources` via the slot-level
+  # `openapi.path_segment` annotation. The body schema, operation IDs, and
+  # tags continue to use the underscore form.
+  Hub:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      web_resources:
+        range: WebResource
+        multivalued: true
+    slot_usage:
+      web_resources:
+        annotations:
+          openapi.path_segment: "web-resources"
+
+  WebResource:
+    annotations:
+      openapi.resource: "true"
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+
   RegularItem:
     description: A class that keeps default auto-inference but opts out of one slot.
     annotations:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1529,6 +1529,188 @@ classes:
             Path(tmp).unlink(missing_ok=True)
 
 
+class TestPathStyle:
+    """Coverage for issue #38 — kebab-case URL paths and per-slot path_segment."""
+
+    def test_default_path_style_is_snake_case(self):
+        """No annotation, no kwarg → underscores preserved (current behaviour)."""
+        spec = _generate()
+        # /persons/{id}/addresses uses default style; that single-word slot
+        # has no underscores so we verify on a multi-word case below.
+        # The Person.knows nested path is suppressed (openapi.nested:false),
+        # so we cross-check via a class-level path with underscore-bearing
+        # auto-derived plural.
+        assert "/big_catalog_items" in spec["paths"]
+        assert "/regular_items" in spec["paths"]
+
+    def test_slot_path_segment_override_takes_verbatim(self):
+        """`openapi.path_segment` on a slot wins regardless of path style."""
+        spec = _generate()
+        # Hub.web_resources has openapi.path_segment: "web-resources".
+        assert "/hubs/{id}/web-resources" in spec["paths"]
+        # And the slot identifier in the schema body stays snake_case.
+        hub_props = spec["components"]["schemas"]["Hub"]["properties"]
+        assert "web_resources" in hub_props
+        assert "web-resources" not in hub_props
+
+    def test_slot_path_segment_override_in_chain_too(self):
+        """The override flows through to deep-chain emission via the leaf's chain."""
+        spec = _generate()
+        # WebResource has chain [(Hub, "web_resources")]; the chain prefix
+        # uses the slot's path_segment override.
+        deep = [p for p in spec["paths"] if "web-resources" in p and "{id}" in p]
+        assert any(p.startswith("/hubs/{hub_id}/web-resources/") for p in deep), (
+            f"expected chain-deep web-resources path; got: {deep}"
+        )
+
+    def test_kebab_case_kwarg_renders_class_segments_with_dashes(self):
+        """Python kwarg `path_style="kebab-case"` flips auto-derived class segments."""
+        spec = _generate(path_style="kebab-case")
+        # `BigCatalogItem` auto-pluralises to `big_catalog_items`; in kebab
+        # mode it becomes `big-catalog-items`.
+        assert "/big-catalog-items" in spec["paths"]
+        assert "/big_catalog_items" not in spec["paths"]
+
+    def test_kebab_case_kwarg_renders_slot_segments_with_dashes(self):
+        """Slot-driven nested URL segments also pick up the kebab style."""
+        spec = _generate(path_style="kebab-case", resource_filter=["RegularItem"])
+        # RegularItem has no nested slots so verify on the flat side: the
+        # `secret_field` slot path_segment isn't relevant; verify by
+        # building a tailored schema below.
+        del spec  # only used for typing — assertions below use the real test.
+
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/kebab-slot
+name: kebab_slot
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      data_services:
+        range: DataService
+        multivalued: true
+  DataService:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            spec = yaml.safe_load(
+                OpenAPIGenerator(tmp, path_style="kebab-case").serialize(format="yaml")
+            )
+            paths = set(spec["paths"])
+            assert "/catalogs/{id}/data-services" in paths
+            assert "/catalogs/{id}/data_services" not in paths
+            assert "/data-services" in paths
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_schema_level_annotation_drives_default(self):
+        """`openapi.path_style: kebab-case` at schema level applies without a kwarg."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/schema-kebab
+name: schema_kebab
+default_range: string
+annotations:
+  openapi.path_style: kebab-case
+classes:
+  DataService:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
+            assert "/data-services" in spec["paths"]
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_kwarg_overrides_schema_level(self):
+        """Python kwarg / CLI flag wins over the schema annotation."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/schema-kebab2
+name: schema_kebab2
+default_range: string
+annotations:
+  openapi.path_style: kebab-case
+classes:
+  DataService:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            spec = yaml.safe_load(
+                OpenAPIGenerator(tmp, path_style="snake_case").serialize(format="yaml")
+            )
+            assert "/data_services" in spec["paths"]
+            assert "/data-services" not in spec["paths"]
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_unsupported_path_style_raises(self):
+        """Unknown style values raise with the supported list."""
+        import pytest
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        gen = OpenAPIGenerator(SCHEMA_PATH, path_style="camelCase")
+        with pytest.raises(ValueError, match="Unsupported"):
+            gen.serialize(format="yaml")
+
+    def test_class_path_override_still_wins(self):
+        """`openapi.path` on a class is taken verbatim — not re-styled."""
+        spec = _generate(path_style="kebab-case")
+        # Address declares `openapi.path: addresses` — already kebab-friendly,
+        # but the point is that even if it were `address_book` the override
+        # would be taken literally. Catalog declares `openapi.path: catalogs`.
+        assert "/addresses" in spec["paths"]
+        assert "/catalogs" in spec["paths"]
+
+    def test_path_template_not_affected_by_style(self):
+        """`openapi.path_template` URLs are taken literally — no style applied."""
+        spec = _generate(path_style="kebab-case")
+        # ResourceVersion declares an explicit template with `by-doi` segment;
+        # the path emits exactly as written.
+        assert "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}" in spec["paths"]
+
+    def test_operation_ids_and_property_keys_unchanged(self):
+        """Kebab style only touches URL segments — body identifiers stay snake."""
+        spec = _generate(path_style="kebab-case")
+        # `BigCatalogItem` becomes `/big-catalog-items` but the operation IDs
+        # and tags still use snake_case identifiers.
+        coll = spec["paths"]["/big-catalog-items"]
+        assert coll["get"]["operationId"] == "list_big_catalog_items"
+        # Component schema property keys for `web_resources` stay snake.
+        assert "web_resources" in spec["components"]["schemas"]["Hub"]["properties"]
+
+
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 


### PR DESCRIPTION
Closes #38.

## Summary

LinkML slot names must be valid identifiers (snake_case), but most public REST APIs render URL segments in kebab-case. Two new annotations bridge the gap without touching slot identifiers in the OpenAPI body:

* **Schema-level / CLI** — `openapi.path_style: "kebab-case"` (or `--path-style kebab-case`) flips the convention for every auto-derived URL segment in the spec. Default `snake_case` (byte-identical to today).
* **Slot-level** — `openapi.path_segment: "<segment>"` overrides the rendered URL segment for one slot, verbatim, regardless of the active style.

## Worked example

```yaml
annotations:
  openapi.path_style: kebab-case

classes:
  Catalog:
    annotations: { openapi.resource: "true" }
    attributes:
      id: { identifier: true, required: true }
      data_services:
        range: DataService
        multivalued: true

  DataService:
    annotations: { openapi.resource: "true" }
    attributes:
      id: { identifier: true, required: true }
```

→
```
/catalogs
/catalogs/{id}
/catalogs/{id}/data-services
/catalogs/{id}/data-services/{data_service_id}
/catalogs/{catalog_id}/data-services/{id}    # deep chain
/data-services
/data-services/{id}
```

The component-schema property `data_services` (snake) and the operation IDs (`list_data_services`) are unchanged — only the URL segment.

Per-slot override:
```yaml
slot_usage:
  web_resources:
    annotations:
      openapi.path_segment: "web-resources"   # taken verbatim
```

## What stays the same

* Default behaviour: `bookstore`, `petstore`, `minimal` regenerate byte-identically.
* Slot identifiers in OpenAPI bodies, operation IDs, tags, JSON property keys, query parameter names, and `x-rdf-property` URIs.
* `openapi.path` overrides on classes — taken verbatim, never re-styled.
* `openapi.path_template` URLs (Layer 4) — taken literally, no style applied.
* Path parameters (`{catalogId}`, `{distId}`) — identifier-shaped, not segment-shaped, so unaffected.

## Resolution order

1. Python `path_style=` kwarg / `--path-style` CLI flag (highest priority)
2. Schema-level `openapi.path_style` annotation
3. Default `"snake_case"` (byte-identical to today)

Unknown values raise at generation time with the supported list (`snake_case`, `kebab-case`).

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 170 / 170 pass (11 new in `TestPathStyle`)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — no drift
- [x] Tests cover: default snake preserved; slot `path_segment` override taken verbatim; override flows through chain emission; kebab kwarg renders class- and slot-derived segments with dashes; schema-level annotation drives default; kwarg overrides schema-level; unknown style raises; `openapi.path` class override still wins; `openapi.path_template` literals unaffected; operation IDs and component property keys stay snake.

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_