### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## Unreleased
+## [0.8.0] — 2026-04-29
+
+Discriminator-completeness release. Polymorphic parent schemas now
+emit a `oneOf` array of subclass `$ref`s alongside the existing
+`discriminator` block — what Swagger UI and codegen tools (TS / Java /
+Spring) actually need to offer polymorphic selection at the call
+site. Schemas without a discriminator regenerate byte-identically.
 
 ### Added
 
@@ -396,6 +402,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.8.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.0
 [0.7.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.7.0
 [0.6.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.1
 [0.6.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.7.0"
+version = "0.8.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Summary

Cuts v0.8.0. Single feature changeset since v0.7.0:

* **PR #48 (#47)** — emit `oneOf` array of subclass `$ref`s alongside the `discriminator` block on every parent schema. Default keeps the parent's `properties`; `--flatten-inheritance` makes the parent `oneOf`-only.

Bumps:
* `pyproject.toml`: `0.7.0` → `0.8.0`
* `src/linkml_openapi/__init__.py`: `__version__ = "0.8.0"`
* `CHANGELOG.md`: promote `Unreleased` under `[0.8.0] — 2026-04-29`; add v0.8.0 anchor.

## Why a minor bump

* Visible behaviour change for any schema with a discriminator — every such parent now carries a new `oneOf` array.
* The shape change unblocks Swagger UI / openapi-generator polymorphic selection (the whole point of the issue).
* Schemas without discriminators (the committed `bookstore` / `petstore` / `minimal` examples) regenerate byte-identically.

## Test plan

- [x] `ruff check` + `format --check` clean
- [x] `pytest tests/ -m "not e2e"` — 187 / 187 pass
- [x] `gen-openapi --version` reports `0.8.0`
- [ ] Merge → cut `v0.8.0` GitHub release → publish workflow uploads to PyPI

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_