### PR TITLE
fix(discriminator): preserve type:object on parent under --flatten-inheritance (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [0.8.1] — 2026-04-29
+
+### Fixed
+
+- **`type: object` is preserved on discriminator parents under
+  `--flatten-inheritance`**
+  ([#50](https://github.com/jackhiggs/linkml-openapi/issues/50)). The
+  flatten branch added in 0.8.0 stripped ``type``, ``properties``,
+  ``required``, and ``additionalProperties`` on discriminator parents
+  on the rationale that subclasses inline the parent's slots under
+  flatten. That rationale was wrong — the parent is still a concrete
+  schema in its own right, and `openapi-generator`'s Spring server
+  library (and other codegens) skip generating a class when
+  ``type: object`` is missing, breaking the controller compile.
+  Polymorphism is orthogonal to whether the parent is a concrete
+  schema; ``type`` / ``properties`` / ``required`` are now preserved
+  alongside ``oneOf`` / ``discriminator`` regardless of the flatten
+  flag. The flag still affects subclass shapes (no ``allOf``
+  back-reference) — its actual job — but doesn't strip the parent's
+  own emission.
+
 ## [0.8.0] — 2026-04-29
 
 Discriminator-completeness release. Polymorphic parent schemas now
@@ -402,6 +423,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.8.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.1
 [0.8.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.0
 [0.7.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.7.0
 [0.6.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.8.0"
+version = "0.8.1"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1280,25 +1280,16 @@ class OpenAPIGenerator(Generator):
         # Spring) need to offer polymorphic selection. The discriminator
         # tells consumers how to *interpret* a payload; oneOf tells them
         # which subclasses are *possible*.
-        one_of_refs: list[Schema | Reference] = [Reference(ref=ref) for ref in mapping.values()]
-
-        if self.flatten_inheritance:
-            # Subclasses are self-contained under --flatten-inheritance,
-            # so the parent doesn't need to carry its own type /
-            # properties — the `oneOf` is the schema. Drop everything
-            # that would otherwise constrain shape; consumers walk the
-            # oneOf branches.
-            schema.oneOf = one_of_refs
-            schema.type = None
-            schema.properties = None
-            schema.required = None
-            schema.additionalProperties = None
-            return
-
-        # Default: keep the parent's own properties so subclasses can
-        # continue to use `allOf: [parent_ref, local]` and pick up the
-        # parent's slots through the ref. Add the `oneOf` alongside.
-        schema.oneOf = one_of_refs
+        #
+        # The parent's own shape (`type: object`, properties, required)
+        # is preserved in *both* flatten and non-flatten modes because
+        # the parent is a concrete schema in its own right — codegens
+        # use `type: object` as the signal to generate a class for it,
+        # and dropping it makes openapi-generator (Spring server, in
+        # particular) skip the parent class entirely. The
+        # `flatten_inheritance` flag affects subclass shapes (no
+        # ``allOf`` back-reference), not the parent's own emission.
+        schema.oneOf = [Reference(ref=ref) for ref in mapping.values()]
 
         # Locate or synthesise the discriminator field. With `is_a`
         # inheritance the local properties live under `allOf[1]`; for

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1972,17 +1972,27 @@ classes:
         assert "sku" in product["properties"]
         assert "kind" in product["required"]
 
-    def test_discriminator_flatten_makes_parent_oneof_only(self):
-        """With --flatten-inheritance, parent is `oneOf` + discriminator only."""
+    def test_discriminator_flatten_preserves_parent_type_and_properties(self):
+        """Flatten mode must keep `type: object` and parent properties (issue #50).
+
+        Codegens (openapi-generator's Spring server in particular) skip
+        generating a class for the parent when `type: object` is missing.
+        Polymorphism is orthogonal to whether the parent is a concrete
+        schema, so `type` / `properties` / `required` are preserved alongside
+        `oneOf` / `discriminator` regardless of the flatten flag.
+        """
         spec = _generate(flatten_inheritance=True)
         product = spec["components"]["schemas"]["Product"]
+        assert product.get("type") == "object"
+        assert "properties" in product
+        # Parent's own identifier slot survives.
+        assert "sku" in product["properties"]
+        # Discriminator field is added by `_inject_subclass_type_value`.
+        assert "kind" in product["properties"]
+        assert "kind" in product.get("required", [])
+        # And the polymorphic union is still emitted.
         assert "oneOf" in product
         assert "discriminator" in product
-        # No type/properties/required/additionalProperties on the parent.
-        assert "type" not in product
-        assert "properties" not in product
-        assert "required" not in product
-        assert "additionalProperties" not in product
 
     def test_discriminator_oneof_targets_match_mapping_targets(self):
         """Every `mapping` target appears as a `oneOf` $ref, no more no less."""


### PR DESCRIPTION
Closes #50.

## Bug

Under `--flatten-inheritance`, v0.8.0 strips `type: object`, `properties`, `required`, and `additionalProperties` from discriminator parents. openapi-generator's Spring server library (and other codegens) read this as abstract / interface and skip generating a Java class for the parent — the controller references `FusionDataService` and the build fails because no such class exists.

### Reproduction (current 0.8.0 output, flatten mode)

```yaml
Vehicle:
  oneOf: [...]
  discriminator: { ... }
  properties:
    vehicle_type: { ... }   # only the discriminator field — vin / make are gone
  required: [vehicle_type]
  # ← no type: object
```

### After this fix

```yaml
Vehicle:
  type: object              # ← back
  properties:
    vin: { ... }            # ← parent's own slots preserved
    make: { ... }
    vehicle_type: { ... }
  required: [vin, vehicle_type]
  oneOf: [...]
  discriminator: { ... }
  additionalProperties: false
```

## Root cause + fix

In #48 the flatten branch of `_inject_discriminator_on_parent` cleared the parent's shape on the rationale that subclasses inline parent slots under flatten so the parent didn't need its own representation. That rationale was wrong: codegens use `type: object` as the orthogonal "this is a concrete schema, generate a class" signal. Polymorphism (oneOf + discriminator) is layered *on top of* a concrete schema, not a replacement for it.

Drop the flatten branch entirely. The parent's shape comes from `_class_to_schema` and survives in all modes; `oneOf` and `discriminator` are *added* alongside. The `flatten_inheritance` flag continues to control subclass shapes (no `allOf` back-reference) — its real purpose — but doesn't touch the parent.

## Bumps

- `__version__`: `0.8.0` → `0.8.1`
- `pyproject.toml` version: `0.8.0` → `0.8.1`
- `CHANGELOG.md`: `[0.8.1] — 2026-04-29` patch entry under `Fixed`

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 187 / 187 pass
- [x] `ruff check` + `format --check` clean
- [x] `bash examples/generate.sh` — no drift
- [x] Updated `test_discriminator_flatten_*` to assert the corrected semantics: parent keeps `type: object`, parent's own properties (`sku`), and the synthesised discriminator field (`kind`) all together.
- [x] `gen-openapi --version` reports `0.8.1`

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_