### PR TITLE
fix(discriminator): exclude parent from its own oneOf and mapping (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [0.8.2] — 2026-04-29
+
+### Fixed
+
+- **Discriminator parent excluded from its own `oneOf` and
+  `discriminator.mapping`**
+  ([#52](https://github.com/jackhiggs/linkml-openapi/issues/52)). The
+  0.8.0 emission included the discriminator-root class itself in its
+  own `oneOf` array (and `discriminator.mapping`) whenever the root
+  wasn't marked ``abstract: true`` in LinkML. openapi-generator's
+  Spring server library reads that self-reference as cyclic
+  inheritance and fails the build. The discriminator parent is the
+  union *category*, never an *instance* of the union; the `oneOf`
+  array now contains only descendant `$ref`s, regardless of whether
+  the parent is `abstract: true` (LinkML's annotation) or just
+  conceptually-but-not-flagged-abstract (DCAT3-style schemas).
+  Behaviour for genuinely abstract parents (Animal / Product in the
+  fixture) is unchanged — they were already excluded by the existing
+  `cls.abstract` filter.
+
 ## [0.8.1] — 2026-04-29
 
 ### Fixed
@@ -423,6 +443,7 @@ feature; new CLI flags are summarised at the end.
 
 Initial public release.
 
+[0.8.2]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.2
 [0.8.1]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.1
 [0.8.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.8.0
 [0.7.0]: https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.8.1"
+version = "0.8.2"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1189,15 +1189,22 @@ class OpenAPIGenerator(Generator):
         parent_field = self._discriminator_field(parent_cls)
         return parent_field != field
 
-    def _concrete_descendants_including_self(self, class_name: str) -> list[str]:
-        """Concrete (non-abstract, non-mixin) descendants plus self if concrete.
+    def _concrete_descendants_excluding_self(self, class_name: str) -> list[str]:
+        """Concrete (non-abstract, non-mixin) descendants — never the root itself.
+
+        The discriminator root is the union *category*; subclasses are the
+        addressable *instances*. Whether the root is marked
+        ``abstract: true`` doesn't matter for this rule — the discriminator
+        semantics make it the union root by definition, so it must not
+        appear in its own ``oneOf`` array or ``discriminator.mapping``
+        (downstream codegens read the self-reference as cyclic inheritance).
 
         Mixins are excluded entirely from polymorphic mappings — they're
         trait composition, not subtyping.
         """
         sv = self.schemaview
         out: list[str] = []
-        for name in [class_name] + list(sv.class_descendants(class_name, reflexive=False)):
+        for name in sv.class_descendants(class_name, reflexive=False):
             cls = sv.get_class(name)
             if cls is None or cls.abstract or cls.mixin:
                 continue
@@ -1233,7 +1240,7 @@ class OpenAPIGenerator(Generator):
                 continue
             if not self._is_discriminator_root(cls, field):
                 continue
-            concrete = self._concrete_descendants_including_self(class_name)
+            concrete = self._concrete_descendants_excluding_self(class_name)
             if not concrete:
                 # Discriminator declared but nothing concrete to dispatch
                 # to — the parent is itself abstract and has no concrete

--- a/tests/fixtures/person.yaml
+++ b/tests/fixtures/person.yaml
@@ -182,6 +182,36 @@ classes:
       artist:
         range: string
 
+  # --- Discriminator on a NON-abstract parent (issue #52) ---
+  # Vehicle is a concrete LinkML class but is the union root of the
+  # discriminator group. The fix at #52 ensures Vehicle is excluded
+  # from its own oneOf / discriminator.mapping — codegens (Spring
+  # server) read parent self-references as cyclic inheritance.
+  Vehicle:
+    annotations:
+      openapi.discriminator: vehicle_type
+    attributes:
+      vin:
+        identifier: true
+        range: string
+        required: true
+
+  Car:
+    is_a: Vehicle
+    annotations:
+      openapi.type_value: car
+    attributes:
+      doors:
+        range: integer
+
+  Truck:
+    is_a: Vehicle
+    annotations:
+      openapi.type_value: truck
+    attributes:
+      payload_tons:
+        range: float
+
   # --- Inverse-direction nested paths (issue #19) ---
   # Article.reviewers declares `inverse: Reviewer.articles` — Reviewer
   # has no explicit `articles` slot, so the generator synthesises the

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2002,6 +2002,50 @@ classes:
         oneof_targets = {entry["$ref"] for entry in product["oneOf"]}
         assert mapping_targets == oneof_targets
 
+    # --- Non-abstract discriminator parent (issue #52) -----------------
+
+    def test_non_abstract_parent_excluded_from_oneof(self):
+        """A non-abstract discriminator parent must not self-ref in its `oneOf`."""
+        spec = _generate()
+        vehicle = spec["components"]["schemas"]["Vehicle"]
+        oneof_refs = {entry["$ref"] for entry in vehicle["oneOf"]}
+        assert "#/components/schemas/Vehicle" not in oneof_refs
+        assert oneof_refs == {
+            "#/components/schemas/Car",
+            "#/components/schemas/Truck",
+        }
+
+    def test_non_abstract_parent_excluded_from_mapping(self):
+        """The discriminator mapping must not key on the parent class itself."""
+        spec = _generate()
+        vehicle = spec["components"]["schemas"]["Vehicle"]
+        mapping = vehicle["discriminator"]["mapping"]
+        # The parent's class-name default ("Vehicle") shouldn't be a key.
+        assert "Vehicle" not in mapping
+        # Concrete subclasses are present with their explicit type_values.
+        assert mapping == {
+            "car": "#/components/schemas/Car",
+            "truck": "#/components/schemas/Truck",
+        }
+
+    def test_abstract_parent_unchanged(self):
+        """Abstract parents (Animal, Product) still produce the right group."""
+        spec = _generate()
+        # Animal uses `designates_type: true`; Dog/Cat are auto-mapped.
+        animal = spec["components"]["schemas"]["Animal"]
+        animal_targets = set(animal["discriminator"]["mapping"].values())
+        assert animal_targets == {
+            "#/components/schemas/Dog",
+            "#/components/schemas/Cat",
+        }
+        # Product uses `openapi.discriminator` + per-subclass `openapi.type_value`.
+        product = spec["components"]["schemas"]["Product"]
+        product_targets = set(product["discriminator"]["mapping"].values())
+        assert product_targets == {
+            "#/components/schemas/Book",
+            "#/components/schemas/Vinyl",
+        }
+
 
 class TestProfiles:
     """Coverage for issue #17 — multi-view profile filtering."""


### PR DESCRIPTION
Closes #52.

## Bug

The 0.8.0 / 0.8.1 emission includes the discriminator root in its own `oneOf` array and `discriminator.mapping` whenever the root isn't marked `abstract: true` in LinkML. openapi-generator's Spring server library reads that self-reference as cyclic inheritance and fails the build.

### Reproduction (current 0.8.1 output for a non-abstract parent)

```yaml
Vehicle:
  type: object
  oneOf:
    - $ref: '#/components/schemas/Vehicle'   # ← self-ref, cycle
    - $ref: '#/components/schemas/Car'
    - $ref: '#/components/schemas/Truck'
  discriminator:
    propertyName: vehicle_type
    mapping:
      Vehicle: '#/components/schemas/Vehicle'   # ← self-ref here too
      car:     '#/components/schemas/Car'
      truck:   '#/components/schemas/Truck'
```

### After this fix

```yaml
Vehicle:
  type: object
  oneOf:
    - $ref: '#/components/schemas/Car'
    - $ref: '#/components/schemas/Truck'
  discriminator:
    propertyName: vehicle_type
    mapping:
      car:   '#/components/schemas/Car'
      truck: '#/components/schemas/Truck'
```

## Root cause + fix

`_concrete_descendants_including_self` iterated `[self] + descendants` and only filtered self out via the `cls.abstract or cls.mixin` check. For non-abstract parents (the DCAT3 case, the user's Vehicle reproduction), self stayed in the list and got mapped under its class-name default.

Replace with `_concrete_descendants_excluding_self`: iterate descendants only. The `cls.abstract or cls.mixin` filter still applies to descendants — an abstract intermediate class in a deeper inheritance chain still gets filtered out — but the root itself is never visited.

## What stays the same

* Abstract parents (`Animal`, `Product` in the fixture) produce the same group as before — they were already excluded by the now-redundant self check.
* Descendants of any kind (concrete) are still emitted with the same `mapping` keys.
* `bookstore` / `petstore` / `minimal` examples have no discriminator parents → no drift.

## Bumps

* `__version__`: `0.8.1` → `0.8.2`
* CHANGELOG: `[0.8.2] — 2026-04-29` patch entry under `Fixed`

## Test plan

- [x] `pytest tests/ -m "not e2e"` — 190 / 190 pass (3 new in `TestDiscriminator` covering non-abstract parent excluded from oneOf, excluded from mapping, plus a regression assertion that abstract parents still group correctly)
- [x] `ruff check` + `format --check` clean
- [x] `bash examples/generate.sh` — no drift
- [x] `gen-openapi --version` reports `0.8.2`
- [x] Manual reproduction (the user's Vehicle/Car/Truck schema) confirms `Vehicle.oneOf` no longer self-refs

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_