### PR TITLE
fix(slot-annotations): propagate parent slot_usage through is_a (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Slot annotations now propagate through `is_a` inheritance**
+  ([#40](https://github.com/jackhiggs/linkml-openapi/issues/40)).
+  ``openapi.nested: "false"`` (and every other ``openapi.*`` slot
+  annotation) declared on a parent class's ``slot_usage`` now reaches
+  every subclass that induces the slot, instead of silently dropping
+  at the inheritance boundary. ``_get_slot_annotation`` consulted only
+  the class's direct ``slot_usage`` and the top-level slot definition;
+  it now also reads the induced slot's annotations, which is where
+  ``linkml-runtime`` deposits the merged ``slot_usage`` from the
+  ``is_a`` chain. Direct slot_usage on the subclass still wins over
+  inherited values (most-specific override semantics, same as LinkML).
+
 ### Added
 
 - **Kebab-case URL paths**

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -657,8 +657,20 @@ class OpenAPIGenerator(Generator):
         ]
 
     def _get_slot_annotation(self, cls: ClassDefinition, slot_name: str, tag: str) -> str | None:
-        """Read a slot annotation, checking class slot_usage first, then the slot itself."""
-        # Check slot_usage on the class
+        """Read a slot annotation, walking the same inheritance chain LinkML does.
+
+        Resolution order (most specific wins):
+
+        1. The class's direct ``slot_usage`` (fast path; same as today).
+        2. The induced slot's annotations — this is where ``linkml-runtime``
+           deposits the merged result of ``slot_usage`` from every ``is_a``
+           ancestor, so a parent class's ``openapi.nested: "false"`` (and
+           any other ``openapi.*`` annotation) reaches its subclasses
+           automatically. Without this step, an annotation declared on a
+           parent in slot_usage would silently fail to apply to children.
+        3. The top-level slot definition (global default; same as today).
+        """
+        # 1. Direct slot_usage on the class.
         if cls.slot_usage:
             for su in (
                 cls.slot_usage.values() if isinstance(cls.slot_usage, dict) else cls.slot_usage
@@ -672,8 +684,26 @@ class OpenAPIGenerator(Generator):
                         ):
                             if hasattr(ann, "tag") and ann.tag == tag:
                                 return str(ann.value)
-        # Check slot's own annotations via schemaview
         sv = self.schemaview
+        # 2. Induced slot annotations — picks up slot_usage inherited from
+        # ancestor classes through the is_a chain.
+        for induced in sv.class_induced_slots(cls.name):
+            if induced.name != slot_name:
+                continue
+            annotations = getattr(induced, "annotations", None)
+            if annotations:
+                # `class_induced_slots` returns SlotDefinition objects whose
+                # `annotations` is a JsonObj — same dict-like access as a
+                # regular Annotations container. Iterate keys defensively.
+                keys = (
+                    list(annotations.keys()) if hasattr(annotations, "keys") else list(annotations)
+                )
+                for key in keys:
+                    ann = annotations[key]
+                    if getattr(ann, "tag", None) == tag:
+                        return str(ann.value)
+            break
+        # 3. Top-level slot definition (global default).
         slot_def = sv.get_slot(slot_name)
         if slot_def and slot_def.annotations:
             for ann in slot_def.annotations.values():

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -450,6 +450,46 @@ classes:
         annotations:
           openapi.query_param: "false"
 
+  # --- Slot-annotation inheritance through is_a (issue #40) ---
+  # `BaseResource` declares `openapi.nested: "false"` on the
+  # `classified_by` slot via slot_usage. The two subclasses inherit the
+  # slot AND the suppression — the nested-path emitter must NOT emit
+  # `/foo_resources/{id}/classified_by` or
+  # `/bar_resources/{id}/classified_by`.
+  Classifier:
+    description: Used as the range of the suppressed slot — needs to be a class
+      so the nested walk would otherwise pick the slot up.
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+
+  BaseResource:
+    abstract: true
+    description: Parent that declares the suppression once for all subclasses.
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      classified_by:
+        range: Classifier
+        multivalued: true
+    slot_usage:
+      classified_by:
+        annotations:
+          openapi.nested: "false"
+
+  FooResource:
+    is_a: BaseResource
+    annotations:
+      openapi.resource: "true"
+
+  BarResource:
+    is_a: BaseResource
+    annotations:
+      openapi.resource: "true"
 enums:
   PersonStatus:
     description: Status of a person

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1711,6 +1711,114 @@ classes:
         assert "web_resources" in spec["components"]["schemas"]["Hub"]["properties"]
 
 
+class TestSlotAnnotationInheritance:
+    """Coverage for issue #40 — slot annotations from parent slot_usage propagate via is_a."""
+
+    def test_inherited_nested_suppression_reaches_subclass(self):
+        """`openapi.nested: "false"` on a parent slot_usage propagates to subclasses."""
+        spec = _generate()
+        # FooResource and BarResource both inherit `classified_by` and the
+        # `openapi.nested: "false"` suppression from BaseResource.slot_usage.
+        # Neither subclass should produce a nested path for that slot.
+        assert "/foo_resources/{id}/classified_by" not in spec["paths"]
+        assert "/bar_resources/{id}/classified_by" not in spec["paths"]
+        # Sanity: the two subclasses themselves are emitted.
+        assert "/foo_resources/{id}" in spec["paths"]
+        assert "/bar_resources/{id}" in spec["paths"]
+
+    def test_subclass_can_override_inherited_annotation(self):
+        """Direct slot_usage on the subclass wins over the inherited value."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/override
+name: ov
+default_range: string
+classes:
+  Tag:
+    attributes:
+      id: { identifier: true, required: true }
+  Parent:
+    abstract: true
+    attributes:
+      id: { identifier: true, required: true }
+      tags:
+        range: Tag
+        multivalued: true
+    slot_usage:
+      tags:
+        annotations:
+          openapi.nested: "false"
+  Child:
+    is_a: Parent
+    annotations: { openapi.resource: "true" }
+    slot_usage:
+      tags:
+        annotations:
+          openapi.nested: "true"
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
+            # Child overrides the inherited "false" with "true" → nested path emits.
+            nested = [p for p in spec["paths"] if p.startswith("/childs/{id}/tags")]
+            paths_dump = sorted(spec["paths"])
+            assert nested, (
+                f"expected child override to re-enable nested emission; got: {paths_dump}"
+            )
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    def test_inherited_path_variable_annotation(self):
+        """Other openapi.* slot annotations propagate the same way (path_variable)."""
+        import tempfile
+        from pathlib import Path
+
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        schema_yaml = """
+id: https://example.org/pv
+name: pv
+default_range: string
+classes:
+  Parent:
+    abstract: true
+    attributes:
+      uri:
+        identifier: true
+        range: uri
+        required: true
+    slot_usage:
+      uri:
+        annotations:
+          openapi.path_variable: slug
+  Child:
+    is_a: Parent
+    annotations: { openapi.resource: "true" }
+"""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+            f.write(schema_yaml)
+            tmp = f.name
+        try:
+            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
+            # `slug` mode emits `string` regardless of the slot's `uri` range —
+            # confirm the inherited annotation reached the subclass.
+            params = spec["paths"]["/childs/{uri}"]["parameters"]
+            uri_param = next(p for p in params if p["name"] == "uri")
+            assert uri_param["schema"]["type"] == "string"
+            assert "format" not in uri_param["schema"], (
+                "slug mode should drop format=uri; if format is present "
+                "the slot_usage annotation didn't propagate"
+            )
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 


### PR DESCRIPTION
Closes #40.

## Bug

`openapi.nested: "false"` (and every other `openapi.*` slot annotation) declared on a parent class's `slot_usage` was silently dropped at the inheritance boundary. Subclasses that induced the slot through `is_a` got the slot but **not** the annotation.

Reproduction (against `main` before this fix):

```yaml
classes:
  Resource:
    attributes:
      classifiedBy: { range: string }
    slot_usage:
      classifiedBy:
        annotations:
          openapi.nested: "false"

  APIDataService:
    is_a: Resource
    annotations: { openapi.resource: "true" }
    attributes:
      id: { identifier: true, required: true }
```

→ `/api_data_services/{id}/classifiedBy` was emitted as a nested path even though the parent had explicitly suppressed it.

## Root cause

`_get_slot_annotation` consulted only:
1. The class's **direct** `slot_usage`.
2. The **top-level** slot definition.

Neither catches inherited slot_usage. Empirically verified that `linkml-runtime`'s `class_induced_slots` correctly merges parent slot_usage into the induced `SlotDefinition`'s `.annotations` — our reader was just ignoring that source.

## Fix

Add a third lookup step on the induced slot's annotations, positioned between the direct-slot_usage fast path and the top-level fallback:

1. Direct slot_usage on the class (fast path).
2. **Induced slot annotations** (new — picks up inherited slot_usage).
3. Top-level slot definition (global default).

Most-specific override semantics preserved: a subclass's direct slot_usage still wins over an inherited annotation, matching LinkML's own behaviour.

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 173 / 173 pass (3 new in `TestSlotAnnotationInheritance`)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — no drift
- [x] Tests cover: parent suppression reaches subclass; subclass override beats inherited annotation; non-`nested` annotations (e.g. `path_variable: slug`) inherit the same way

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_