### PR TITLE
feat: path_template collection ops + multi-level composition + openapi.tag (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## Unreleased
+
+### Added
+
+- **`openapi.path_template` now emits a collection path alongside the
+  item path** ([#44](https://github.com/jackhiggs/linkml-openapi/issues/44)).
+  When the template ends with a ``/{name}`` segment the leaf is
+  treated as the item path; the segment is stripped to form the
+  collection path, which gets ``list`` / ``create`` operations from
+  the class's ``openapi.operations``. Operation IDs are still
+  suffixed ``_via_template`` for global uniqueness, and the
+  collection drops the leaf-id parameter from its path-parameter
+  list. Opt out with the new ``openapi.path_template_collection:
+  "false"`` class annotation for genuinely item-only legacy URLs.
+- **Multi-level composition chains.** When an ``inlined: true``
+  composition target itself has ``inlined: true`` slots, the nested
+  paths now chain through every level instead of stopping after one
+  hop. So ``Catalog.datasets[FusionDataset].distributions[FusionDistribution]``
+  emits ``/catalogs/{catalogId}/datasets/{datasetId}/distributions``
+  and ``…/distributions/{distributionId}`` automatically — no need
+  for the intermediate to be a resource in its own right. Mutual
+  composition (``A.bs[B].as[A]``) is cycle-protected; the recursion
+  walks one cycle around then short-circuits.
+- **`openapi.tag` class annotation.** Overrides the ``tags`` value
+  used in OpenAPI operations, controlling how Swagger UI groups
+  endpoints. Default is the class name (current behaviour).
+  **Composition- and reference-derived nested operations now inherit
+  the *target* class's tag** (``Dataset``) rather than the previous
+  ``Parent.slot`` form (``Catalog.datasets``), so all "Dataset"
+  operations appear under one Swagger UI group regardless of where
+  in the URL hierarchy they live. This is a visible change in the
+  committed examples (`bookstore`, `petstore`); schemas without
+  ``openapi.tag`` keep the new target-class-name default.
+
 ## [0.6.1] — 2026-04-28
 
 Internal cleanup release driven by a code-reuse / quality / efficiency

--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ endpoints regardless of any of these annotations.
 | `openapi.path` | class | path segment string | Auto-pluralized snake_case of class name |
 | `openapi.operations` | class | comma-separated list | `list,create,read,update,delete` |
 | `openapi.media_types` | class | comma-separated list | `application/json` |
+| `openapi.tag` | class | string | Class name (composition-derived ops inherit from the target) |
 | `openapi.path_style` | schema | `snake_case` / `kebab-case` | `snake_case` |
 | `openapi.auto_query_params` | schema or class | `"true"` / `"false"` | `"true"` (auto-infer scalar slots) |
 | `openapi.path_id` | class | identifier name | `<class_snake>_id` (e.g. `catalog_id`) |
@@ -988,6 +989,7 @@ endpoints regardless of any of these annotations.
 | `openapi.nested_only` | class | `"true"` / `"false"` | Both flat and deep paths emit |
 | `openapi.flat_only` | class | `"true"` / `"false"` | Both flat and deep paths emit (mutually exclusive with `nested_only`) |
 | `openapi.path_template` | class | URL template with `{name}` placeholders | Auto-derived chain |
+| `openapi.path_template_collection` | class | `"true"` / `"false"` | Collection emits when the template ends in `/{name}` |
 | `openapi.path_param_sources` | class | comma-separated `name:Class.slot` entries | (required when `path_template` is set) |
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.path_segment` | slot (via `slot_usage`) | URL segment string | Slot name with active path-style applied |

--- a/examples/bookstore/openapi.yaml
+++ b/examples/bookstore/openapi.yaml
@@ -166,7 +166,7 @@ paths:
   /books/{id}/authors:
     get:
       tags:
-      - Book.authors
+      - Author
       summary: List Author attached to Book.authors
       operationId: list_book_authors
       responses:
@@ -190,7 +190,7 @@ paths:
       deprecated: false
     post:
       tags:
-      - Book.authors
+      - Author
       summary: Attach Author to Book.authors
       operationId: attach_book_authors
       requestBody:
@@ -235,7 +235,7 @@ paths:
   /books/{id}/authors/{author_id}:
     delete:
       tags:
-      - Book.authors
+      - Author
       summary: Detach Author from Book.authors
       operationId: detach_book_authors
       responses:

--- a/examples/petstore/openapi.yaml
+++ b/examples/petstore/openapi.yaml
@@ -507,7 +507,7 @@ paths:
   /owners/{id}/pets:
     get:
       tags:
-      - Owner.pets
+      - Pet
       summary: List Pet attached to Owner.pets
       operationId: list_owner_pets
       responses:
@@ -531,7 +531,7 @@ paths:
       deprecated: false
     post:
       tags:
-      - Owner.pets
+      - Pet
       summary: Attach Pet to Owner.pets
       operationId: attach_owner_pets
       requestBody:
@@ -576,7 +576,7 @@ paths:
   /owners/{id}/pets/{pet_id}:
     delete:
       tags:
-      - Owner.pets
+      - Pet
       summary: Detach Pet from Owner.pets
       operationId: detach_owner_pets
       responses:

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -201,6 +201,12 @@ class OpenAPIGenerator(Generator):
         # Reset the x-rdf-* maps; _build_openapi populates them as it walks the schema.
         self._x_rdf_class: dict[str, str] = {}
         self._x_rdf_property: dict[tuple[str, str], str] = {}
+        # Multi-level composition recursion happens inside
+        # `_add_composition_paths`; the stack tracks which composition
+        # targets are currently being emitted so a cyclic
+        # composition-of-composition chain (`A.bs[B].as[A]`) terminates
+        # cleanly instead of recursing forever.
+        self._composition_emission_stack: set[str] = set()
         # Resolved name of the schema referenced from non-2xx responses, or
         # None when error_schema is off. Cached per-build so each operation
         # builder doesn't re-resolve.
@@ -1334,7 +1340,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"List {_to_path_segment(class_name).replace('_', ' ')}",
             operationId=f"list_{_to_path_segment(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             parameters=self._make_query_params(cls),
             responses={
                 "200": Response(
@@ -1350,7 +1356,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"Create a {class_name}",
             operationId=f"create_{_to_snake_case(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             requestBody=RequestBody(
                 required=True,
                 content=self._content_for(ref, media_types),
@@ -1370,7 +1376,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"Get a {class_name}",
             operationId=f"get_{_to_snake_case(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             responses={
                 "200": Response(
                     description=f"{class_name} details",
@@ -1386,7 +1392,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"Update a {class_name}",
             operationId=f"update_{_to_snake_case(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             requestBody=RequestBody(
                 required=True,
                 content=self._content_for(ref, media_types),
@@ -1405,7 +1411,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"Delete a {class_name}",
             operationId=f"delete_{_to_snake_case(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             responses={
                 "204": Response(description=f"{class_name} deleted"),
                 "404": self._error_response("Not found"),
@@ -1428,7 +1434,7 @@ class OpenAPIGenerator(Generator):
         return Operation(
             summary=f"Patch a {class_name}",
             operationId=f"patch_{_to_snake_case(class_name)}",
-            tags=[class_name],
+            tags=[self._class_tag(class_name)],
             requestBody=RequestBody(
                 required=True,
                 content={
@@ -1560,6 +1566,21 @@ class OpenAPIGenerator(Generator):
         if override:
             return override.strip()
         return f"{_to_snake_case(class_name)}_id"
+
+    def _class_tag(self, class_name: str) -> str:
+        """OpenAPI ``tags`` value to use for a class's operations.
+
+        Defaults to the class name (current behaviour); the
+        ``openapi.tag`` class annotation overrides it. Composition- and
+        reference-derived nested operations call this with the *target*
+        class so all "Dataset" operations end up under one Swagger UI
+        group regardless of where in the URL hierarchy they emit.
+        """
+        cls = self.schemaview.get_class(class_name)
+        override = self._class_annotation(cls, "openapi.tag") if cls else None
+        if override:
+            return override.strip()
+        return class_name
 
     def _resolve_item_path_vars(
         self,
@@ -2082,7 +2103,7 @@ class OpenAPIGenerator(Generator):
         template: str,
         operations: list[str],
     ) -> dict[str, PathItem]:
-        """Emit a deep item path from a literal `openapi.path_template`.
+        """Emit a deep item path (and optional collection) from a literal `openapi.path_template`.
 
         The user-supplied template replaces the auto-derived chain. Each
         ``{name}`` placeholder must have a matching ``name:Class.slot``
@@ -2090,6 +2111,12 @@ class OpenAPIGenerator(Generator):
         the parameter schema (so typed parameters and RDF metadata still
         flow). Validates: placeholder set matches source-key set,
         every ``Class.slot`` resolves, no duplicates.
+
+        When the template ends with a ``/{name}`` segment, the collection
+        path (template minus that tail) is emitted by default with
+        ``list`` / ``create`` operations from ``operations``. Opt out
+        with ``openapi.path_template_collection: "false"`` for legacy
+        item-only URLs.
         """
         sv = self.schemaview
         sources_raw = self._class_annotation(cls, "openapi.path_param_sources") or ""
@@ -2117,7 +2144,9 @@ class OpenAPIGenerator(Generator):
                 f"Extra sources (not in template): {sorted(extra_sources)!r}."
             )
 
-        params: list[Parameter] = []
+        # Build a parameter for each placeholder, indexed by name so the
+        # collection-path emission can drop the leaf-id one.
+        params_by_name: dict[str, Parameter] = {}
         for name in unique_placeholders:
             src_class, src_slot = sources[name]
             if sv.get_class(src_class) is None:
@@ -2133,19 +2162,43 @@ class OpenAPIGenerator(Generator):
                     f"refers to unknown slot {src_class}.{src_slot!r} for "
                     f"parameter {name!r}."
                 )
-            params.append(
-                Parameter(
-                    name=name,
-                    param_in=ParameterLocation.PATH,
-                    required=True,
-                    param_schema=self._slot_to_schema(slot),
-                )
+            params_by_name[name] = Parameter(
+                name=name,
+                param_in=ParameterLocation.PATH,
+                required=True,
+                param_schema=self._slot_to_schema(slot),
             )
 
-        deep_item = PathItem(parameters=params)
+        deep_item = PathItem(parameters=[params_by_name[n] for n in unique_placeholders])
         self._attach_item_operations(deep_item, cls, class_name, operations)
+        deep_paths: dict[str, PathItem] = {template: deep_item}
 
-        deep_paths = {template: deep_item}
+        # Collection path: default-on when the template ends with a
+        # placeholder segment AND the class declares any of `list` /
+        # `create` in its operations. Opt-out with
+        # `openapi.path_template_collection: "false"`.
+        collection_opt_in = self._class_annotation(cls, "openapi.path_template_collection")
+        emit_collection = collection_opt_in is None or _is_truthy(collection_opt_in)
+        if emit_collection and template.endswith("}"):
+            # Strip the trailing `/{name}` segment.
+            tail_open = template.rfind("/{")
+            tail_name = template[tail_open + 2 : -1] if tail_open != -1 else None
+            if tail_name and tail_name in params_by_name:
+                collection_path = template[:tail_open]
+                if collection_path:  # don't emit the empty-prefix degenerate case
+                    collection_params = [
+                        params_by_name[n] for n in unique_placeholders if n != tail_name
+                    ]
+                    collection = PathItem(
+                        parameters=list(collection_params) if collection_params else None
+                    )
+                    if OP_LIST in operations:
+                        collection.get = self._make_list_operation(cls, class_name)
+                    if OP_CREATE in operations:
+                        collection.post = self._make_create_operation(cls, class_name)
+                    if collection.get is not None or collection.post is not None:
+                        deep_paths[collection_path] = collection
+
         self._suffix_operation_ids(deep_paths, "_via_template")
         return deep_paths
 
@@ -2159,11 +2212,20 @@ class OpenAPIGenerator(Generator):
         target_id_slot: SlotDefinition | None,
         parent_path_params: list[Parameter],
     ) -> None:
+        # Cycle protection — must come before any emission. Mutual
+        # composition (`A.bs[B].as[A]`) would otherwise recurse one
+        # extra hop and emit paths whose URL parameters repeat (e.g.
+        # `/as/{id}/bs/{b_id}/as/{a_id}/bs/{b_id}`). The stack is
+        # populated by the recursion below, so the *second* visit to
+        # an already-being-emitted target short-circuits before any
+        # paths are added.
+        if target_class_name in self._composition_emission_stack:
+            return
         target_cls = self.schemaview.get_class(target_class_name)
         media_types = self._get_media_types(target_cls)
         target_ref = Reference(ref=f"#/components/schemas/{target_class_name}")
         array_schema = Schema(type=DataType.ARRAY, items=target_ref)
-        op_tag = f"{parent_class_name}.{slot.name}"
+        op_tag = self._class_tag(target_class_name)
         slot_seg = slot.name
 
         collection = PathItem(parameters=list(parent_path_params))
@@ -2252,6 +2314,65 @@ class OpenAPIGenerator(Generator):
         )
         paths[item_path] = item
 
+        # Multi-level composition: when the composed target itself has
+        # `inlined: true` slots, recurse and emit deeper paths under
+        # this item URL. The cycle stack (checked at the top of this
+        # method) terminates mutual-composition graphs; references
+        # aren't recursed into because they already address the target
+        # as its own resource at the top level.
+        self._composition_emission_stack.add(target_class_name)
+        try:
+            self._recurse_composition_children(
+                paths, target_class_name, item_path, item_path_params
+            )
+        finally:
+            self._composition_emission_stack.discard(target_class_name)
+
+    def _recurse_composition_children(
+        self,
+        paths: dict,
+        target_class_name: str,
+        item_path: str,
+        item_path_params: list[Parameter],
+    ) -> None:
+        """Walk a composition target's own composition slots and emit deeper paths.
+
+        Only ``inlined: true`` (composition) children are recursed —
+        reference-shaped children address the target as its own
+        resource at the top level and don't need a deeper URL prefix.
+        Honours ``openapi.nested: "false"`` and profile exclusions.
+        """
+        sv = self.schemaview
+        target_cls = sv.get_class(target_class_name)
+        if target_cls is None:
+            return
+        for child_slot in self._induced_slots_iter(target_class_name):
+            if not child_slot.multivalued:
+                continue
+            if self._is_slot_excluded(child_slot):
+                continue
+            child_target = child_slot.range
+            if not child_target or sv.get_class(child_target) is None:
+                continue
+            nested_ann = self._get_slot_annotation(target_cls, child_slot.name, "openapi.nested")
+            if nested_ann is not None and not _is_truthy(nested_ann):
+                continue
+            if not self._is_composition(child_slot):
+                continue
+            child_target_id = self._identifier_slot(child_target)
+            child_collection_path = (
+                f"{item_path}/{self._render_slot_segment(target_cls, child_slot)}"
+            )
+            self._add_composition_paths(
+                paths,
+                child_collection_path,
+                target_class_name,
+                child_slot,
+                child_target,
+                child_target_id,
+                item_path_params,
+            )
+
     def _add_reference_paths(
         self,
         paths: dict,
@@ -2280,7 +2401,7 @@ class OpenAPIGenerator(Generator):
         link_ref = Reference(ref="#/components/schemas/ResourceLink")
         # Body accepts a single link or a batch — clients prefer batch.
         link_body_schema = Schema(oneOf=[link_ref, Schema(type=DataType.ARRAY, items=link_ref)])
-        op_tag = f"{parent_class_name}.{slot.name}"
+        op_tag = self._class_tag(target_class_name)
         slot_seg = slot.name
 
         collection = PathItem(parameters=list(parent_path_params))

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -490,6 +490,60 @@ classes:
     is_a: BaseResource
     annotations:
       openapi.resource: "true"
+
+  # --- Multi-level composition + openapi.tag (issue #44) ---
+  # Library composes BookEntry composes ChapterEntry. The composed
+  # targets are not resources in their own right; they have no flat
+  # path. The deeper composition chain emits naturally:
+  #   /libraries/{libraryId}/books            (collection)
+  #   /libraries/{libraryId}/books/{bookId}   (item)
+  #   /libraries/{libraryId}/books/{bookId}/chapters
+  #   /libraries/{libraryId}/books/{bookId}/chapters/{chapterId}
+  # Operations are tagged by `openapi.tag` (Library / Book / Chapter),
+  # not by class name (Library / BookEntry / ChapterEntry).
+  Library:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_id: libraryId
+      openapi.tag: Library
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      books:
+        range: BookEntry
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+
+  BookEntry:
+    annotations:
+      openapi.path_id: bookId
+      openapi.tag: Book
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      chapters:
+        range: ChapterEntry
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+
+  ChapterEntry:
+    annotations:
+      openapi.path_id: chapterId
+      openapi.tag: Chapter
+    attributes:
+      id:
+        identifier: true
+        range: string
+        required: true
+      title:
+        range: string
+
 enums:
   PersonStatus:
     description: Status of a person

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1671,6 +1671,142 @@ classes:
         )
 
 
+class TestCompositionAndTagEnhancements:
+    """Coverage for issue #44 — path_template collection ops, multi-level
+    composition chain, and the `openapi.tag` class annotation."""
+
+    # --- Enhancement 5: openapi.tag --------------------------------------
+
+    def test_openapi_tag_overrides_flat_class_name(self):
+        """Flat operations on a tagged class use `openapi.tag`, not the class name."""
+        spec = _generate()
+        # Library declares `openapi.tag: Library` (matches class name) —
+        # use BookEntry indirectly: its composition-derived ops should
+        # carry tag `Book`, not `BookEntry`.
+        list_book_op = spec["paths"]["/libraries/{libraryId}/books"]["get"]
+        assert list_book_op["tags"] == ["Book"]
+
+    def test_openapi_tag_inherits_from_target_in_composition(self):
+        """Composition-derived nested ops use the *target* class's tag, not the parent's."""
+        spec = _generate()
+        # /libraries/{id}/books/{id}/chapters → tagged Chapter (target),
+        # NOT Library (parent) and NOT BookEntry (intermediate class).
+        chapter_coll = spec["paths"]["/libraries/{libraryId}/books/{bookId}/chapters"]["get"]
+        assert chapter_coll["tags"] == ["Chapter"]
+
+    def test_openapi_tag_default_is_class_name(self):
+        """Without the annotation, the tag is still the class name (backward compat)."""
+        spec = _generate()
+        # Person has no `openapi.tag` set; tag stays "Person".
+        list_persons = spec["paths"]["/persons"]["get"]
+        assert list_persons["tags"] == ["Person"]
+
+    # --- Enhancement 2: path_template collection ops ---------------------
+
+    def test_path_template_emits_collection_alongside_item(self):
+        """When the template ends in `/{name}`, the collection path also emits."""
+        spec = _generate()
+        item = "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
+        coll = "/v2/catalogs/{cId}/resources/by-doi/{doi}"
+        assert item in spec["paths"]
+        assert coll in spec["paths"]
+
+    def test_path_template_collection_has_list_and_create(self):
+        """The templated collection emits list (GET) + create (POST)."""
+        spec = _generate()
+        coll = spec["paths"]["/v2/catalogs/{cId}/resources/by-doi/{doi}"]
+        assert "get" in coll
+        assert "post" in coll
+        # operationIds are suffixed `_via_template` for global uniqueness.
+        assert coll["get"]["operationId"].endswith("_via_template")
+        assert coll["post"]["operationId"].endswith("_via_template")
+
+    def test_path_template_collection_drops_leaf_id_param(self):
+        """The collection's path-parameter list excludes the stripped placeholder."""
+        spec = _generate()
+        coll = spec["paths"]["/v2/catalogs/{cId}/resources/by-doi/{doi}"]
+        names = {p["name"] for p in coll.get("parameters", [])}
+        assert names == {"cId", "doi"}  # `version` is the stripped tail
+
+    def test_path_template_collection_opt_out(self):
+        """`openapi.path_template_collection: "false"` suppresses the collection."""
+        spec = _generate_from_string("""
+id: https://example.org/template-no-coll
+name: tnc
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+  Item:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/legacy/items/{id}"
+      openapi.path_param_sources: "id:Item.id"
+      openapi.path_template_collection: "false"
+      openapi.nested_only: "true"
+    attributes:
+      id: { identifier: true, required: true }
+""")
+        assert "/legacy/items/{id}" in spec["paths"]
+        assert "/legacy/items" not in spec["paths"]
+
+    # --- Enhancement 3: multi-level composition chain --------------------
+
+    def test_multi_level_composition_emits_full_chain(self):
+        """Composition-of-composition emits collection + item at every level."""
+        spec = _generate()
+        for path in (
+            "/libraries/{libraryId}/books",
+            "/libraries/{libraryId}/books/{bookId}",
+            "/libraries/{libraryId}/books/{bookId}/chapters",
+            "/libraries/{libraryId}/books/{bookId}/chapters/{chapterId}",
+        ):
+            assert path in spec["paths"], f"missing deep composition path: {path}"
+
+    def test_multi_level_composition_intermediate_has_no_flat_path(self):
+        """Composed intermediates without `openapi.resource: true` don't get flat URLs."""
+        spec = _generate()
+        # BookEntry is composed under Library — no `/book_entries` flat path.
+        assert "/book_entries" not in spec["paths"]
+        assert "/books" not in spec["paths"]  # also no auto-pluralised flat
+
+    def test_multi_level_composition_cycle_protection(self):
+        """Mutual composition (`A.bs[B].as[A]`) terminates without infinite recursion."""
+        spec = _generate_from_string("""
+id: https://example.org/cycle
+name: cy
+default_range: string
+classes:
+  A:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      bs:
+        range: B
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+  B:
+    attributes:
+      id: { identifier: true, required: true }
+      as:
+        range: A
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+""")
+        # Generation completes — no stack overflow. The recursion
+        # walks one cycle around (A → B → A) so we get the cycle-back
+        # path /as/{id}/bs/{b_id}/as/{a_id}, but the SECOND cycle is
+        # short-circuited by the stack guard so no /…/bs/{b_id} suffix
+        # appears beyond that depth.
+        assert "/as/{id}/bs/{b_id}/as/{a_id}" in spec["paths"]
+        # No re-emission of B's collection beyond the first cycle.
+        assert not any(p.startswith("/as/{id}/bs/{b_id}/as/{a_id}/bs") for p in spec["paths"])
+
+
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 


### PR DESCRIPTION
Closes #44.

## Summary

Three enhancements driven by 1:1 matching against the existing DCAT3 catalog API. Bundled because they all touch the nested-path / operation-builder seams.

### `openapi.tag` — Swagger UI grouping

Class-level annotation overriding the operation `tags` value. Default is the class name (current behaviour). **Composition- and reference-derived nested operations now inherit the *target* class's tag** rather than the previous `Parent.slot` form, so all "Dataset" operations end up under one Swagger UI group regardless of where in the URL hierarchy they live.

```yaml
classes:
  FusionDataset:
    annotations:
      openapi.tag: Dataset
```

Visible diff in the committed examples: `Book.authors` → `Author`, `Owner.pets` → `Pet`.

### `openapi.path_template` now emits a collection path

When the template ends with a `/{name}` segment, the leaf is the item path; the segment is stripped to form the collection path, which gets `list` / `create` operations from the class's `openapi.operations`. Operation IDs still suffixed `_via_template`; the collection drops the leaf-id parameter from its path-parameter list. Opt out with the new `openapi.path_template_collection: "false"` for genuinely item-only legacy URLs.

```yaml
ResourceVersion:
  annotations:
    openapi.path_template: "/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}"
    openapi.path_param_sources: "cId:Catalog.id,doi:ResourceVersion.doi,version:ResourceVersion.version"
```

→
```
/v2/catalogs/{cId}/resources/by-doi/{doi}              (GET, POST)
/v2/catalogs/{cId}/resources/by-doi/{doi}/{version}    (GET, PUT, DELETE)
```

### Multi-level composition chain

`inlined: true` composition targets that have their own `inlined: true` slots now chain through every level. `Catalog.datasets[FusionDataset].distributions[FusionDistribution]` emits:

```
/catalogs/{catalogId}/datasets
/catalogs/{catalogId}/datasets/{datasetId}
/catalogs/{catalogId}/datasets/{datasetId}/distributions
/catalogs/{catalogId}/datasets/{datasetId}/distributions/{distributionId}
```

…without needing FusionDataset or FusionDistribution to be resources in their own right. Mutual composition (`A.bs[B].as[A]`) is cycle-protected: the stack-checked guard at the top of `_add_composition_paths` short-circuits before emitting any path whose URL would contain a duplicate parameter.

## Existing-schema impact

* `bookstore` / `petstore`: tag values for composition / reference operations change (`Book.authors` → `Author`, `Owner.pets` → `Pet`). Expected per the issue — composition-derived tags now inherit from the target.
* No other drift. Schemas without the new annotations regenerate the same path set as 0.6.1.
* `openapi.path_id` on composition targets was *already* honoured (verified at the start of #44); no change to that behaviour.

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 183 / 183 pass (10 new in `TestCompositionAndTagEnhancements`)
- [x] `ruff check` + `format --check` clean
- [x] `bash examples/generate.sh` — only the intended `Book.authors → Author` / `Owner.pets → Pet` tag changes
- [x] Tests cover: `openapi.tag` flat override, composition tag inheritance, default = class name, `path_template` collection emission, collection drops leaf-id param, opt-out via `path_template_collection: false`, multi-level composition emits all four levels, intermediates have no flat path, cycle protection terminates without duplicate-parameter URLs

## Out of scope

Enhancement 4 from the desktop session (`openapi.custom_operations` for non-CRUD endpoints like `PUT /{id}/status`, `POST /bulk`) — hand-author post-generation today; can be filed separately if there's appetite.

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_