### PR TITLE
chore(release): 0.6.1 — simplify cleanup of v0.4.0..v0.6.0 changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [0.6.1] — 2026-04-28
+
+Internal cleanup release driven by a code-reuse / quality / efficiency
+review across the v0.4.0..v0.6.0 changeset. No behaviour change —
+generated specs are byte-identical against every committed example —
+but a few internal corners are cleaner and one latent correctness
+issue is fixed.
+
+### Fixed
+
+- **Parent-chain cache was order-dependent.** ``_collect_parent_chains``
+  memoised chains under one walk's ``on_path`` and reused them under
+  another's, so a class reachable through two ancestor sub-graphs could
+  show different chains depending on which leaf the top-level loop
+  reached first. The cache is dropped — the relationship-graph walk is
+  cheap on resource classes and now deterministic.
+
+### Changed
+
+- **Hot-path performance.** A per-build cache of induced slots indexed
+  by ``(class_name, slot_name)`` collapses the previous O(slots²)
+  lookups in ``_get_slot_annotation``, ``_render_slot_segment``, the
+  nested-path emitters, and the chain builder to O(1). The
+  ``_get_resource_classes`` result is now cached too — both
+  ``_collect_parent_chains`` and ``_build_openapi`` need it.
+- **DRY internals.** The triplicated ``openapi.path_id`` rename logic
+  (flat item path, ``_make_nested_paths``, deep-chain emitter) is
+  consolidated into a single ``_resolve_item_path_vars`` helper. The
+  five-line CRUD-attach block (``if "read" in operations: …`` repeated
+  across three emit-methods) is a single ``_attach_item_operations``
+  call. The 15+ test methods that hand-rolled the temp-file +
+  generate + cleanup boilerplate now use module-level
+  ``_generate_from_string`` / ``_generate_from_string_raises``
+  helpers.
+- **Constants over magic strings.** Module-level ``PATH_STYLE_SNAKE``
+  / ``PATH_STYLE_KEBAB`` / ``SUPPORTED_PATH_STYLES`` and
+  ``OP_LIST`` / ``OP_CREATE`` / ``OP_READ`` / ``OP_UPDATE`` /
+  ``OP_PATCH`` / ``OP_DELETE`` (plus ``DEFAULT_OPERATIONS``,
+  ``ITEM_OPERATIONS``) replace the repeated string literals. The CLI
+  ``--path-style`` choices are derived from the same constant so the
+  list can't drift.
+- Stale ``# (issue #N)`` markers removed from in-source section
+  dividers — issue references belong in commit messages and the
+  changelog, not in code that has to stay current.
+
 ## [0.6.0] — 2026-04-28
 
 URL-shape and inheritance-correctness release. The new `openapi.path_style`
@@ -274,6 +319,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.6.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.1
 [0.6.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.0
 [0.5.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.5.0
 [0.4.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.6.0"
+version = "0.6.1"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -3,7 +3,7 @@
 import click
 
 from linkml_openapi import __version__
-from linkml_openapi.generator import OpenAPIGenerator
+from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
 
 
 @click.command(name="gen-openapi")
@@ -68,7 +68,7 @@ from linkml_openapi.generator import OpenAPIGenerator
 )
 @click.option(
     "--path-style",
-    type=click.Choice(["snake_case", "kebab-case"]),
+    type=click.Choice(sorted(SUPPORTED_PATH_STYLES)),
     default=None,
     help=(
         "URL path-segment convention. Defaults to the schema-level "

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -135,6 +135,25 @@ def _parse_csv(value: str | None, *, lowercase: bool = False) -> list[str]:
     return [t for t in out if t]
 
 
+# URL path-segment styles. Module-level so the CLI can import the
+# canonical list of choices without re-listing it.
+PATH_STYLE_SNAKE = "snake_case"
+PATH_STYLE_KEBAB = "kebab-case"
+SUPPORTED_PATH_STYLES: frozenset[str] = frozenset({PATH_STYLE_SNAKE, PATH_STYLE_KEBAB})
+
+# Operation tokens accepted by `openapi.operations`. Order matters for
+# the default emission tuple — list/create on collection, then item ops.
+OP_LIST = "list"
+OP_CREATE = "create"
+OP_READ = "read"
+OP_UPDATE = "update"
+OP_PATCH = "patch"
+OP_DELETE = "delete"
+DEFAULT_OPERATIONS: tuple[str, ...] = (OP_LIST, OP_CREATE, OP_READ, OP_UPDATE, OP_DELETE)
+# Operations that need an item path (i.e. an addressable identifier).
+ITEM_OPERATIONS: frozenset[str] = frozenset({OP_READ, OP_UPDATE, OP_PATCH, OP_DELETE})
+
+
 @dataclass
 class OpenAPIGenerator(Generator):
     """Generate an OpenAPI 3.1 specification from a LinkML schema."""
@@ -199,6 +218,17 @@ class OpenAPIGenerator(Generator):
             self._excluded_slots,
             self._profile_description,
         ) = self._resolve_profile_filter()
+        # Per-build cache of induced slots keyed `(class_name, slot_name)`.
+        # `_get_slot_annotation`, `_render_slot_segment`, and the
+        # nested-path / chain emitters used to call
+        # `class_induced_slots(name)` and linearly scan the result on
+        # every lookup, giving O(slots²) per class. The cache collapses
+        # the inner loop to O(1).
+        self._induced_slot_cache: dict[str, dict[str, SlotDefinition]] = {}
+        # Pre-compute the resource-class list once. `_collect_parent_chains`
+        # and `_build_openapi` both need it, and the underlying walk is
+        # O(classes × slots).
+        self._resource_classes_cache: list[str] | None = None
         # Pre-compute the synthetic-inverse index once; without this each
         # resource-class iteration in `_build_openapi` would re-walk every
         # class and slot in the schema (O(resource_classes × all_classes ×
@@ -331,9 +361,9 @@ class OpenAPIGenerator(Generator):
             if not nested_only:
                 collection_path = f"/{path_segment}"
                 collection_item = PathItem()
-                if "list" in operations:
+                if OP_LIST in operations:
                     collection_item.get = self._make_list_operation(cls, class_name)
-                if "create" in operations:
+                if OP_CREATE in operations:
                     collection_item.post = self._make_create_operation(cls, class_name)
                 paths[collection_path] = collection_item
 
@@ -344,45 +374,18 @@ class OpenAPIGenerator(Generator):
             # nested-paths-from-this-class, and in any deep chain that
             # passes through this class as an ancestor.
             if path_vars:
-                path_id_override = (
-                    self._class_annotation(cls, "openapi.path_id") if len(path_vars) == 1 else None
-                )
-                resolved_path_vars = [
-                    (
-                        path_id_override.strip() if path_id_override else slot.name,
-                        slot,
-                        mode,
-                    )
-                    for slot, mode in path_vars
-                ]
-                item_suffix = "/".join(f"{{{name}}}" for name, _slot, _mode in resolved_path_vars)
-                path_params = [
-                    Parameter(
-                        name=name,
-                        param_in=ParameterLocation.PATH,
-                        required=True,
-                        param_schema=self._path_variable_schema(slot, mode),
-                    )
-                    for name, slot, mode in resolved_path_vars
-                ]
+                item_suffix, path_params = self._resolve_item_path_vars(class_name, path_vars)
 
                 if not nested_only:
                     item_path = f"/{path_segment}/{item_suffix}"
                     item = PathItem(parameters=path_params)
-                    if "read" in operations:
-                        item.get = self._make_read_operation(cls, class_name)
-                    if "update" in operations:
-                        item.put = self._make_update_operation(cls, class_name)
-                    if "patch" in operations:
-                        item.patch = self._make_patch_operation(cls, class_name)
-                    if "delete" in operations:
-                        item.delete = self._make_delete_operation(cls, class_name)
+                    self._attach_item_operations(item, cls, class_name, operations)
                     paths[item_path] = item
 
                 # The PATCH body schema is needed whenever `patch` is
                 # listed, regardless of which URL forms emit, so generate
                 # it outside the nested-only branch.
-                if "patch" in operations and f"{class_name}Patch" not in schemas:
+                if OP_PATCH in operations and f"{class_name}Patch" not in schemas:
                     schemas[f"{class_name}Patch"] = self._build_patch_schema(class_name, cls)
 
                 paths.update(self._make_nested_paths(class_name, path_segment, path_vars))
@@ -448,13 +451,11 @@ class OpenAPIGenerator(Generator):
 
     def _class_to_schema(self, cls: ClassDefinition) -> Schema:
         """Convert a LinkML class to a JSON Schema object."""
-        sv = self.schemaview
-
         if cls.is_a and not self.flatten_inheritance:
-            parent_slot_names = {s.name for s in sv.class_induced_slots(cls.is_a)}
+            parent_slot_names = set(self._induced_slots_by_name(cls.is_a))
             local_properties: dict[str, Schema | Reference] = {}
             local_required: list[str] = []
-            for slot in sv.class_induced_slots(cls.name):
+            for slot in self._induced_slots_iter(cls.name):
                 if self._is_slot_excluded(slot):
                     continue
                 self._record_rdf_slot_uri(cls.name, slot)
@@ -486,7 +487,7 @@ class OpenAPIGenerator(Generator):
         properties: dict[str, Schema | Reference] = {}
         required: list[str] = []
 
-        for slot in sv.class_induced_slots(cls.name):
+        for slot in self._induced_slots_iter(cls.name):
             if self._is_slot_excluded(slot):
                 continue
             self._record_rdf_slot_uri(cls.name, slot)
@@ -628,33 +629,72 @@ class OpenAPIGenerator(Generator):
     def _get_resource_classes(self) -> list[str]:
         """Determine which classes should have REST endpoints.
 
+        Cached on the instance for the duration of a build because both
+        ``_collect_parent_chains`` and ``_build_openapi`` need it; the
+        underlying walk is O(classes × slots).
+
         Profile filtering applies last: a class excluded by the active
         profile never gets endpoints, even if it carries
         ``openapi.resource: "true"``.
         """
+        cached = getattr(self, "_resource_classes_cache", None)
+        if cached is not None:
+            return cached
         sv = self.schemaview
         excluded = self._excluded_classes
 
         if self.resource_filter:
-            return [c for c in self.resource_filter if c not in excluded]
+            result = [c for c in self.resource_filter if c not in excluded]
+        else:
+            annotated = [
+                name
+                for name in sv.all_classes()
+                if name not in excluded
+                and _is_truthy(
+                    self._class_annotation(sv.get_class(name), "openapi.resource") or False
+                )
+            ]
+            if annotated:
+                result = annotated
+            else:
+                result = [
+                    name
+                    for name in sv.all_classes()
+                    if name not in excluded
+                    and not sv.get_class(name).abstract
+                    and not sv.get_class(name).mixin
+                    and list(self._induced_slots_iter(name))
+                ]
+        self._resource_classes_cache = result
+        return result
 
-        annotated = [
-            name
-            for name in sv.all_classes()
-            if name not in excluded
-            and _is_truthy(self._class_annotation(sv.get_class(name), "openapi.resource") or False)
-        ]
-        if annotated:
-            return annotated
+    def _induced_slots_by_name(self, class_name: str) -> dict[str, SlotDefinition]:
+        """Per-build cache of induced slots indexed by slot name.
 
-        return [
-            name
-            for name in sv.all_classes()
-            if name not in excluded
-            and not sv.get_class(name).abstract
-            and not sv.get_class(name).mixin
-            and list(sv.class_induced_slots(name))
-        ]
+        The first call walks ``class_induced_slots(class_name)``;
+        subsequent calls are an O(1) dict lookup. Used by
+        ``_get_slot_annotation``, ``_render_slot_segment``, the
+        nested-path emitters, and the chain builder — call sites that
+        previously did a full linear scan per slot lookup, giving
+        O(slots²) per class.
+
+        The backing dict is also lazily allocated on first call so test
+        paths that exercise helper methods directly (without going
+        through ``serialize()``) still work.
+        """
+        cache = getattr(self, "_induced_slot_cache", None)
+        if cache is None:
+            cache = {}
+            self._induced_slot_cache = cache
+        cached = cache.get(class_name)
+        if cached is None:
+            cached = {s.name: s for s in self.schemaview.class_induced_slots(class_name)}
+            cache[class_name] = cached
+        return cached
+
+    def _induced_slots_iter(self, class_name: str):
+        """Cached iteration order matching ``class_induced_slots`` semantics."""
+        return self._induced_slots_by_name(class_name).values()
 
     def _get_slot_annotation(self, cls: ClassDefinition, slot_name: str, tag: str) -> str | None:
         """Read a slot annotation, walking the same inheritance chain LinkML does.
@@ -686,10 +726,10 @@ class OpenAPIGenerator(Generator):
                                 return str(ann.value)
         sv = self.schemaview
         # 2. Induced slot annotations — picks up slot_usage inherited from
-        # ancestor classes through the is_a chain.
-        for induced in sv.class_induced_slots(cls.name):
-            if induced.name != slot_name:
-                continue
+        # ancestor classes through the is_a chain. Cached by class name
+        # so this is an O(1) dict lookup.
+        induced = self._induced_slots_by_name(cls.name).get(slot_name)
+        if induced is not None:
             annotations = getattr(induced, "annotations", None)
             if annotations:
                 # `class_induced_slots` returns SlotDefinition objects whose
@@ -702,7 +742,6 @@ class OpenAPIGenerator(Generator):
                     ann = annotations[key]
                     if getattr(ann, "tag", None) == tag:
                         return str(ann.value)
-            break
         # 3. Top-level slot definition (global default).
         slot_def = sv.get_slot(slot_name)
         if slot_def and slot_def.annotations:
@@ -744,7 +783,7 @@ class OpenAPIGenerator(Generator):
         annotated: list[tuple[SlotDefinition, str]] = []
         identifier_slot: SlotDefinition | None = None
         id_named_slot: SlotDefinition | None = None
-        for slot in self.schemaview.class_induced_slots(cls.name):
+        for slot in self._induced_slots_iter(cls.name):
             mode = self._path_variable_mode(
                 self._get_slot_annotation(cls, slot.name, "openapi.path_variable")
             )
@@ -759,26 +798,24 @@ class OpenAPIGenerator(Generator):
         fallback = identifier_slot or id_named_slot
         return [(fallback, "iri")] if fallback else []
 
-    _SUPPORTED_PATH_STYLES: ClassVar[frozenset[str]] = frozenset({"snake_case", "kebab-case"})
-
     def _resolve_path_style(self) -> str:
         """Pick the effective URL path-segment convention for this build.
 
         Resolution order: CLI / Python `path_style` kwarg, then the
         schema-level `openapi.path_style` annotation, then the
-        backward-compatible default `"snake_case"`. Unknown values raise
+        backward-compatible default `snake_case`. Unknown values raise
         with the supported list.
         """
         candidate = self.path_style
         if candidate is None:
             candidate = self._schema_annotation("openapi.path_style")
         if candidate is None:
-            return "snake_case"
+            return PATH_STYLE_SNAKE
         normalised = str(candidate).strip().lower()
-        if normalised not in self._SUPPORTED_PATH_STYLES:
+        if normalised not in SUPPORTED_PATH_STYLES:
             raise ValueError(
                 f"Unsupported `openapi.path_style` {candidate!r}; "
-                f"expected one of {sorted(self._SUPPORTED_PATH_STYLES)!r}."
+                f"expected one of {sorted(SUPPORTED_PATH_STYLES)!r}."
             )
         return normalised
 
@@ -792,11 +829,12 @@ class OpenAPIGenerator(Generator):
         ``openapi.path`` and ``openapi.path_segment`` are taken verbatim
         and never re-styled.
 
-        Falls back to ``"snake_case"`` when called before a full
-        ``serialize()`` build has cached the resolved style — keeps
-        helper methods safely callable from tests and ad-hoc scripts.
+        Reads `_effective_path_style` directly; the attribute is set
+        eagerly in ``serialize()`` for normal builds, and lazily by
+        ``_resolve_path_style`` if a helper method is called before a
+        full serialize (keeps test paths safe).
         """
-        if getattr(self, "_effective_path_style", "snake_case") == "kebab-case":
+        if getattr(self, "_effective_path_style", PATH_STYLE_SNAKE) == PATH_STYLE_KEBAB:
             return name.replace("_", "-")
         return name
 
@@ -842,7 +880,7 @@ class OpenAPIGenerator(Generator):
         """Get the list of CRUD operations for a class."""
         ops = self._class_annotation(cls, "openapi.operations")
         if ops is None:
-            return ["list", "create", "read", "update", "delete"]
+            return list(DEFAULT_OPERATIONS)
         return _parse_csv(ops)
 
     # --- RDF extension propagation -----------------------------------------
@@ -931,7 +969,7 @@ class OpenAPIGenerator(Generator):
             )
         return custom
 
-    # --- Profiles (issue #17) ----------------------------------------------
+    # --- Profiles --------------------------------------------------------
 
     _PROFILE_LIST_KEYS = ("exclude_classes", "exclude_slots", "include_classes", "include_slots")
     _PROFILE_STR_KEYS = ("description",)
@@ -1012,7 +1050,7 @@ class OpenAPIGenerator(Generator):
             if class_name in excluded_classes:
                 continue
             cls = sv.get_class(class_name)
-            for slot in sv.class_induced_slots(class_name):
+            for slot in self._induced_slots_iter(class_name):
                 if slot.name not in excluded_slots:
                     continue
                 pv = self._get_slot_annotation(cls, slot.name, "openapi.path_variable")
@@ -1095,11 +1133,11 @@ class OpenAPIGenerator(Generator):
             },
         )
 
-    # --- Discriminator / polymorphism (issue #20) --------------------------
+    # --- Discriminator / polymorphism -----------------------------------
 
     def _designates_type_slot(self, class_name: str) -> SlotDefinition | None:
         """Return the slot with `designates_type: true` on this class, or None."""
-        for slot in self.schemaview.class_induced_slots(class_name):
+        for slot in self._induced_slots_iter(class_name):
             if getattr(slot, "designates_type", False):
                 return slot
         return None
@@ -1374,7 +1412,7 @@ class OpenAPIGenerator(Generator):
             },
         )
 
-    # --- PATCH (issue #16) -------------------------------------------------
+    # --- PATCH operations ------------------------------------------------
 
     def _make_patch_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         """Emit a PATCH item operation using JSON Merge Patch (RFC 7396).
@@ -1428,7 +1466,7 @@ class OpenAPIGenerator(Generator):
             self._x_rdf_class[patch_name] = sv.expand_curie(cls.class_uri)
 
         properties: dict[str, Schema | Reference] = {}
-        for slot in sv.class_induced_slots(class_name):
+        for slot in self._induced_slots_iter(class_name):
             if slot.identifier:
                 continue
             properties[slot.name] = self._slot_to_schema(slot)
@@ -1446,7 +1484,7 @@ class OpenAPIGenerator(Generator):
             schema.properties = properties
         return schema
 
-    # --- Composition vs reference (issue #18) ------------------------------
+    # --- Composition vs reference ---------------------------------------
 
     def _validate_resource_addressability(
         self, class_name: str, path_vars: list, operations: list[str]
@@ -1458,7 +1496,7 @@ class OpenAPIGenerator(Generator):
         is present the class can't be referenced individually and the
         generator should fail loudly rather than silently drop the item path.
         """
-        item_ops = {"read", "update", "delete"} & set(operations)
+        item_ops = ITEM_OPERATIONS & set(operations) - {OP_PATCH}
         if item_ops and not path_vars:
             raise ValueError(
                 f'Class {class_name!r} has openapi.resource: "true" with '
@@ -1470,7 +1508,7 @@ class OpenAPIGenerator(Generator):
 
     def _identifier_slot(self, class_name: str) -> SlotDefinition | None:
         """Return the identifier slot of the class, or None if it has none."""
-        for slot in self.schemaview.class_induced_slots(class_name):
+        for slot in self._induced_slots_iter(class_name):
             if slot.identifier:
                 return slot
         return None
@@ -1523,6 +1561,63 @@ class OpenAPIGenerator(Generator):
             return override.strip()
         return f"{_to_snake_case(class_name)}_id"
 
+    def _resolve_item_path_vars(
+        self,
+        class_name: str,
+        path_vars: list,
+    ) -> tuple[str, list[Parameter]]:
+        """Render a class's path variables into a URL suffix and Parameter list.
+
+        Single source of truth for the ``openapi.path_id`` rename: when
+        the class has exactly one path variable *and* declares
+        ``openapi.path_id``, the override renames the URL parameter (and
+        the matching ``Parameter.name``) so the same identifier shows up
+        consistently in the flat item path, in nested-paths-from-this-
+        class, and in any deep chain that passes through this class as an
+        ancestor. Without the annotation the URL parameter falls back to
+        the slot name (preserving byte-identical output for existing
+        schemas).
+        """
+        cls = self.schemaview.get_class(class_name)
+        path_id_override: str | None = None
+        if len(path_vars) == 1 and cls is not None:
+            raw = self._class_annotation(cls, "openapi.path_id")
+            path_id_override = raw.strip() if raw else None
+        names = [path_id_override or slot.name for slot, _mode in path_vars]
+        item_suffix = "/".join(f"{{{name}}}" for name in names)
+        path_params = [
+            Parameter(
+                name=name,
+                param_in=ParameterLocation.PATH,
+                required=True,
+                param_schema=self._path_variable_schema(slot, mode),
+            )
+            for name, (slot, mode) in zip(names, path_vars)
+        ]
+        return item_suffix, path_params
+
+    def _attach_item_operations(
+        self,
+        item: PathItem,
+        cls: ClassDefinition,
+        class_name: str,
+        operations: list[str],
+    ) -> None:
+        """Attach `read` / `update` / `patch` / `delete` operations to a PathItem.
+
+        Single source of truth for the conditional CRUD-attach block,
+        previously duplicated across ``_build_openapi``,
+        ``_emit_chained_deep_path``, and ``_emit_templated_deep_path``.
+        """
+        if OP_READ in operations:
+            item.get = self._make_read_operation(cls, class_name)
+        if OP_UPDATE in operations:
+            item.put = self._make_update_operation(cls, class_name)
+        if OP_PATCH in operations:
+            item.patch = self._make_patch_operation(cls, class_name)
+        if OP_DELETE in operations:
+            item.delete = self._make_delete_operation(cls, class_name)
+
     def _nested_item_path_var(self, target_class_name: str) -> str:
         """Path-variable name for the linked item under a nested path.
 
@@ -1541,41 +1636,15 @@ class OpenAPIGenerator(Generator):
         """Single-level nested paths under a class's own item path.
 
         Thin wrapper that renders ``parent_path_segment`` + ``parent_path_vars``
-        into a URL prefix and the matching parameter list, then delegates to
-        :meth:`_make_nested_paths_with_prefix` so single-level and N-level
-        emission share the same code path. Honours the parent's
-        ``openapi.path_id`` so the nested URL and the class's own flat item
-        path use the same parameter name.
+        into a URL prefix and the matching parameter list (via the same
+        ``openapi.path_id`` resolution used by the flat item path), then
+        delegates to :meth:`_make_nested_paths_with_prefix` so single-level
+        and N-level emission share the same code path.
         """
-        parent_cls = self.schemaview.get_class(parent_class_name)
-        path_id_override = (
-            self._class_annotation(parent_cls, "openapi.path_id")
-            if parent_cls and len(parent_path_vars) == 1
-            else None
+        var_suffix, parent_path_params = self._resolve_item_path_vars(
+            parent_class_name, parent_path_vars
         )
-        named_vars = [
-            (
-                path_id_override.strip() if path_id_override else slot.name,
-                slot,
-                mode,
-            )
-            for slot, mode in parent_path_vars
-        ]
-        parent_var_suffix = "/".join(f"{{{name}}}" for name, _slot, _mode in named_vars)
-        prefix = (
-            f"{parent_path_segment}/{parent_var_suffix}"
-            if parent_var_suffix
-            else parent_path_segment
-        )
-        parent_path_params = [
-            Parameter(
-                name=name,
-                param_in=ParameterLocation.PATH,
-                required=True,
-                param_schema=self._path_variable_schema(slot, mode),
-            )
-            for name, slot, mode in named_vars
-        ]
+        prefix = f"{parent_path_segment}/{var_suffix}" if var_suffix else parent_path_segment
         return self._make_nested_paths_with_prefix(parent_class_name, prefix, parent_path_params)
 
     def _make_nested_paths_with_prefix(
@@ -1607,7 +1676,7 @@ class OpenAPIGenerator(Generator):
         parent_cls = sv.get_class(parent_class_name)
         out: dict[str, PathItem] = {}
 
-        for slot in sv.class_induced_slots(parent_class_name):
+        for slot in self._induced_slots_iter(parent_class_name):
             if not slot.multivalued:
                 continue
             if self._is_slot_excluded(slot):
@@ -1699,16 +1768,14 @@ class OpenAPIGenerator(Generator):
         for src_class_name in sv.all_classes():
             if src_class_name in self._excluded_classes:
                 continue
-            for slot in sv.class_induced_slots(src_class_name):
+            for slot in self._induced_slots_iter(src_class_name):
                 if not slot.inverse or "." not in str(slot.inverse):
                     continue
                 tgt_class, tgt_slot_name = str(slot.inverse).split(".", 1)
                 if tgt_slot_name in self._excluded_slots:
                     continue
                 if tgt_class not in target_slot_names_cache:
-                    target_slot_names_cache[tgt_class] = {
-                        s.name for s in sv.class_induced_slots(tgt_class)
-                    }
+                    target_slot_names_cache[tgt_class] = set(self._induced_slots_by_name(tgt_class))
                 if tgt_slot_name in target_slot_names_cache[tgt_class]:
                     continue  # the target has a real slot — emits naturally
                 seen = seen_per_target.setdefault(tgt_class, set())
@@ -1754,7 +1821,7 @@ class OpenAPIGenerator(Generator):
             if parent_name not in resource_classes:
                 continue
             parent_cls = sv.get_class(parent_name)
-            for slot in sv.class_induced_slots(parent_name):
+            for slot in self._induced_slots_iter(parent_name):
                 if not slot.multivalued:
                     continue
                 if self._is_slot_excluded(slot):
@@ -1772,10 +1839,12 @@ class OpenAPIGenerator(Generator):
         index: dict[str, list[list[tuple[str, str]]]] = {}
 
         def walk(leaf: str, on_path: tuple[str, ...]) -> list[list[tuple[str, str]]]:
-            if leaf in index:
-                # Memoised — but we still need to filter chains that would
-                # introduce a cycle from the caller's perspective.
-                return [c for c in index[leaf] if not any(p in on_path for p, _ in c)]
+            # Memoisation here is unsound: chains computed under one
+            # `on_path` can prune ancestors that a different caller's
+            # `on_path` would have allowed, so the cached result depends
+            # on which leaf's walk reaches a given subgraph first. The
+            # graph is small (resource classes only) so a fresh walk per
+            # leaf is cheap and deterministic.
             chains: list[list[tuple[str, str]]] = []
             for parent_name, slot_name in direct_parents.get(leaf, []):
                 if parent_name in on_path:
@@ -1786,13 +1855,13 @@ class OpenAPIGenerator(Generator):
                 else:
                     for u in upper:
                         chains.append(u + [(parent_name, slot_name)])
-            index[leaf] = chains
             return chains
 
         for cls_name in list(direct_parents.keys()):
-            walk(cls_name, ())
-        # Drop classes with no chains so callers can skip via membership check.
-        return {k: v for k, v in index.items() if v}
+            chains = walk(cls_name, (cls_name,))
+            if chains:
+                index[cls_name] = chains
+        return index
 
     @staticmethod
     def _suffix_operation_ids(paths: dict[str, PathItem], suffix: str) -> None:
@@ -1920,10 +1989,7 @@ class OpenAPIGenerator(Generator):
                 )
             param_name = self._class_path_id_name(parent_name)
             parent_cls = sv.get_class(parent_name)
-            slot_def = next(
-                (s for s in sv.class_induced_slots(parent_name) if s.name == slot_name),
-                None,
-            )
+            slot_def = self._induced_slots_by_name(parent_name).get(slot_name)
             slot_segment = (
                 self._render_slot_segment(parent_cls, slot_def)
                 if slot_def is not None
@@ -1963,16 +2029,8 @@ class OpenAPIGenerator(Generator):
         """
         chain_prefix, chain_params = self._build_chain_path_params(chain)
         deep_item_path = f"/{chain_prefix}/{item_suffix}"
-        deep_item_params = list(chain_params) + path_params
-        deep_item = PathItem(parameters=deep_item_params)
-        if "read" in operations:
-            deep_item.get = self._make_read_operation(cls, class_name)
-        if "update" in operations:
-            deep_item.put = self._make_update_operation(cls, class_name)
-        if "patch" in operations:
-            deep_item.patch = self._make_patch_operation(cls, class_name)
-        if "delete" in operations:
-            deep_item.delete = self._make_delete_operation(cls, class_name)
+        deep_item = PathItem(parameters=list(chain_params) + path_params)
+        self._attach_item_operations(deep_item, cls, class_name, operations)
         chain_suffix = "_via_" + "_".join(_to_snake_case(p) for p, _ in chain)
         deep_paths = {deep_item_path: deep_item}
         self._suffix_operation_ids(deep_paths, chain_suffix)
@@ -2068,10 +2126,7 @@ class OpenAPIGenerator(Generator):
                     f"refers to unknown class {src_class!r} for "
                     f"parameter {name!r}."
                 )
-            slot = next(
-                (s for s in sv.class_induced_slots(src_class) if s.name == src_slot),
-                None,
-            )
+            slot = self._induced_slots_by_name(src_class).get(src_slot)
             if slot is None:
                 raise ValueError(
                     f"Class {class_name!r} `openapi.path_param_sources` "
@@ -2088,14 +2143,7 @@ class OpenAPIGenerator(Generator):
             )
 
         deep_item = PathItem(parameters=params)
-        if "read" in operations:
-            deep_item.get = self._make_read_operation(cls, class_name)
-        if "update" in operations:
-            deep_item.put = self._make_update_operation(cls, class_name)
-        if "patch" in operations:
-            deep_item.patch = self._make_patch_operation(cls, class_name)
-        if "delete" in operations:
-            deep_item.delete = self._make_delete_operation(cls, class_name)
+        self._attach_item_operations(deep_item, cls, class_name, operations)
 
         deep_paths = {template: deep_item}
         self._suffix_operation_ids(deep_paths, "_via_template")
@@ -2379,7 +2427,7 @@ class OpenAPIGenerator(Generator):
         inferred_params: list[Parameter] = []
         sort_tokens: list[str] = []
 
-        for slot in sv.class_induced_slots(cls.name):
+        for slot in self._induced_slots_iter(cls.name):
             if self._is_slot_excluded(slot):
                 continue
             caps = self._query_param_capabilities(cls, slot.name)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -27,6 +27,41 @@ def _generate(**kwargs) -> dict:
     return yaml.safe_load(raw)
 
 
+def _generate_from_string(schema_yaml: str, **kwargs) -> dict:
+    """Run the generator against a one-shot YAML string.
+
+    Centralises the temp-file write / parse / cleanup dance that
+    several test classes need when verifying behaviour against a tiny
+    ad-hoc schema (ambiguous chains, malformed templates, schema-level
+    annotations, etc.).
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+        f.write(schema_yaml)
+        tmp = f.name
+    try:
+        return yaml.safe_load(OpenAPIGenerator(tmp, **kwargs).serialize(format="yaml"))
+    finally:
+        Path(tmp).unlink(missing_ok=True)
+
+
+def _generate_from_string_raises(schema_yaml: str, match: str, **kwargs) -> None:
+    """Same as :func:`_generate_from_string` but expects a ValueError."""
+    import tempfile
+
+    import pytest
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
+        f.write(schema_yaml)
+        tmp = f.name
+    try:
+        with pytest.raises(ValueError, match=match):
+            OpenAPIGenerator(tmp, **kwargs).serialize(format="yaml")
+    finally:
+        Path(tmp).unlink(missing_ok=True)
+
+
 # --- Utility function tests ---
 
 
@@ -536,12 +571,7 @@ class TestAutoQueryParamsOptOut:
 
     def test_schema_level_disables_auto_inference(self):
         """`openapi.auto_query_params: "false"` at schema level suppresses every class's auto."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/schema-off
 name: schema_off
 default_range: string
@@ -559,26 +589,13 @@ classes:
         range: string
       colour:
         range: string
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            spec = yaml.safe_load(gen.serialize(format="yaml"))
-            names = [p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]]
-            assert names == ["limit", "offset"]
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        names = [p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]]
+        assert names == ["limit", "offset"]
 
     def test_class_level_overrides_schema_level(self):
         """When the schema-level default is off, class-level "true" re-enables for one class."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/schema-mixed
 name: schema_mixed
 default_range: string
@@ -604,28 +621,15 @@ classes:
         required: true
       title:
         range: string
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            spec = yaml.safe_load(gen.serialize(format="yaml"))
-            quiet = {p["name"] for p in spec["paths"]["/quiets"]["get"]["parameters"]}
-            loud = {p["name"] for p in spec["paths"]["/louds"]["get"]["parameters"]}
-            assert quiet == {"limit", "offset"}
-            assert loud == {"limit", "offset", "title"}
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        quiet = {p["name"] for p in spec["paths"]["/quiets"]["get"]["parameters"]}
+        loud = {p["name"] for p in spec["paths"]["/louds"]["get"]["parameters"]}
+        assert quiet == {"limit", "offset"}
+        assert loud == {"limit", "offset", "title"}
 
     def test_explicitly_annotated_slots_still_emit_when_auto_off(self):
         """Auto off doesn't suppress slots that have a truthy `openapi.query_param`."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/schema-mixed-slots
 name: schema_mixed_slots
 default_range: string
@@ -644,20 +648,12 @@ classes:
           openapi.query_param: "true"
       ignored:
         range: string
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            spec = yaml.safe_load(gen.serialize(format="yaml"))
-            names = {p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]}
-            # Annotated slot still emits; the un-annotated one does not.
-            assert "title" in names
-            assert "ignored" not in names
-            assert {"limit", "offset"} <= names
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        names = {p["name"] for p in spec["paths"]["/items"]["get"]["parameters"]}
+        # Annotated slot still emits; the un-annotated one does not.
+        assert "title" in names
+        assert "ignored" not in names
+        assert {"limit", "offset"} <= names
 
 
 class TestFormatAnnotation:
@@ -1218,14 +1214,8 @@ class TestDeepNestedPaths:
 
     def test_ambiguous_chain_without_annotation_raises(self):
         """An ambiguous leaf without `openapi.parent_path` raises with candidates."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/ambig
 name: ambig
 default_range: string
@@ -1257,27 +1247,14 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="multiple parent chains"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="multiple parent chains",
+        )
 
     def test_parent_path_unmatched_value_raises(self):
         """When `openapi.parent_path` doesn't match any chain, error lists candidates."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/ambig2
 name: ambig2
 default_range: string
@@ -1310,16 +1287,9 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="no matching chain"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="no matching chain",
+        )
 
 
 class TestPathTemplateAndFlatOnly:
@@ -1368,14 +1338,8 @@ class TestPathTemplateAndFlatOnly:
 
     def test_path_template_placeholder_mismatch_raises(self):
         """Source keys must exactly match template placeholders."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/bad-template
 name: bt
 default_range: string
@@ -1389,27 +1353,14 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="don't match"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="don't match",
+        )
 
     def test_path_template_unknown_source_raises(self):
         """A `Class.slot` source must resolve."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/bad-source
 name: bs
 default_range: string
@@ -1423,27 +1374,14 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="unknown class"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="unknown class",
+        )
 
     def test_path_template_malformed_source_entry_raises(self):
         """Source format is `name:Class.slot`; missing pieces raise."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/malformed
 name: m
 default_range: string
@@ -1457,16 +1395,9 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="malformed source"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="malformed source",
+        )
 
     def test_flat_only_drops_chain_derived_deep_path(self):
         """`openapi.flat_only` suppresses the deep chain emission for the class."""
@@ -1496,14 +1427,8 @@ classes:
 
     def test_flat_only_and_nested_only_together_raise(self):
         """Setting both is a generation error — they're mutually exclusive."""
-        import tempfile
-        from pathlib import Path
-
-        import pytest
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        _generate_from_string_raises(
+            """
 id: https://example.org/mutex
 name: mu
 default_range: string
@@ -1517,16 +1442,9 @@ classes:
       id:
         identifier: true
         required: true
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            gen = OpenAPIGenerator(tmp)
-            with pytest.raises(ValueError, match="mutually exclusive"):
-                gen.serialize(format="yaml")
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            match="mutually exclusive",
+        )
 
 
 class TestPathStyle:
@@ -1573,18 +1491,8 @@ class TestPathStyle:
 
     def test_kebab_case_kwarg_renders_slot_segments_with_dashes(self):
         """Slot-driven nested URL segments also pick up the kebab style."""
-        spec = _generate(path_style="kebab-case", resource_filter=["RegularItem"])
-        # RegularItem has no nested slots so verify on the flat side: the
-        # `secret_field` slot path_segment isn't relevant; verify by
-        # building a tailored schema below.
-        del spec  # only used for typing — assertions below use the real test.
-
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string(
+            """
 id: https://example.org/kebab-slot
 name: kebab_slot
 default_range: string
@@ -1600,29 +1508,17 @@ classes:
     annotations: { openapi.resource: "true" }
     attributes:
       id: { identifier: true, required: true }
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            spec = yaml.safe_load(
-                OpenAPIGenerator(tmp, path_style="kebab-case").serialize(format="yaml")
-            )
-            paths = set(spec["paths"])
-            assert "/catalogs/{id}/data-services" in paths
-            assert "/catalogs/{id}/data_services" not in paths
-            assert "/data-services" in paths
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            path_style="kebab-case",
+        )
+        paths = set(spec["paths"])
+        assert "/catalogs/{id}/data-services" in paths
+        assert "/catalogs/{id}/data_services" not in paths
+        assert "/data-services" in paths
 
     def test_schema_level_annotation_drives_default(self):
         """`openapi.path_style: kebab-case` at schema level applies without a kwarg."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/schema-kebab
 name: schema_kebab
 default_range: string
@@ -1633,24 +1529,13 @@ classes:
     annotations: { openapi.resource: "true" }
     attributes:
       id: { identifier: true, required: true }
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
-            assert "/data-services" in spec["paths"]
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        assert "/data-services" in spec["paths"]
 
     def test_kwarg_overrides_schema_level(self):
         """Python kwarg / CLI flag wins over the schema annotation."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string(
+            """
 id: https://example.org/schema-kebab2
 name: schema_kebab2
 default_range: string
@@ -1661,18 +1546,11 @@ classes:
     annotations: { openapi.resource: "true" }
     attributes:
       id: { identifier: true, required: true }
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            spec = yaml.safe_load(
-                OpenAPIGenerator(tmp, path_style="snake_case").serialize(format="yaml")
-            )
-            assert "/data_services" in spec["paths"]
-            assert "/data-services" not in spec["paths"]
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""",
+            path_style="snake_case",
+        )
+        assert "/data_services" in spec["paths"]
+        assert "/data-services" not in spec["paths"]
 
     def test_unsupported_path_style_raises(self):
         """Unknown style values raise with the supported list."""
@@ -1728,12 +1606,7 @@ class TestSlotAnnotationInheritance:
 
     def test_subclass_can_override_inherited_annotation(self):
         """Direct slot_usage on the subclass wins over the inherited value."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/override
 name: ov
 default_range: string
@@ -1759,29 +1632,15 @@ classes:
       tags:
         annotations:
           openapi.nested: "true"
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
-            # Child overrides the inherited "false" with "true" → nested path emits.
-            nested = [p for p in spec["paths"] if p.startswith("/childs/{id}/tags")]
-            paths_dump = sorted(spec["paths"])
-            assert nested, (
-                f"expected child override to re-enable nested emission; got: {paths_dump}"
-            )
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        # Child overrides the inherited "false" with "true" → nested path emits.
+        nested = [p for p in spec["paths"] if p.startswith("/childs/{id}/tags")]
+        paths_dump = sorted(spec["paths"])
+        assert nested, f"expected child override to re-enable nested emission; got: {paths_dump}"
 
     def test_inherited_path_variable_annotation(self):
         """Other openapi.* slot annotations propagate the same way (path_variable)."""
-        import tempfile
-        from pathlib import Path
-
-        from linkml_openapi.generator import OpenAPIGenerator
-
-        schema_yaml = """
+        spec = _generate_from_string("""
 id: https://example.org/pv
 name: pv
 default_range: string
@@ -1800,23 +1659,16 @@ classes:
   Child:
     is_a: Parent
     annotations: { openapi.resource: "true" }
-"""
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
-            f.write(schema_yaml)
-            tmp = f.name
-        try:
-            spec = yaml.safe_load(OpenAPIGenerator(tmp).serialize(format="yaml"))
-            # `slug` mode emits `string` regardless of the slot's `uri` range —
-            # confirm the inherited annotation reached the subclass.
-            params = spec["paths"]["/childs/{uri}"]["parameters"]
-            uri_param = next(p for p in params if p["name"] == "uri")
-            assert uri_param["schema"]["type"] == "string"
-            assert "format" not in uri_param["schema"], (
-                "slug mode should drop format=uri; if format is present "
-                "the slot_usage annotation didn't propagate"
-            )
-        finally:
-            Path(tmp).unlink(missing_ok=True)
+""")
+        # `slug` mode emits `string` regardless of the slot's `uri` range —
+        # confirm the inherited annotation reached the subclass.
+        params = spec["paths"]["/childs/{uri}"]["parameters"]
+        uri_param = next(p for p in params if p["name"] == "uri")
+        assert uri_param["schema"]["type"] == "string"
+        assert "format" not in uri_param["schema"], (
+            "slug mode should drop format=uri; if format is present "
+            "the slot_usage annotation didn't propagate"
+        )
 
 
 class TestDiscriminator:


### PR DESCRIPTION
## Summary

Internal cleanup release driven by a parallel code-reuse / quality / efficiency review across the four feature/fix PRs that landed since v0.4.0 (#33 / #36 nested item paths + Layer 4, #35 query-param opt-out, #39 kebab paths, #41 slot-annotation inheritance). Net: **+372 / -426** lines (most savings in tests via the new helper).

**No behaviour change** — `bookstore`, `petstore`, and `minimal` regenerate byte-identically. Bumps to 0.6.1.

## Fixed

- **Order-dependent parent-chain memoisation.** `_collect_parent_chains` cached chains under one walk's `on_path` and reused them under another's, so a class reachable through two ancestor sub-graphs could show different chains depending on which leaf the top-level loop reached first. Drop the cache — the relationship-graph walk is cheap on resource classes and now deterministic. Found by the efficiency-review agent; fits a 0.6.1 (no current schema in the wild trips it, but it could.)

## Changed

- **Hot-path performance.** Per-build cache of induced slots keyed `(class_name, slot_name)` collapses the previous O(slots²) lookups in `_get_slot_annotation`, `_render_slot_segment`, the nested-path emitters, and the chain builder to O(1). `_get_resource_classes` is also cached now (called twice per build by `_collect_parent_chains` and `_build_openapi`).

- **DRY internals.**
  - Triplicated `openapi.path_id` rename logic (flat item path, `_make_nested_paths`, deep-chain emitter) → single `_resolve_item_path_vars` helper.
  - Five-line CRUD-attach block (`if "read" in operations: …`) repeated across three emit-methods → single `_attach_item_operations` call.
  - ~15 test methods hand-rolling the temp-file + generate + cleanup boilerplate → module-level `_generate_from_string` / `_generate_from_string_raises` helpers.

- **Constants over magic strings.**
  - `PATH_STYLE_SNAKE` / `PATH_STYLE_KEBAB` / `SUPPORTED_PATH_STYLES`.
  - `OP_LIST` / `OP_CREATE` / `OP_READ` / `OP_UPDATE` / `OP_PATCH` / `OP_DELETE` plus `DEFAULT_OPERATIONS` / `ITEM_OPERATIONS`.
  - The CLI `--path-style` choices now derive from `SUPPORTED_PATH_STYLES` so the list can't drift.

- **Stale `# (issue #N)` markers** removed from in-source section dividers — issue references belong in commit messages and the changelog, not in code that has to stay current.

## Deferred

The simplify reviews flagged a few items I judged too invasive for a patch release; tracking them in case you want them as a follow-up:
- `NestedEdge` dataclass to consolidate the 7-param signatures of `_add_composition_paths` / `_add_reference_paths`.
- Extract `_emit_paths_for_resource(class_name)` from the ~120-line `_build_openapi` loop body.
- `_needs_resource_link` returned explicitly instead of via instance side-channel.
- Group `_PATH_TEMPLATE_PLACEHOLDER_RE` near the other class-level constants.

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 173 / 173 pass
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `bash examples/generate.sh && git status -- examples/` — no drift
- [x] `gen-openapi --version` reports `0.6.1`

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_