### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## Unreleased
+## [0.7.0] — 2026-04-28
+
+DCAT3 1:1-match release. Three composition / tagging enhancements
+driven by 1:1 matching against the existing DCAT3 catalog API. The
+visible change in committed examples is the composition tag
+inheritance — operations under `Book.authors` are now tagged
+`Author` instead of `Book.authors`. Schemas without the new
+annotations get the same path *set* as 0.6.1 plus the new tag
+default.
 
 ### Added
 
@@ -353,6 +361,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.7.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.7.0
 [0.6.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.1
 [0.6.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.0
 [0.5.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.6.1"
+version = "0.7.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

Cuts v0.7.0. Single feature changeset since v0.6.1:

* **PR #45 (#44)** — three composition / tagging enhancements:
  * `openapi.tag` class annotation; composition-derived nested ops inherit from the target.
  * `openapi.path_template` now emits a collection path alongside the item path (opt-out via `openapi.path_template_collection: "false"`).
  * Multi-level composition chains via `inlined: true` recursion (cycle-protected).

Bumps:
* `pyproject.toml`: `0.6.1` → `0.7.0`
* `src/linkml_openapi/__init__.py`: `__version__ = "0.7.0"`
* `CHANGELOG.md`: promote `Unreleased` under `[0.7.0] — 2026-04-28`; add v0.7.0 anchor.

## Why a minor bump

* New annotations (`openapi.tag`, `openapi.path_template_collection`) — additive class-level API.
* **Visible behaviour change** in operation tags: composition / reference nested ops now inherit from the *target* class. The change is intended (per #44) but it does shift committed-example output (`bookstore` `Book.authors` → `Author`, `petstore` `Owner.pets` → `Pet`).
* Multi-level composition can emit new paths for any schema with `inlined: true` composition that goes more than one level deep — additive, but observable.
* The CHANGELOG header explicitly notes pre-1.0 minor bumps may carry visible behaviour changes.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/ -m "not e2e"` — 183 / 183 pass
- [x] `gen-openapi --version` reports `0.7.0`
- [ ] Merge → cut `v0.7.0` GitHub release → publish workflow uploads to PyPI

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_