### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## Unreleased
+## [0.6.0] — 2026-04-28
+
+URL-shape and inheritance-correctness release. The new `openapi.path_style`
+turns kebab-case URLs on with one annotation, and the `is_a` propagation
+fix finally lets parent-class slot suppressions reach subclasses where
+LinkML semantics already said they should.
 
 ### Fixed
 
@@ -269,6 +274,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.6.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.0
 [0.5.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.5.0
 [0.4.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.4.0
 [0.3.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.5.0"
+version = "0.6.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
## Summary

Cuts v0.6.0. Two changesets land since v0.5.0:

* **PR #39 (#38)** — kebab-case URL paths. Schema-level / CLI `openapi.path_style: "kebab-case"` flips every auto-derived URL segment globally; per-slot `openapi.path_segment` overrides verbatim. Default remains `snake_case` for byte-identical existing-schema output.
* **PR #41 (#40)** — slot annotations from parent `slot_usage` now propagate through `is_a` to subclasses. `_get_slot_annotation` was reading only the class's direct `slot_usage` and the top-level slot; the fix adds the induced slot's annotations as a third source, where `linkml-runtime` already merges the parent's `slot_usage`. Fixes the case where `openapi.nested: "false"` on a parent silently failed to suppress nested paths for subclasses.

Bumps:
* `pyproject.toml`: `0.5.0` → `0.6.0`
* `src/linkml_openapi/__init__.py`: `__version__ = "0.6.0"`
* `CHANGELOG.md`: promote `Unreleased` under `[0.6.0] — 2026-04-28`; add v0.6.0 anchor.

## Why a minor bump

* Mix of `Added` (#39 — new annotations and CLI flag) and `Fixed` (#41 — bug that changes generated output for any schema with parent-`slot_usage`-annotated slots induced into subclasses).
* The CHANGELOG header notes pre-1.0 minor bumps may carry visible behaviour changes; #41 specifically can change output for affected schemas.
* Schemas without parent slot_usage annotations regenerate byte-identically (`bookstore`, `petstore`, `minimal`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/ -m "not e2e"` — 173 / 173 pass
- [x] `gen-openapi --version` reports `0.6.0`
- [ ] Merge → cut `v0.6.0` GitHub release → publish workflow uploads to PyPI

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_