### PR TITLE
feat: post-processors framework, name-mappings, dcat3-demo + spring-rdf-runtime

### DIFF
--- a/examples/bookstore/openapi.yaml
+++ b/examples/bookstore/openapi.yaml
@@ -556,7 +556,8 @@ components:
             minimum: 1
           authors:
             items:
-              $ref: '#/components/schemas/Author'
+              type: string
+              format: uri
             type: array
             description: Authors of the book
         additionalProperties: false

--- a/examples/dcat3-demo/.gitignore
+++ b/examples/dcat3-demo/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+.idea/
+.vscode/

--- a/examples/dcat3-demo/pom.xml
+++ b/examples/dcat3-demo/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.example</groupId>
+    <artifactId>dcat3-demo</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>DCAT3 OpenAPI roundtrip demo</name>
+    <description>
+        Generates Spring server interfaces from the DCAT3 OpenAPI spec
+        produced by linkml-openapi, then serves a runtime Swagger UI via
+        springdoc so the round-trip can be inspected against the original.
+    </description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.0</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <openapi-generator.version>7.10.0</openapi-generator.version>
+        <springdoc.version>2.7.0</springdoc.version>
+        <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
+        <swagger.annotations.version>2.2.27</swagger.annotations.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- springdoc serves /v3/api-docs and /swagger-ui from the live app -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- Annotations / API surface used by the generated server stubs -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>${swagger.annotations.version}</version>
+        </dependency>
+
+        <!-- Spec-driven RDF serdes: JSON-LD / Turtle / RDF/XML
+             HttpMessageConverters that read the sidecar openapi.yaml at
+             startup and walk DTOs reflectively against
+             x-rdf-class / x-rdf-property. -->
+        <dependency>
+            <groupId>io.linkmlspring</groupId>
+            <artifactId>spring-rdf</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              Run gen-spring-server during generate-sources so the Java
+              source tree + sidecar OpenAPI spec land under
+              target/generated-sources/openapi (gitignored, regenerated
+              every build). Hand-written code under src/main/java
+              (Application.java, StubControllers.java) lives alongside.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>gen-spring-server</id>
+                        <phase>generate-sources</phase>
+                        <goals><goal>exec</goal></goals>
+                        <configuration>
+                            <executable>uv</executable>
+                            <workingDirectory>${project.basedir}/../..</workingDirectory>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>gen-spring-server</argument>
+                                <argument>${project.basedir}/../../tests/fixtures/dcat3.yaml</argument>
+                                <argument>--output</argument>
+                                <argument>${project.build.directory}/generated-sources/openapi/java</argument>
+                                <argument>--package</argument>
+                                <argument>io.example.dcat</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+              Add the generated sources + resources to Maven's
+              compile / resource paths so javac and Spring Boot find
+              them without committing them to src/.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-source</id>
+                        <phase>generate-sources</phase>
+                        <goals><goal>add-source</goal></goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/openapi/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-generated-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals><goal>add-resource</goal></goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/openapi/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/dcat3-demo/src/main/java/io/example/dcat/Application.java
+++ b/examples/dcat3-demo/src/main/java/io/example/dcat/Application.java
@@ -1,0 +1,11 @@
+package io.example.dcat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/examples/dcat3-demo/src/main/java/io/example/dcat/StubControllers.java
+++ b/examples/dcat3-demo/src/main/java/io/example/dcat/StubControllers.java
@@ -1,0 +1,320 @@
+package io.example.dcat;
+
+import io.example.dcat.api.AgentApi;
+import io.example.dcat.api.CatalogApi;
+import io.example.dcat.api.CatalogRecordApi;
+import io.example.dcat.api.DataServiceApi;
+import io.example.dcat.api.DatasetApi;
+import io.example.dcat.api.DatasetSeriesApi;
+import io.example.dcat.api.DistributionApi;
+import io.example.dcat.model.Agent;
+import io.example.dcat.model.Catalog;
+import io.example.dcat.model.CatalogRecord;
+import io.example.dcat.model.DataService;
+import io.example.dcat.model.Dataset;
+import io.example.dcat.model.DatasetSeries;
+import io.example.dcat.model.Distribution;
+import io.example.dcat.store.InMemoryStore;
+import io.example.dcat.store.Stores;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Concrete @RestController beans backing the generated *Api
+ * interfaces with the in-memory {@link Stores} so the demo serves
+ * actual DCAT-3 data — list / read / create / update / delete on
+ * every top-level resource.
+ *
+ * <p>RDF content negotiation flows through transparently: the
+ * controllers return Java DTOs; the spec-driven
+ * {@link io.linkmlspring.rdf.RdfMapper} marshals them to Turtle /
+ * JSON-LD / RDF/XML based on the {@code Accept} header. The
+ * controllers know nothing about RDF.
+ *
+ * <p>Nested CRUD and attach/detach paths still 501 — those
+ * relationship operations are out of scope for the seed-data
+ * demo.
+ */
+@Configuration
+public class StubControllers {
+
+    /**
+     * DCAT resources are addressed by full IRI (the URL is the
+     * identity). The Spring path parameter receives just the URL
+     * suffix (e.g. {@code city-data}); we prepend a base URI to
+     * build the full IRI before the store lookup. Hardcoded here
+     * for demo simplicity — a real service would pull this from
+     * configuration or the request's host header.
+     */
+    private static final String BASE = "https://example.org/";
+
+    private static String iri(String type, String id) {
+        return BASE + type + "/" + id;
+    }
+
+    private static <T> ResponseEntity<T> readOr404(
+            InMemoryStore<T> store, String fullId) {
+        return store.get(fullId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    private static <T> ResponseEntity<Void> deleteOr404(
+            InMemoryStore<T> store, String fullId) {
+        return store.remove(fullId)
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+
+    // -----------------------------------------------------------------
+
+    @RestController
+    public static class CatalogController implements CatalogApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<Catalog>> listCatalogs(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(stores.catalogs.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<Catalog> getCatalog(String id) {
+            return readOr404(stores.catalogs, iri("catalogs", id));
+        }
+
+        @Override
+        public ResponseEntity<Catalog> createCatalog(Catalog body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.catalogs.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Catalog> updateCatalog(
+                String id, Catalog body) {
+            body.setId(iri("catalogs", id));
+            return ResponseEntity.ok(stores.catalogs.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteCatalog(String id) {
+            return deleteOr404(stores.catalogs, iri("catalogs", id));
+        }
+    }
+
+    @RestController
+    public static class DatasetController implements DatasetApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<Dataset>> listDatasets(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(stores.datasets.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<Dataset> getDataset(String id) {
+            return readOr404(stores.datasets, iri("datasets", id));
+        }
+
+        @Override
+        public ResponseEntity<Dataset> createDataset(Dataset body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.datasets.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Dataset> updateDataset(
+                String id, Dataset body) {
+            body.setId(iri("datasets", id));
+            return ResponseEntity.ok(stores.datasets.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteDataset(String id) {
+            return deleteOr404(stores.datasets, iri("datasets", id));
+        }
+    }
+
+    @RestController
+    public static class DatasetSeriesController implements DatasetSeriesApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<DatasetSeries>> listDatasetSeriess(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(
+                    stores.datasetSeries.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<DatasetSeries> getDatasetSeries(String id) {
+            return readOr404(stores.datasetSeries, iri("dataset_series", id));
+        }
+
+        @Override
+        public ResponseEntity<DatasetSeries> createDatasetSeries(
+                DatasetSeries body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.datasetSeries.put(body));
+        }
+
+        @Override
+        public ResponseEntity<DatasetSeries> updateDatasetSeries(
+                String id, DatasetSeries body) {
+            body.setId(iri("dataset_series", id));
+            return ResponseEntity.ok(stores.datasetSeries.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteDatasetSeries(String id) {
+            return deleteOr404(stores.datasetSeries, iri("dataset_series", id));
+        }
+    }
+
+    @RestController
+    public static class DataServiceController implements DataServiceApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<DataService>> listDataServices(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(
+                    stores.dataServices.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<DataService> getDataService(String id) {
+            return readOr404(stores.dataServices, iri("data_services", id));
+        }
+
+        @Override
+        public ResponseEntity<DataService> createDataService(
+                DataService body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.dataServices.put(body));
+        }
+
+        @Override
+        public ResponseEntity<DataService> updateDataService(
+                String id, DataService body) {
+            body.setId(iri("data_services", id));
+            return ResponseEntity.ok(stores.dataServices.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteDataService(String id) {
+            return deleteOr404(stores.dataServices, iri("data_services", id));
+        }
+    }
+
+    @RestController
+    public static class DistributionController implements DistributionApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<Distribution>> listDistributions(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(
+                    stores.distributions.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<Distribution> getDistribution(String id) {
+            return readOr404(stores.distributions, iri("distributions", id));
+        }
+
+        @Override
+        public ResponseEntity<Distribution> createDistribution(
+                Distribution body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.distributions.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Distribution> updateDistribution(
+                String id, Distribution body) {
+            body.setId(iri("distributions", id));
+            return ResponseEntity.ok(stores.distributions.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteDistribution(String id) {
+            return deleteOr404(stores.distributions, iri("distributions", id));
+        }
+    }
+
+    @RestController
+    public static class CatalogRecordController implements CatalogRecordApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<CatalogRecord>> listCatalogRecords(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(
+                    stores.catalogRecords.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<CatalogRecord> getCatalogRecord(String id) {
+            return readOr404(stores.catalogRecords, iri("catalog_records", id));
+        }
+
+        @Override
+        public ResponseEntity<CatalogRecord> createCatalogRecord(
+                CatalogRecord body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.catalogRecords.put(body));
+        }
+
+        @Override
+        public ResponseEntity<CatalogRecord> updateCatalogRecord(
+                String id, CatalogRecord body) {
+            body.setId(iri("catalog_records", id));
+            return ResponseEntity.ok(stores.catalogRecords.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteCatalogRecord(String id) {
+            return deleteOr404(stores.catalogRecords, iri("catalog_records", id));
+        }
+    }
+
+    @RestController
+    public static class AgentController implements AgentApi {
+        @Autowired private Stores stores;
+
+        @Override
+        public ResponseEntity<List<Agent>> listAgents(
+                Integer limit, Integer offset) {
+            return ResponseEntity.ok(stores.agents.list(limit, offset));
+        }
+
+        @Override
+        public ResponseEntity<Agent> getAgent(String id) {
+            return readOr404(stores.agents, iri("agents", id));
+        }
+
+        @Override
+        public ResponseEntity<Agent> createAgent(Agent body) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(stores.agents.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Agent> updateAgent(
+                String id, Agent body) {
+            body.setId(iri("agents", id));
+            return ResponseEntity.ok(stores.agents.put(body));
+        }
+
+        @Override
+        public ResponseEntity<Void> deleteAgent(String id) {
+            return deleteOr404(stores.agents, iri("agents", id));
+        }
+    }
+}

--- a/examples/dcat3-demo/src/main/java/io/example/dcat/store/InMemoryStore.java
+++ b/examples/dcat3-demo/src/main/java/io/example/dcat/store/InMemoryStore.java
@@ -1,0 +1,58 @@
+package io.example.dcat.store;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Tiny per-class in-memory CRUD store for the demo. Not production —
+ * no persistence, no transactions, no concurrency guarantees beyond
+ * {@link ConcurrentHashMap} atomicity. Lets the controllers serve
+ * real DCAT-3 data so the spec-driven RDF round-trip can be observed
+ * end-to-end (POST a Turtle Catalog, GET it back as JSON-LD).
+ *
+ * <p>Each {@code InMemoryStore<T>} is keyed by the resource's IRI
+ * (the value of the DTO's {@code id} field). The {@code idGetter}
+ * lambda extracts that key — Java DTOs from the linkml-spring
+ * generator name the field {@code id} consistently, but using a
+ * lambda keeps the store reusable for any DTO shape.
+ */
+public class InMemoryStore<T> {
+
+    private final Map<String, T> byId = new ConcurrentHashMap<>();
+    private final Function<T, String> idGetter;
+
+    public InMemoryStore(Function<T, String> idGetter) {
+        this.idGetter = idGetter;
+    }
+
+    public List<T> list(int limit, int offset) {
+        // Stable ordering by IRI so paging is deterministic across
+        // requests. Real services would page over a sorted index.
+        List<T> all = new ArrayList<>(byId.values());
+        all.sort((a, b) -> idGetter.apply(a).compareTo(idGetter.apply(b)));
+        int start = Math.min(Math.max(offset, 0), all.size());
+        int end = Math.min(start + Math.max(limit, 0), all.size());
+        return all.subList(start, end);
+    }
+
+    public Optional<T> get(String id) {
+        return Optional.ofNullable(byId.get(id));
+    }
+
+    public T put(T item) {
+        byId.put(idGetter.apply(item), item);
+        return item;
+    }
+
+    public boolean remove(String id) {
+        return byId.remove(id) != null;
+    }
+
+    public int size() {
+        return byId.size();
+    }
+}

--- a/examples/dcat3-demo/src/main/java/io/example/dcat/store/Stores.java
+++ b/examples/dcat3-demo/src/main/java/io/example/dcat/store/Stores.java
@@ -1,0 +1,221 @@
+package io.example.dcat.store;
+
+import io.example.dcat.model.Agent;
+import io.example.dcat.model.Catalog;
+import io.example.dcat.model.CatalogRecord;
+import io.example.dcat.model.DataService;
+import io.example.dcat.model.Dataset;
+import io.example.dcat.model.DatasetSeries;
+import io.example.dcat.model.Distribution;
+import jakarta.annotation.PostConstruct;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring-managed registry of one {@link InMemoryStore} per resource
+ * type, seeded at startup with a small but interconnected DCAT-3
+ * dataset so the live demo is browsable rather than empty.
+ *
+ * <p>Seed shape: one root Catalog ("city-data"), two Datasets
+ * (transit-2024 and budget-2024 — one with two embedded
+ * Distributions, one in a DatasetSeries), one DataService, two
+ * Agents (publisher + a creator), one CatalogRecord, one
+ * DatasetSeries (annual-budgets). Cross-references use absolute
+ * IRIs so RDF/XML pretty-print works.
+ */
+@Component
+public class Stores {
+
+    public final InMemoryStore<Catalog> catalogs =
+            new InMemoryStore<>(Catalog::getId);
+    public final InMemoryStore<Dataset> datasets =
+            new InMemoryStore<>(Dataset::getId);
+    public final InMemoryStore<DatasetSeries> datasetSeries =
+            new InMemoryStore<>(DatasetSeries::getId);
+    public final InMemoryStore<DataService> dataServices =
+            new InMemoryStore<>(DataService::getId);
+    public final InMemoryStore<Distribution> distributions =
+            new InMemoryStore<>(Distribution::getId);
+    public final InMemoryStore<CatalogRecord> catalogRecords =
+            new InMemoryStore<>(CatalogRecord::getId);
+    public final InMemoryStore<Agent> agents =
+            new InMemoryStore<>(Agent::getId);
+
+    @PostConstruct
+    public void seed() {
+        // --- Agents ---
+        Agent cityDataOffice = new Agent();
+        cityDataOffice.setId(
+                "https://example.org/agents/city-data-office");
+        cityDataOffice.setName("City Data Office");
+        cityDataOffice.setHomepage(URI.create(
+                "https://city.example.org/data-office"));
+        cityDataOffice.setMbox(URI.create(
+                "mailto:data@city.example.org"));
+        agents.put(cityDataOffice);
+
+        Agent transitAgency = new Agent();
+        transitAgency.setId(
+                "https://example.org/agents/transit-agency");
+        transitAgency.setName("Metropolitan Transit Agency");
+        transitAgency.setHomepage(URI.create(
+                "https://transit.example.org"));
+        agents.put(transitAgency);
+
+        // --- DatasetSeries ---
+        DatasetSeries annualBudgets = new DatasetSeries();
+        annualBudgets.setId(
+                "https://example.org/dataset_series/annual-budgets");
+        annualBudgets.setTitle("Annual Budget Series");
+        annualBudgets.setDescription(
+                "Yearly publication of the city's enacted budget,"
+                        + " 2018-present.");
+        annualBudgets.setIssued(
+                OffsetDateTime.parse("2018-01-01T00:00:00Z"));
+        annualBudgets.setPublisher(URI.create(
+                "https://example.org/agents/city-data-office"));
+        datasetSeries.put(annualBudgets);
+
+        // --- DataService ---
+        DataService transitApi = new DataService();
+        transitApi.setId(
+                "https://example.org/data_services/transit-api");
+        transitApi.setTitle("Transit Real-time API");
+        transitApi.setDescription(
+                "GTFS-realtime feed with vehicle positions,"
+                        + " trip updates, and service alerts.");
+        transitApi.setEndpointURL(URI.create(
+                "https://transit.example.org/api/v1"));
+        transitApi.setEndpointDescription(URI.create(
+                "https://transit.example.org/api/v1/openapi.yaml"));
+        transitApi.setServesDataset(List.of(URI.create(
+                "https://example.org/datasets/transit-2024")));
+        transitApi.setPublisher(URI.create(
+                "https://example.org/agents/transit-agency"));
+        dataServices.put(transitApi);
+
+        // --- Distributions (embedded under Dataset, but also stored
+        //     standalone so /distributions endpoints work) ---
+        Distribution transitGtfsZip = new Distribution();
+        transitGtfsZip.setId(
+                "https://example.org/distributions/transit-2024-gtfs");
+        transitGtfsZip.setTitle("GTFS schedule (zipped)");
+        transitGtfsZip.setDescription(
+                "Static schedule data in GTFS format, "
+                        + "ZIP-packaged.");
+        transitGtfsZip.setAccessURL(URI.create(
+                "https://transit.example.org/gtfs/2024.zip"));
+        transitGtfsZip.setDownloadURL(URI.create(
+                "https://transit.example.org/gtfs/2024.zip"));
+        transitGtfsZip.setMediaType(URI.create(
+                "https://www.iana.org/assignments/media-types/application/zip"));
+        transitGtfsZip.setByteSize(8_452_096L);
+        transitGtfsZip.setLicense(URI.create(
+                "https://creativecommons.org/publicdomain/zero/1.0/"));
+        distributions.put(transitGtfsZip);
+
+        Distribution transitGtfsCsv = new Distribution();
+        transitGtfsCsv.setId(
+                "https://example.org/distributions/transit-2024-csv");
+        transitGtfsCsv.setTitle("GTFS schedule (CSV bundle)");
+        transitGtfsCsv.setAccessURL(URI.create(
+                "https://transit.example.org/gtfs/2024-csv/"));
+        transitGtfsCsv.setMediaType(URI.create(
+                "https://www.iana.org/assignments/media-types/text/csv"));
+        transitGtfsCsv.setByteSize(24_117_248L);
+        distributions.put(transitGtfsCsv);
+
+        Distribution budgetCsv = new Distribution();
+        budgetCsv.setId(
+                "https://example.org/distributions/budget-2024-csv");
+        budgetCsv.setTitle("Enacted budget — line items (CSV)");
+        budgetCsv.setAccessURL(URI.create(
+                "https://city.example.org/budget/2024.csv"));
+        budgetCsv.setMediaType(URI.create(
+                "https://www.iana.org/assignments/media-types/text/csv"));
+        budgetCsv.setByteSize(512_000L);
+        budgetCsv.setLicense(URI.create(
+                "https://creativecommons.org/licenses/by/4.0/"));
+        distributions.put(budgetCsv);
+
+        // --- Datasets ---
+        Dataset transit = new Dataset();
+        transit.setId("https://example.org/datasets/transit-2024");
+        transit.setTitle("Transit schedule 2024");
+        transit.setDescription(
+                "Bus, rail, and ferry schedules for the city's "
+                        + "transit network, calendar year 2024.");
+        transit.setIssued(
+                OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+        transit.setModified(
+                OffsetDateTime.parse("2024-12-15T00:00:00Z"));
+        transit.setKeyword(List.of(
+                "transit", "schedule", "gtfs", "public-transport"));
+        transit.setLicense(URI.create(
+                "https://creativecommons.org/publicdomain/zero/1.0/"));
+        transit.setPublisher(URI.create(
+                "https://example.org/agents/transit-agency"));
+        transit.setDistribution(List.of(transitGtfsZip, transitGtfsCsv));
+        datasets.put(transit);
+
+        Dataset budget = new Dataset();
+        budget.setId("https://example.org/datasets/budget-2024");
+        budget.setTitle("Enacted budget 2024");
+        budget.setDescription(
+                "Line-item enacted budget for fiscal year 2024, "
+                        + "all city departments.");
+        budget.setIssued(
+                OffsetDateTime.parse("2024-07-01T00:00:00Z"));
+        budget.setKeyword(List.of("budget", "finance", "fiscal-2024"));
+        budget.setLicense(URI.create(
+                "https://creativecommons.org/licenses/by/4.0/"));
+        budget.setPublisher(URI.create(
+                "https://example.org/agents/city-data-office"));
+        budget.setInSeries(List.of(URI.create(
+                "https://example.org/dataset_series/annual-budgets")));
+        budget.setDistribution(List.of(budgetCsv));
+        datasets.put(budget);
+
+        // --- Catalog ---
+        Catalog cityData = new Catalog();
+        cityData.setId("https://example.org/catalogs/city-data");
+        cityData.setTitle("City Open Data Portal");
+        cityData.setDescription(
+                "A curated index of open datasets and data services "
+                        + "published by city departments.");
+        cityData.setIssued(
+                OffsetDateTime.parse("2018-01-15T00:00:00Z"));
+        cityData.setModified(OffsetDateTime.now());
+        cityData.setKeyword(List.of(
+                "open-data", "government", "civic"));
+        cityData.setLandingPage(URI.create(
+                "https://city.example.org/data"));
+        cityData.setLicense(URI.create(
+                "https://creativecommons.org/publicdomain/zero/1.0/"));
+        cityData.setPublisher(URI.create(
+                "https://example.org/agents/city-data-office"));
+        cityData.setDataset(List.of(
+                URI.create("https://example.org/datasets/transit-2024"),
+                URI.create("https://example.org/datasets/budget-2024")));
+        cityData.setService(List.of(URI.create(
+                "https://example.org/data_services/transit-api")));
+        cityData.setHomepage(URI.create(
+                "https://city.example.org/data"));
+        catalogs.put(cityData);
+
+        // --- CatalogRecord ---
+        CatalogRecord transitRecord = new CatalogRecord();
+        transitRecord.setId(
+                "https://example.org/catalog_records/transit-2024");
+        transitRecord.setTitle(
+                "Catalog registration: transit schedule 2024");
+        transitRecord.setPrimaryTopic(URI.create(
+                "https://example.org/datasets/transit-2024"));
+        transitRecord.setListingDate(
+                OffsetDateTime.parse("2024-01-05T00:00:00Z"));
+        transitRecord.setModificationDate(OffsetDateTime.now());
+        catalogRecords.put(transitRecord);
+    }
+}

--- a/examples/dcat3-demo/src/main/resources/application.properties
+++ b/examples/dcat3-demo/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+server.port=8080
+
+# Where springdoc serves the live OpenAPI spec / Swagger UI
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.display-request-duration=true
+
+# Serve the spec as OpenAPI 3.1 so $ref siblings are legal — without
+# this the x-rdf-property extension on single-valued composition
+# fields (Dataset.spatial, Dataset.temporal, Distribution.checksum)
+# gets stripped because OpenAPI 3.0 disallows siblings next to a $ref.
+springdoc.api-docs.version=OPENAPI_3_1

--- a/examples/dcat3-demo/src/main/resources/static/redoc.html
+++ b/examples/dcat3-demo/src/main/resources/static/redoc.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DCAT-3 — Redoc</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+  <!--
+    Loads the live OpenAPI spec served by springdoc at /v3/api-docs and
+    renders it with Redoc. Compare with /swagger-ui.html for the same
+    spec under Swagger UI's renderer; Redoc handles allOf-based
+    inheritance more cleanly (no inherited-enum bleed-through under
+    subclasses' Models view).
+  -->
+  <redoc spec-url="/v3/api-docs"
+         expand-responses="200"
+         hide-loading></redoc>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+</body>
+</html>

--- a/examples/petstore/openapi.yaml
+++ b/examples/petstore/openapi.yaml
@@ -656,7 +656,8 @@ components:
           pattern: ^\S+@\S+\.\S+$
         pets:
           items:
-            $ref: '#/components/schemas/Pet'
+            type: string
+            format: uri
           type: array
           description: Pets owned by this person
       additionalProperties: false

--- a/examples/spring-rdf-runtime/.gitignore
+++ b/examples/spring-rdf-runtime/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+.idea/
+.vscode/

--- a/examples/spring-rdf-runtime/pom.xml
+++ b/examples/spring-rdf-runtime/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.linkmlspring</groupId>
+    <artifactId>spring-rdf</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>linkml-spring RDF runtime</name>
+    <description>
+        Spring HttpMessageConverters that serialise/deserialise Java
+        DTOs as JSON-LD, Turtle, and RDF/XML, driven by the
+        OpenAPI spec's x-rdf-class / x-rdf-property extensions. No
+        per-DTO annotations required — the spec is the source of
+        truth, the runtime walks it at startup and uses reflection
+        to map fields to RDF predicates.
+    </description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-boot.version>3.4.0</spring-boot.version>
+        <jena.version>5.2.0</jena.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Apache Jena — RDF model + parsers + writers for all three
+             formats (Turtle, JSON-LD, RDF/XML). One dep, three formats. -->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-arq</artifactId>
+            <version>${jena.version}</version>
+        </dependency>
+
+        <!-- YAML parsing for the OpenAPI spec at startup. -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/LinkmlSpringRdfAutoConfiguration.java
+++ b/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/LinkmlSpringRdfAutoConfiguration.java
@@ -1,0 +1,49 @@
+package io.linkmlspring.rdf;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Wires the {@link SpecRegistry}, {@link RdfMapper}, and three
+ * RDF {@link RdfHttpMessageConverter}s into the Spring context.
+ *
+ * <p>Spring Boot auto-detects this class via the
+ * {@code AutoConfiguration.imports} META-INF file. Applications
+ * that pull this artefact as a dependency get the converters
+ * registered automatically; no XML, no @Import.
+ *
+ * <p>The OpenAPI spec location defaults to {@code classpath:openapi.yaml}
+ * (the file produced by {@code gen-spring-server}'s sidecar emit)
+ * but is overridable via {@code linkml.rdf.spec-classpath}.
+ */
+@AutoConfiguration
+public class LinkmlSpringRdfAutoConfiguration {
+
+    @Bean
+    public SpecRegistry linkmlRdfSpecRegistry(
+            @Value("${linkml.rdf.spec-classpath:/openapi.yaml}")
+            String specClasspath) {
+        return SpecRegistry.load(specClasspath);
+    }
+
+    @Bean
+    public RdfMapper linkmlRdfMapper(SpecRegistry registry) {
+        return new RdfMapper(registry);
+    }
+
+    @Bean
+    public RdfHttpMessageConverter turtleHttpMessageConverter(RdfMapper mapper) {
+        return RdfHttpMessageConverter.turtle(mapper);
+    }
+
+    @Bean
+    public RdfHttpMessageConverter jsonLdHttpMessageConverter(RdfMapper mapper) {
+        return RdfHttpMessageConverter.jsonLd(mapper);
+    }
+
+    @Bean
+    public RdfHttpMessageConverter rdfXmlHttpMessageConverter(RdfMapper mapper) {
+        return RdfHttpMessageConverter.rdfXml(mapper);
+    }
+}

--- a/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/RdfHttpMessageConverter.java
+++ b/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/RdfHttpMessageConverter.java
@@ -1,0 +1,135 @@
+package io.linkmlspring.rdf;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFFormat;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+/**
+ * Spring {@link org.springframework.http.converter.HttpMessageConverter}
+ * for one RDF wire format. Subclasses pin the media type and Jena
+ * {@link RDFFormat}; everything else (DTO walking, predicate
+ * lookup, model construction) lives in {@link RdfMapper}.
+ *
+ * <p>Read side currently only sketches: returns {@code null}. The
+ * demo controllers all return server-side data (501 → hardcoded), so
+ * inbound RDF is not exercised in this MVP. Wiring deserialisation
+ * is a follow-up — Jena {@code RDFParser} produces a Model, then
+ * subjects matching a known {@code rdf:type} dispatch to the right
+ * Java DTO via {@link SpecRegistry#classIri(String)}.
+ */
+public class RdfHttpMessageConverter
+        extends AbstractHttpMessageConverter<Object> {
+
+    public static final MediaType TEXT_TURTLE = new MediaType("text", "turtle");
+    public static final MediaType APPLICATION_LD_JSON =
+            new MediaType("application", "ld+json");
+    public static final MediaType APPLICATION_RDF_XML =
+            new MediaType("application", "rdf+xml");
+
+    private final RdfMapper mapper;
+    private final RDFFormat format;
+
+    public RdfHttpMessageConverter(
+            RdfMapper mapper, RDFFormat format, MediaType mediaType) {
+        super(mediaType);
+        this.mapper = mapper;
+        this.format = format;
+    }
+
+    /** Turtle converter — ``text/turtle`` ↔ Jena {@code TURTLE_PRETTY}. */
+    public static RdfHttpMessageConverter turtle(RdfMapper mapper) {
+        return new RdfHttpMessageConverter(
+                mapper, RDFFormat.TURTLE_PRETTY, TEXT_TURTLE);
+    }
+
+    /** JSON-LD converter — ``application/ld+json`` ↔ Jena
+     *  {@code JSONLD11_PRETTY}. */
+    public static RdfHttpMessageConverter jsonLd(RdfMapper mapper) {
+        return new RdfHttpMessageConverter(
+                mapper, RDFFormat.JSONLD11_PRETTY, APPLICATION_LD_JSON);
+    }
+
+    /** RDF/XML converter — ``application/rdf+xml`` ↔ Jena
+     *  {@code RDFXML_PRETTY}. */
+    public static RdfHttpMessageConverter rdfXml(RdfMapper mapper) {
+        return new RdfHttpMessageConverter(
+                mapper, RDFFormat.RDFXML_PRETTY, APPLICATION_RDF_XML);
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        // We accept anything — the mapper silently emits no triples
+        // for classes outside the spec, and Spring will refuse the
+        // converter pairing if the response type is unannotated.
+        return true;
+    }
+
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        return super.canRead(clazz, mediaType);
+    }
+
+    @Override
+    protected Object readInternal(
+            Class<?> clazz, HttpInputMessage inputMessage)
+            throws IOException, HttpMessageNotReadableException {
+        // Parse the request body into a Jena Model in the matching
+        // syntax, then dispatch to the spec-driven inverse mapper.
+        org.apache.jena.rdf.model.Model model =
+                org.apache.jena.rdf.model.ModelFactory
+                        .createDefaultModel();
+        try {
+            org.apache.jena.riot.RDFParser
+                    .source(inputMessage.getBody())
+                    .lang(format.getLang())
+                    .parse(model);
+        } catch (Exception e) {
+            throw new HttpMessageNotReadableException(
+                    "Failed to parse RDF request body as " + format,
+                    e,
+                    inputMessage);
+        }
+        Object dto = mapper.fromModel(model, clazz);
+        if (dto == null) {
+            throw new HttpMessageNotReadableException(
+                    "No subject of type "
+                            + clazz.getSimpleName()
+                            + " found in RDF body",
+                    inputMessage);
+        }
+        return dto;
+    }
+
+    @Override
+    protected void writeInternal(Object payload, HttpOutputMessage out)
+            throws IOException {
+        if (payload instanceof Iterable<?> iter) {
+            // Spring lists become rdf:Bag-style if you let Jena
+            // default; we keep it flat — emit each item's triples
+            // in turn into a single Model so a Catalog response
+            // carrying List<Catalog> serialises as a graph union.
+            Model model = org.apache.jena.rdf.model.ModelFactory
+                    .createDefaultModel();
+            for (Object item : iter) {
+                mapper.addToModel(item, model);
+            }
+            org.apache.jena.riot.RDFDataMgr.write(
+                    out.getBody(), model, format);
+            return;
+        }
+        Model model = mapper.toModel(payload);
+        org.apache.jena.riot.RDFDataMgr.write(
+                out.getBody(), model, format);
+    }
+
+    @Override
+    public List<MediaType> getSupportedMediaTypes() {
+        return super.getSupportedMediaTypes();
+    }
+}

--- a/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/RdfMapper.java
+++ b/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/RdfMapper.java
@@ -1,0 +1,453 @@
+package io.linkmlspring.rdf;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
+
+/**
+ * Reflection-based DTO → Jena Model mapper, driven by a
+ * {@link SpecRegistry} loaded from the OpenAPI spec at startup.
+ *
+ * <p>Conventions:
+ *
+ * <ul>
+ *   <li>The DTO's {@code id} field provides the RDF subject IRI. If
+ *       absent or null, the resource is emitted as a blank node.
+ *   <li>Inherited fields are walked too — Catalog reaches every
+ *       Resource/Dataset field via {@link Class#getSuperclass()}.
+ *   <li>Embedded value classes (no {@code id} field) become blank
+ *       nodes attached to the parent via the predicate from the
+ *       parent's spec entry.
+ *   <li>{@code java.net.URI} field values become RDF resources;
+ *       primitives become typed literals; {@link OffsetDateTime}
+ *       becomes an {@code xsd:dateTime} literal; everything else
+ *       becomes a plain literal via {@code toString}.
+ * </ul>
+ */
+public final class RdfMapper {
+
+    /** DTO field that carries the subject IRI — structural marker,
+     *  not a data triple, so it doesn't come from the spec. If the
+     *  codegen ever picks a different name, surface it via an
+     *  ``x-rdf-id-field`` class extension and read it from the
+     *  registry; for now the convention is enough. */
+    private static final String FIELD_ID = "id";
+
+    private final SpecRegistry registry;
+
+    public RdfMapper(SpecRegistry registry) {
+        this.registry = registry;
+    }
+
+    /** Add the DTO's triples to the supplied model and return the
+     *  subject resource (so callers can chain with related DTOs). */
+    public Resource addToModel(Object dto, Model model) {
+        if (dto == null) {
+            return null;
+        }
+        String schemaName = dto.getClass().getSimpleName();
+        Resource subject = subjectFor(dto, model);
+        String classIri = registry.classIri(schemaName);
+        if (classIri != null) {
+            subject.addProperty(RDF.type, model.createResource(classIri));
+        }
+        // Walk inherited fields too: Catalog ⇢ Dataset ⇢ Resource.
+        for (Class<?> c = dto.getClass(); c != null && c != Object.class;
+                c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                emitField(dto, c, f, subject, model);
+            }
+        }
+        return subject;
+    }
+
+    /** Build a fresh Model carrying the single DTO. Used by the
+     *  HttpMessageConverter on each write. */
+    public Model toModel(Object dto) {
+        Model model = ModelFactory.createDefaultModel();
+        addToModel(dto, model);
+        return model;
+    }
+
+    // --- internals ----------------------------------------------------
+
+    private Resource subjectFor(Object dto, Model model) {
+        try {
+            Field idField = findField(dto.getClass(), FIELD_ID);
+            if (idField != null) {
+                idField.setAccessible(true);
+                Object id = idField.get(dto);
+                if (id != null) {
+                    return model.createResource(id.toString());
+                }
+            }
+        } catch (IllegalAccessException ignored) {
+            // fall through to blank node
+        }
+        return model.createResource(); // blank node
+    }
+
+    private void emitField(
+            Object dto,
+            Class<?> declaringClass,
+            Field f,
+            Resource subject,
+            Model model) {
+        // The id field is the subject IRI itself, not a triple.
+        if (FIELD_ID.equals(f.getName())) {
+            return;
+        }
+        // Static / synthetic fields aren't user data.
+        int mods = f.getModifiers();
+        if (java.lang.reflect.Modifier.isStatic(mods)) {
+            return;
+        }
+        String predicateIri = registry.propertyIri(
+                declaringClass.getSimpleName(), f.getName());
+        if (predicateIri == null) {
+            // Walk up: the predicate may be declared on a superclass's
+            // schema entry rather than the leaf's.
+            for (Class<?> c = declaringClass.getSuperclass();
+                    c != null && c != Object.class;
+                    c = c.getSuperclass()) {
+                predicateIri = registry.propertyIri(
+                        c.getSimpleName(), f.getName());
+                if (predicateIri != null) {
+                    break;
+                }
+            }
+        }
+        if (predicateIri == null) {
+            return; // no RDF mapping declared — skip silently
+        }
+
+        try {
+            f.setAccessible(true);
+            Object value = f.get(dto);
+            if (value == null) {
+                return;
+            }
+            Property predicate = model.createProperty(predicateIri);
+            if (value instanceof Collection<?> col) {
+                for (Object item : col) {
+                    addObjectTriple(subject, predicate, item, model);
+                }
+            } else {
+                addObjectTriple(subject, predicate, value, model);
+            }
+        } catch (IllegalAccessException ignored) {
+            // Skip inaccessible fields rather than crash the marshal.
+        }
+    }
+
+    private void addObjectTriple(
+            Resource subject, Property predicate, Object value, Model model) {
+        if (value == null) {
+            return;
+        }
+        RDFNode node = toRdfNode(value, model);
+        if (node != null) {
+            subject.addProperty(predicate, node);
+        }
+    }
+
+    private RDFNode toRdfNode(Object value, Model model) {
+        if (value instanceof URI uri) {
+            return model.createResource(uri.toString());
+        }
+        if (value instanceof OffsetDateTime odt) {
+            return model.createTypedLiteral(
+                    odt.toString(), XSDDatatype.XSDdateTime);
+        }
+        if (value instanceof Number n) {
+            // Numbers go in as xsd-typed literals so RDF consumers
+            // round-trip the type rather than re-parsing strings.
+            if (value instanceof Integer || value instanceof Long) {
+                return model.createTypedLiteral(
+                        value.toString(), XSDDatatype.XSDinteger);
+            }
+            if (value instanceof Float || value instanceof Double) {
+                return model.createTypedLiteral(
+                        value.toString(), XSDDatatype.XSDdouble);
+            }
+            return model.createTypedLiteral(
+                    n.toString(), XSDDatatype.XSDdecimal);
+        }
+        if (value instanceof Boolean b) {
+            return model.createTypedLiteral(
+                    b.toString(), XSDDatatype.XSDboolean);
+        }
+        if (value instanceof String s) {
+            return model.createLiteral(s);
+        }
+        // Anything else — assume it's a known DTO whose schema we
+        // recognise: recurse, attach as a sub-resource.
+        if (registry.classIri(value.getClass().getSimpleName()) != null) {
+            return addToModel(value, model);
+        }
+        // Fallback: stringify so we don't drop the value silently.
+        return model.createLiteral(value.toString());
+    }
+
+    private static Field findField(Class<?> cls, String name) {
+        for (Class<?> c = cls; c != null && c != Object.class;
+                c = c.getSuperclass()) {
+            try {
+                return c.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                // try parent
+            }
+        }
+        return null;
+    }
+
+    // =================================================================
+    // Reverse direction: Jena Model → Java DTO
+    // =================================================================
+
+    /**
+     * Hydrate an instance of {@code targetClass} from {@code model} by
+     * locating a subject whose ``rdf:type`` matches the class's
+     * ``x-rdf-class`` (looked up via the registry), then mapping each
+     * predicate triple to the DTO's matching field.
+     *
+     * <p>Conventions mirror {@link #addToModel}:
+     * <ul>
+     *   <li>Subject IRI → ``id`` field
+     *   <li>Predicate ↔ field by reverse lookup of
+     *       {@link SpecRegistry#propertiesFor}
+     *   <li>RDF resource → {@link URI}; literal → primitive / String /
+     *       OffsetDateTime per field type; multivalued field → all
+     *       triples for the predicate gathered into a List
+     * </ul>
+     *
+     * <p>Returns {@code null} when no subject in the model carries the
+     * expected type — callers raise as appropriate.
+     */
+    public <T> T fromModel(Model model, Class<T> targetClass) {
+        String classIri = registry.classIri(targetClass.getSimpleName());
+        if (classIri == null) {
+            throw new IllegalStateException(
+                    "Class " + targetClass.getSimpleName()
+                            + " has no x-rdf-class in the loaded spec");
+        }
+        Resource typeResource = model.createResource(classIri);
+        StmtIterator subjects = model.listStatements(
+                null, RDF.type, typeResource);
+        if (!subjects.hasNext()) {
+            return null;
+        }
+        Resource subject = subjects.nextStatement().getSubject();
+        try {
+            T instance = targetClass.getDeclaredConstructor()
+                    .newInstance();
+            hydrate(instance, subject, model);
+            return instance;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                    "Failed to instantiate " + targetClass.getName(),
+                    e);
+        }
+    }
+
+    private void hydrate(Object instance, Resource subject, Model model)
+            throws ReflectiveOperationException {
+        // 1. Set the id field to the subject IRI (or leave blank if a
+        //    blank node — we serialise blank nodes for embedded
+        //    objects only).
+        if (subject.isURIResource()) {
+            Field idField = findField(instance.getClass(), FIELD_ID);
+            if (idField != null) {
+                idField.setAccessible(true);
+                idField.set(instance, coerceToFieldType(
+                        idField.getGenericType(), subject.getURI()));
+            }
+        }
+
+        // 2. Build a reverse predicate→field map by walking the DTO's
+        //    inheritance chain and consulting the registry. Cached
+        //    nowhere — fresh per call; fast enough for typical
+        //    payloads, and avoids stale state if the registry is
+        //    swapped at runtime.
+        Map<String, Field> predicateToField = new HashMap<>();
+        for (Class<?> c = instance.getClass();
+                c != null && c != Object.class;
+                c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                if (FIELD_ID.equals(f.getName())) {
+                    continue;
+                }
+                String predicate = lookupPredicate(c, f.getName());
+                if (predicate != null) {
+                    predicateToField.putIfAbsent(predicate, f);
+                }
+            }
+        }
+
+        // 3. Walk every triple from the subject and populate fields.
+        Map<Field, List<Object>> multivaluedAccum = new HashMap<>();
+        StmtIterator it = subject.listProperties();
+        while (it.hasNext()) {
+            Statement s = it.nextStatement();
+            Property p = s.getPredicate();
+            if (RDF.type.equals(p)) {
+                continue; // handled by class dispatch, not as data
+            }
+            Field f = predicateToField.get(p.getURI());
+            if (f == null) {
+                continue;
+            }
+            f.setAccessible(true);
+            Object value = rdfNodeToJava(
+                    s.getObject(), elementType(f), model);
+            if (value == null) {
+                continue;
+            }
+            if (Collection.class.isAssignableFrom(f.getType())) {
+                multivaluedAccum
+                        .computeIfAbsent(f, k -> new ArrayList<>())
+                        .add(value);
+            } else {
+                f.set(instance, value);
+            }
+        }
+        for (Map.Entry<Field, List<Object>> e : multivaluedAccum.entrySet()) {
+            e.getKey().set(instance, e.getValue());
+        }
+    }
+
+    private String lookupPredicate(Class<?> cls, String fieldName) {
+        // The registry is keyed by schema name (Java class simple
+        // name); inherited fields' predicates may be on an ancestor.
+        for (Class<?> c = cls; c != null && c != Object.class;
+                c = c.getSuperclass()) {
+            String iri = registry.propertyIri(c.getSimpleName(), fieldName);
+            if (iri != null) {
+                return iri;
+            }
+        }
+        return null;
+    }
+
+    private static Type elementType(Field f) {
+        // For ``List<X>`` fields we want X to drive the per-element
+        // coercion. Otherwise the field's own type.
+        if (Collection.class.isAssignableFrom(f.getType())) {
+            Type generic = f.getGenericType();
+            if (generic instanceof ParameterizedType pt
+                    && pt.getActualTypeArguments().length == 1) {
+                return pt.getActualTypeArguments()[0];
+            }
+            return Object.class;
+        }
+        return f.getGenericType();
+    }
+
+    private Object rdfNodeToJava(RDFNode node, Type targetType, Model model) {
+        Class<?> raw = rawClass(targetType);
+        if (node.isURIResource()) {
+            String uri = node.asResource().getURI();
+            if (URI.class.equals(raw)) {
+                return URI.create(uri);
+            }
+            if (String.class.equals(raw)) {
+                return uri;
+            }
+            // Embedded sub-resource — recurse if we know the type.
+            if (raw != null
+                    && registry.classIri(raw.getSimpleName()) != null) {
+                try {
+                    Object child = raw.getDeclaredConstructor().newInstance();
+                    hydrate(child, node.asResource(), model);
+                    return child;
+                } catch (ReflectiveOperationException e) {
+                    return null;
+                }
+            }
+            return uri;
+        }
+        if (node.isAnon()) {
+            // Blank node — embedded structured value.
+            if (raw != null
+                    && registry.classIri(raw.getSimpleName()) != null) {
+                try {
+                    Object child = raw.getDeclaredConstructor().newInstance();
+                    hydrate(child, node.asResource(), model);
+                    return child;
+                } catch (ReflectiveOperationException e) {
+                    return null;
+                }
+            }
+            return null;
+        }
+        if (node.isLiteral()) {
+            Literal lit = node.asLiteral();
+            return coerceLiteral(lit, raw);
+        }
+        return null;
+    }
+
+    private static Class<?> rawClass(Type t) {
+        if (t instanceof Class<?> c) {
+            return c;
+        }
+        if (t instanceof ParameterizedType pt
+                && pt.getRawType() instanceof Class<?> rc) {
+            return rc;
+        }
+        return Object.class;
+    }
+
+    private static Object coerceLiteral(Literal lit, Class<?> target) {
+        if (target == null || String.class.equals(target)) {
+            return lit.getString();
+        }
+        if (Long.class.equals(target) || long.class.equals(target)) {
+            return lit.getLong();
+        }
+        if (Integer.class.equals(target) || int.class.equals(target)) {
+            return lit.getInt();
+        }
+        if (Double.class.equals(target) || double.class.equals(target)) {
+            return lit.getDouble();
+        }
+        if (Float.class.equals(target) || float.class.equals(target)) {
+            return lit.getFloat();
+        }
+        if (Boolean.class.equals(target) || boolean.class.equals(target)) {
+            return lit.getBoolean();
+        }
+        if (OffsetDateTime.class.equals(target)) {
+            return OffsetDateTime.parse(lit.getString());
+        }
+        if (URI.class.equals(target)) {
+            return URI.create(lit.getString());
+        }
+        return lit.getString();
+    }
+
+    private static Object coerceToFieldType(Type targetType, String value) {
+        Class<?> raw = rawClass(targetType);
+        if (URI.class.equals(raw)) {
+            return URI.create(value);
+        }
+        return value;
+    }
+}

--- a/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/SpecRegistry.java
+++ b/examples/spring-rdf-runtime/src/main/java/io/linkmlspring/rdf/SpecRegistry.java
@@ -1,0 +1,137 @@
+package io.linkmlspring.rdf;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Loads the OpenAPI spec from the classpath at startup and exposes
+ * the RDF identity map: schema name → x-rdf-class IRI, plus
+ * per-schema property name → x-rdf-property IRI.
+ *
+ * <p>The spec is the single source of truth — no parallel Java
+ * annotations, no codegen-time mapping table. Adding a new RDF-
+ * carrying field on the LinkML side is automatically picked up
+ * by the runtime when the spec regenerates.
+ *
+ * <p>Walks both top-level {@code components/schemas/<name>/properties}
+ * and the {@code allOf[].properties} branch used by the inheritance
+ * shape, so subclass schemas pick up their own local properties (the
+ * inherited ones come from the parent class's entry).
+ */
+public final class SpecRegistry {
+
+    /**
+     * @param specClasspath classpath path of the OpenAPI YAML spec,
+     *                      typically {@code "/openapi.yaml"}.
+     */
+    @SuppressWarnings("unchecked")
+    public static SpecRegistry load(String specClasspath) {
+        try (InputStream in =
+                SpecRegistry.class.getResourceAsStream(specClasspath)) {
+            if (in == null) {
+                throw new IllegalStateException(
+                        "OpenAPI spec not found on classpath at "
+                                + specClasspath);
+            }
+            Map<String, Object> root = new Yaml().load(in);
+            Map<String, Object> schemas = path(
+                    root, "components", "schemas");
+            return new SpecRegistry(schemas == null
+                    ? Collections.emptyMap()
+                    : schemas);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Failed to load OpenAPI spec from classpath:"
+                            + specClasspath,
+                    e);
+        }
+    }
+
+    private final Map<String, String> classIri;
+    private final Map<String, Map<String, String>> propertyIri;
+
+    @SuppressWarnings("unchecked")
+    private SpecRegistry(Map<String, Object> schemas) {
+        this.classIri = new HashMap<>();
+        this.propertyIri = new HashMap<>();
+        for (Map.Entry<String, Object> entry : schemas.entrySet()) {
+            String schemaName = entry.getKey();
+            if (!(entry.getValue() instanceof Map<?, ?> sch)) {
+                continue;
+            }
+            Map<String, Object> schema = (Map<String, Object>) sch;
+            Object cls = schema.get("x-rdf-class");
+            if (cls instanceof String s) {
+                this.classIri.put(schemaName, s);
+            }
+            Map<String, String> propsOut = new LinkedHashMap<>();
+            collectProperties(schema, propsOut);
+            if (!propsOut.isEmpty()) {
+                this.propertyIri.put(schemaName, propsOut);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void collectProperties(
+            Map<String, Object> schema, Map<String, String> out) {
+        if (schema.get("properties") instanceof Map<?, ?> props) {
+            walk((Map<String, Object>) props, out);
+        }
+        if (schema.get("allOf") instanceof List<?> allOf) {
+            for (Object part : allOf) {
+                if (part instanceof Map<?, ?> p
+                        && p.get("properties") instanceof Map<?, ?> pp) {
+                    walk((Map<String, Object>) pp, out);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void walk(
+            Map<String, Object> props, Map<String, String> out) {
+        for (Map.Entry<String, Object> e : props.entrySet()) {
+            if (!(e.getValue() instanceof Map<?, ?> v)) {
+                continue;
+            }
+            Object iri = ((Map<String, Object>) v).get("x-rdf-property");
+            if (iri instanceof String s) {
+                out.put(e.getKey(), s);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> path(
+            Map<String, Object> root, String... segments) {
+        Map<String, Object> cur = root;
+        for (String seg : segments) {
+            Object next = cur == null ? null : cur.get(seg);
+            cur = (next instanceof Map) ? (Map<String, Object>) next : null;
+        }
+        return cur;
+    }
+
+    /** RDF type IRI for a Java/spec class name, or {@code null}. */
+    public String classIri(String schemaName) {
+        return classIri.get(schemaName);
+    }
+
+    /** RDF predicate IRI for a property on a class, or {@code null}. */
+    public String propertyIri(String schemaName, String propertyName) {
+        Map<String, String> props = propertyIri.get(schemaName);
+        return props == null ? null : props.get(propertyName);
+    }
+
+    /** Property → predicate map for a class (empty when missing). */
+    public Map<String, String> propertiesFor(String schemaName) {
+        return propertyIri.getOrDefault(
+                schemaName, Collections.emptyMap());
+    }
+}

--- a/examples/spring-rdf-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/examples/spring-rdf-runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.linkmlspring.rdf.LinkmlSpringRdfAutoConfiguration

--- a/examples/spring-rdf-runtime/src/test/java/io/linkmlspring/rdf/RdfMapperTest.java
+++ b/examples/spring-rdf-runtime/src/test/java/io/linkmlspring/rdf/RdfMapperTest.java
@@ -1,0 +1,237 @@
+package io.linkmlspring.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reflection-based DTO → Jena Model mapping. Uses a tiny in-test DTO
+ * (no dependency on the demo project's Catalog) so the tests pin the
+ * mapping behaviour in isolation.
+ */
+class RdfMapperTest {
+
+    static class Catalog {
+        public String id;
+        public String title;
+        public URI landingPage;
+        public List<String> keyword;
+        public OffsetDateTime issued;
+        public Long byteSize;
+        // Synthesised polymorphism markers — must be skipped.
+        public String resourceType;
+        public String legacyType;
+    }
+
+    private static SpecRegistry registry() {
+        return SpecRegistry.load("/test-spec.yaml");
+    }
+
+    private static Resource buildSubject(Catalog c) {
+        Model m = new RdfMapper(registry()).toModel(c);
+        return m.listSubjects().nextResource();
+    }
+
+    @Test
+    void idFieldBecomesSubjectIri() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        Resource subj = buildSubject(c);
+        assertEquals("https://example.org/catalogs/cat-1", subj.getURI());
+    }
+
+    @Test
+    void rdfTypeEmittedFromXRdfClass() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        Model m = new RdfMapper(registry()).toModel(c);
+        boolean hasType = m.contains(
+                m.createResource("https://example.org/catalogs/cat-1"),
+                RDF.type,
+                m.createResource("http://www.w3.org/ns/dcat#Catalog"));
+        assertTrue(hasType);
+    }
+
+    @Test
+    void stringFieldBecomesPlainLiteralUnderItsPredicate() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        c.title = "Open Data Portal";
+        Model m = new RdfMapper(registry()).toModel(c);
+        Statement s = m.listStatements(
+                        m.createResource("https://example.org/catalogs/cat-1"),
+                        m.createProperty("http://purl.org/dc/terms/title"),
+                        (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement();
+        assertEquals("Open Data Portal", s.getString());
+    }
+
+    @Test
+    void uriFieldBecomesRdfResource() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        c.landingPage = URI.create("https://example.org/catalog/cat-1");
+        Model m = new RdfMapper(registry()).toModel(c);
+        Statement s = m.listStatements(
+                        null,
+                        m.createProperty(
+                                "http://www.w3.org/ns/dcat#landingPage"),
+                        (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement();
+        assertTrue(s.getObject().isURIResource());
+        assertEquals(
+                "https://example.org/catalog/cat-1",
+                s.getObject().asResource().getURI());
+    }
+
+    @Test
+    void multivaluedListBecomesMultipleTriples() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        c.keyword = List.of("a", "b", "c");
+        Model m = new RdfMapper(registry()).toModel(c);
+        StmtIterator it = m.listStatements(
+                null,
+                m.createProperty("http://www.w3.org/ns/dcat#keyword"),
+                (org.apache.jena.rdf.model.RDFNode) null);
+        int count = 0;
+        while (it.hasNext()) {
+            it.nextStatement();
+            count++;
+        }
+        assertEquals(3, count);
+    }
+
+    static class Doc {
+        public String id;
+        public OffsetDateTime issued;
+        public Long byteSize;
+    }
+
+    @Test
+    void offsetDateTimeBecomesXsdDateTimeLiteral() {
+        // OffsetDateTime → typed literal so RDF consumers preserve
+        // the type rather than re-parsing strings.
+        Doc d = new Doc();
+        d.id = "https://example.org/d/1";
+        d.issued = OffsetDateTime.parse("2024-01-15T00:00:00Z");
+        Model m = new RdfMapper(registry()).toModel(d);
+        Statement s = m.listStatements(
+                        null,
+                        m.createProperty("http://purl.org/dc/terms/issued"),
+                        (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement();
+        assertTrue(s.getLiteral().getDatatypeURI().endsWith("dateTime"));
+    }
+
+    @Test
+    void numberFieldBecomesXsdIntegerLiteral() {
+        Doc d = new Doc();
+        d.id = "https://example.org/d/1";
+        d.byteSize = 4096L;
+        Model m = new RdfMapper(registry()).toModel(d);
+        Statement s = m.listStatements(
+                        null,
+                        m.createProperty("http://www.w3.org/ns/dcat#byteSize"),
+                        (org.apache.jena.rdf.model.RDFNode) null)
+                .nextStatement();
+        assertTrue(s.getLiteral().getDatatypeURI().endsWith("integer"));
+        assertEquals(4096L, s.getLong());
+    }
+
+    @Test
+    void resourceTypeAndLegacyTypeFieldsAreSkipped() {
+        // These are JSON polymorphism markers, not RDF predicates.
+        // rdf:type comes from x-rdf-class; the field values would
+        // duplicate it (with a string label rather than a class IRI).
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        c.resourceType = "Catalog";
+        c.legacyType = "com.xyz.dcat.Catalog";
+        Model m = new RdfMapper(registry()).toModel(c);
+        // Single rdf:type triple — only the one from x-rdf-class.
+        StmtIterator it = m.listStatements(
+                null,
+                RDF.type,
+                (org.apache.jena.rdf.model.RDFNode) null);
+        int count = 0;
+        while (it.hasNext()) {
+            it.nextStatement();
+            count++;
+        }
+        assertEquals(1, count);
+    }
+
+    @Test
+    void readsBackInstanceFromTurtle() {
+        // Round-trip a full DTO: serialise → parse → reconstruct.
+        // Confirms that the spec-driven mapping works in both
+        // directions against the same SpecRegistry.
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        c.title = "Open Data Portal";
+        c.landingPage = URI.create(
+                "https://example.org/catalog/cat-1");
+        c.keyword = List.of("open-data", "civic");
+        Model written = new RdfMapper(registry()).toModel(c);
+
+        // Serialise + reparse to mimic the HttpMessageConverter
+        // round-trip (write side then read side).
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        org.apache.jena.riot.RDFDataMgr.write(
+                out, written, org.apache.jena.riot.RDFFormat.TURTLE);
+        Model parsed = org.apache.jena.rdf.model.ModelFactory
+                .createDefaultModel();
+        org.apache.jena.riot.RDFParser
+                .source(new java.io.ByteArrayInputStream(out.toByteArray()))
+                .lang(org.apache.jena.riot.Lang.TURTLE)
+                .parse(parsed);
+
+        Catalog hydrated = new RdfMapper(registry())
+                .fromModel(parsed, Catalog.class);
+        assertEquals(
+                "https://example.org/catalogs/cat-1", hydrated.id);
+        assertEquals("Open Data Portal", hydrated.title);
+        assertEquals(
+                URI.create("https://example.org/catalog/cat-1"),
+                hydrated.landingPage);
+        assertEquals(2, hydrated.keyword.size());
+        assertTrue(hydrated.keyword.contains("open-data"));
+        assertTrue(hydrated.keyword.contains("civic"));
+    }
+
+    @Test
+    void readsReturnsNullWhenNoSubjectMatchesType() {
+        // Empty model — no subject carries the expected rdf:type, so
+        // fromModel returns null rather than fabricating an instance.
+        Model empty = org.apache.jena.rdf.model.ModelFactory
+                .createDefaultModel();
+        Catalog dto = new RdfMapper(registry())
+                .fromModel(empty, Catalog.class);
+        org.junit.jupiter.api.Assertions.assertNull(dto);
+    }
+
+    @Test
+    void nullFieldsEmitNoTriples() {
+        Catalog c = new Catalog();
+        c.id = "https://example.org/catalogs/cat-1";
+        // title, landingPage, etc. are all null.
+        Model m = new RdfMapper(registry()).toModel(c);
+        // Only the rdf:type triple should be present.
+        assertEquals(1, m.size());
+        assertFalse(m.contains(
+                null,
+                m.createProperty("http://purl.org/dc/terms/title")));
+    }
+
+}

--- a/examples/spring-rdf-runtime/src/test/java/io/linkmlspring/rdf/SpecRegistryTest.java
+++ b/examples/spring-rdf-runtime/src/test/java/io/linkmlspring/rdf/SpecRegistryTest.java
@@ -1,0 +1,60 @@
+package io.linkmlspring.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SpecRegistryTest {
+
+    @Test
+    void loadsXRdfClassFromSpec() {
+        SpecRegistry r = SpecRegistry.load("/test-spec.yaml");
+        assertEquals(
+                "http://www.w3.org/ns/dcat#Catalog",
+                r.classIri("Catalog"));
+    }
+
+    @Test
+    void schemaWithoutXRdfClassReturnsNull() {
+        // ``NoRdf`` schema deliberately lacks the extension — confirms
+        // we silently skip schemas with no RDF metadata rather than
+        // throwing or registering bogus mappings.
+        SpecRegistry r = SpecRegistry.load("/test-spec.yaml");
+        assertNull(r.classIri("NoRdf"));
+    }
+
+    @Test
+    void loadsXRdfPropertyForFieldsOnSchema() {
+        SpecRegistry r = SpecRegistry.load("/test-spec.yaml");
+        Map<String, String> props = r.propertiesFor("Catalog");
+        assertEquals(
+                "http://purl.org/dc/terms/title", props.get("title"));
+        assertEquals(
+                "http://www.w3.org/ns/dcat#landingPage",
+                props.get("landingPage"));
+        assertEquals(
+                "http://www.w3.org/ns/dcat#keyword",
+                props.get("keyword"));
+    }
+
+    @Test
+    void unknownSchemaReturnsEmptyPropertyMap() {
+        // Defensive: callers walking unknown classes shouldn't crash.
+        SpecRegistry r = SpecRegistry.load("/test-spec.yaml");
+        assertTrue(r.propertiesFor("Nonexistent").isEmpty());
+    }
+
+    @Test
+    void missingClasspathSpecRaisesIllegalState() {
+        // Loud failure when the spec is misconfigured — silently
+        // serving an empty registry would mean every RDF response
+        // serialises to an empty graph with no diagnostic.
+        assertThrows(
+                IllegalStateException.class,
+                () -> SpecRegistry.load("/no-such-spec.yaml"));
+    }
+}

--- a/examples/spring-rdf-runtime/src/test/resources/test-spec.yaml
+++ b/examples/spring-rdf-runtime/src/test/resources/test-spec.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: Test fixture
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Catalog:
+      type: object
+      x-rdf-class: http://www.w3.org/ns/dcat#Catalog
+      properties:
+        title:
+          type: string
+          x-rdf-property: http://purl.org/dc/terms/title
+        landingPage:
+          type: string
+          format: uri
+          x-rdf-property: http://www.w3.org/ns/dcat#landingPage
+        keyword:
+          type: array
+          items:
+            type: string
+          x-rdf-property: http://www.w3.org/ns/dcat#keyword
+    NoRdf:
+      type: object
+      properties:
+        plain:
+          type: string
+    Doc:
+      type: object
+      x-rdf-class: http://example.org/Doc
+      properties:
+        issued:
+          type: string
+          format: date-time
+          x-rdf-property: http://purl.org/dc/terms/issued
+        byteSize:
+          type: integer
+          x-rdf-property: http://www.w3.org/ns/dcat#byteSize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ gen-spring-server = "linkml_openapi.spring.cli:cli"
 
 [project.entry-points."linkml.generators"]
 openapi = "linkml_openapi.generator:OpenAPIGenerator"
+spring = "linkml_openapi.spring.generator:SpringServerGenerator"
 
 [tool.ruff]
 line-length = 100

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -1,5 +1,7 @@
 """CLI for generating OpenAPI specs from LinkML schemas."""
 
+from pathlib import Path
+
 import click
 
 from linkml_openapi import __version__
@@ -79,12 +81,47 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
         "are unaffected."
     ),
 )
+@click.option(
+    "--emit-name-mappings",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=None,
+    metavar="PATH",
+    help=(
+        "Write the wire→codegen rename map to PATH for use with "
+        "`openapi-generator-cli --name-mappings @PATH`. Captures any "
+        "`openapi.legacy_type_codegen_name` (and similar) annotations "
+        "from the schema. No file is written when the schema declares "
+        "no renames."
+    ),
+)
+@click.option(
+    "--post-process",
+    "post_process",
+    default=None,
+    metavar="NAME[,NAME...]",
+    help=(
+        "Comma-separated list of registered post-processors to apply "
+        "to the generated spec, in order. See "
+        "linkml_openapi.post_processors for the registry. Example: "
+        "--post-process extract-inline-oneof"
+    ),
+)
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, resource_filter=(), **kwargs):
+def cli(yamlfile, resource_filter=(), emit_name_mappings=None,
+        post_process=None, **kwargs):
     """Generate an OpenAPI specification from a LinkML schema."""
     resource_filter = list(resource_filter) if resource_filter else None
+    if post_process:
+        kwargs["post_processors"] = [
+            n.strip() for n in post_process.split(",") if n.strip()
+        ]
     gen = OpenAPIGenerator(yamlfile, resource_filter=resource_filter, **kwargs)
-    click.echo(gen.serialize())
+    spec = gen.serialize()
+    click.echo(spec)
+    if emit_name_mappings is not None:
+        content = gen.emit_name_mappings()
+        if content:
+            emit_name_mappings.write_text(content)
 
 
 def main():

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -107,14 +107,11 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
     ),
 )
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, resource_filter=(), emit_name_mappings=None,
-        post_process=None, **kwargs):
+def cli(yamlfile, resource_filter=(), emit_name_mappings=None, post_process=None, **kwargs):
     """Generate an OpenAPI specification from a LinkML schema."""
     resource_filter = list(resource_filter) if resource_filter else None
     if post_process:
-        kwargs["post_processors"] = [
-            n.strip() for n in post_process.split(",") if n.strip()
-        ]
+        kwargs["post_processors"] = [n.strip() for n in post_process.split(",") if n.strip()]
     gen = OpenAPIGenerator(yamlfile, resource_filter=resource_filter, **kwargs)
     spec = gen.serialize()
     click.echo(spec)

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -287,6 +287,7 @@ class OpenAPIGenerator(Generator):
         self._inject_rdf_extensions(raw)
         if self.post_processors:
             from linkml_openapi.post_processors import apply as _apply_post
+
             raw = _apply_post(raw, list(self.post_processors))
         if self.format == "json":
             return json.dumps(raw, indent=2) + "\n"
@@ -322,8 +323,7 @@ class OpenAPIGenerator(Generator):
         if not self._codegen_name_mappings:
             return ""
         lines = [
-            f"{wire}={codegen}"
-            for wire, codegen in sorted(self._codegen_name_mappings.items())
+            f"{wire}={codegen}" for wire, codegen in sorted(self._codegen_name_mappings.items())
         ]
         return "\n".join(lines) + "\n"
 
@@ -1331,8 +1331,7 @@ class OpenAPIGenerator(Generator):
         field = self._inherited_discriminator_field(class_name)
         if field is not None:
             mapping = {
-                self._type_value(sv.get_class(n)): f"#/components/schemas/{n}"
-                for n in descendants
+                self._type_value(sv.get_class(n)): f"#/components/schemas/{n}" for n in descendants
             }
             schema.discriminator = Discriminator(propertyName=field, mapping=mapping)
         return schema
@@ -1364,11 +1363,7 @@ class OpenAPIGenerator(Generator):
         for class_name in sv.all_classes():
             edges: list[tuple[str, str]] = []
             for slot in self._induced_slots_iter(class_name):
-                if (
-                    slot.range
-                    and sv.get_class(slot.range)
-                    and self._is_composition(slot)
-                ):
+                if slot.range and sv.get_class(slot.range) and self._is_composition(slot):
                     edges.append((slot.name, slot.range))
             if edges:
                 composition[class_name] = edges
@@ -1388,7 +1383,7 @@ class OpenAPIGenerator(Generator):
             in_stack[node] = len(edge_stack)
             for slot_name, target in composition.get(node, []):
                 if target in in_stack:
-                    return edge_stack[in_stack[target]:] + [(node, slot_name, target)]
+                    return edge_stack[in_stack[target] :] + [(node, slot_name, target)]
                 if target not in visited and target in composition:
                     edge_stack.append((node, slot_name, target))
                     cycle = find_cycle(target)
@@ -1405,18 +1400,14 @@ class OpenAPIGenerator(Generator):
             cycle = find_cycle(class_name)
             if cycle is None:
                 continue
-            cycle_classes = {parent for parent, _, _ in cycle} | {
-                child for _, _, child in cycle
-            }
+            cycle_classes = {parent for parent, _, _ in cycle} | {child for _, _, child in cycle}
             if any(
-                self._class_annotation(sv.get_class(n), "openapi.recurse_max_depth")
-                is not None
+                self._class_annotation(sv.get_class(n), "openapi.recurse_max_depth") is not None
                 for n in cycle_classes
             ):
                 continue
             path = (
-                " -> ".join(f"{parent}.{slot}" for parent, slot, _ in cycle)
-                + f" -> {cycle[-1][2]}"
+                " -> ".join(f"{parent}.{slot}" for parent, slot, _ in cycle) + f" -> {cycle[-1][2]}"
             )
             raise ValueError(
                 f"Inlined composition cycle detected: {path}. Inlined cycles "
@@ -1595,14 +1586,10 @@ class OpenAPIGenerator(Generator):
             legacy_field = self._class_annotation(cls, "openapi.legacy_type_field")
             if legacy_field is not None:
                 legacy_field = legacy_field.strip()
-                codegen_name = self._class_annotation(
-                    cls, "openapi.legacy_type_codegen_name"
-                )
+                codegen_name = self._class_annotation(cls, "openapi.legacy_type_codegen_name")
                 codegen_name = codegen_name.strip() if codegen_name else None
                 for sub_name in seen.values():
-                    self._inject_legacy_type_value(
-                        schemas, sub_name, legacy_field, codegen_name
-                    )
+                    self._inject_legacy_type_value(schemas, sub_name, legacy_field, codegen_name)
 
     @staticmethod
     def _writable_local_schema(schema: Schema) -> Schema:
@@ -1979,9 +1966,7 @@ class OpenAPIGenerator(Generator):
                         self._type_value(sv.get_class(n)): f"#/components/schemas/{n}"
                         for n in descendants
                     }
-                    schema.discriminator = Discriminator(
-                        propertyName=field, mapping=mapping
-                    )
+                    schema.discriminator = Discriminator(propertyName=field, mapping=mapping)
                 return schema
 
         return Reference(ref=f"#/components/schemas/{range_name}")

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -9,7 +9,7 @@ Converts LinkML schema definitions into OpenAPI 3.1 specifications with:
 import json
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 import yaml
@@ -207,12 +207,35 @@ class OpenAPIGenerator(Generator):
     # identifiers in the OpenAPI body, operation IDs, tags, and RDF
     # extensions are unaffected — only the URL segment changes.
     path_style: str | None = None
+    # Names of registered post-processors to apply (in order) after the
+    # canonical spec is built but before serialisation. See
+    # ``linkml_openapi.post_processors`` for the registry. Each
+    # post-processor adapts the spec for a specific consumer
+    # (codegens, validators, JSON-LD adapters) without changing the
+    # generator's authoring-clarity defaults.
+    post_processors: list[str] = field(default_factory=list)
 
     def serialize(self, **kwargs) -> str:
         """Generate and serialize the OpenAPI spec."""
         # Reset the x-rdf-* maps; _build_openapi populates them as it walks the schema.
         self._x_rdf_class: dict[str, str] = {}
         self._x_rdf_property: dict[tuple[str, str], str] = {}
+        # Per-build cache so the schema-walk helpers (descendants,
+        # induced slots, etc.) don't re-traverse the class graph for
+        # every reference site. Reset here to pick up any schema-view
+        # changes between successive ``serialize()`` calls.
+        self._concrete_descendants_cache: dict[str, list[str]] = {}
+        # Codegen field-name overrides — accumulated for the companion
+        # ``name-mappings`` file. openapi-generator does not have a
+        # universal *spec-level* extension that reliably renames a
+        # JSON property to a clean target-language identifier
+        # (``x-codegen-name`` is operation-only on most templates). The
+        # working mechanism is the ``--name-mappings`` CLI flag (or
+        # ``@file`` form). We collect every ``wire-name=codegen-name``
+        # pair the schema declares and let
+        # :meth:`emit_name_mappings` write a sibling file the user
+        # passes to ``openapi-generator-cli``.
+        self._codegen_name_mappings: dict[str, str] = {}
         # Multi-level composition recursion happens inside
         # `_add_composition_paths`; the stack tracks which composition
         # targets are currently being emitted so a cyclic
@@ -262,9 +285,47 @@ class OpenAPIGenerator(Generator):
         self._strip_invalid_parameter_fields(raw)
         self._coerce_numeric_constraints(raw)
         self._inject_rdf_extensions(raw)
+        if self.post_processors:
+            from linkml_openapi.post_processors import apply as _apply_post
+            raw = _apply_post(raw, list(self.post_processors))
         if self.format == "json":
             return json.dumps(raw, indent=2) + "\n"
         return yaml.dump(raw, default_flow_style=False, sort_keys=False)
+
+    def name_mappings(self) -> dict[str, str]:
+        """Return the wire→codegen rename map collected during the build.
+
+        Populated from ``openapi.legacy_type_codegen_name`` (and any
+        future codegen-rename annotations). Empty when the schema
+        declares no overrides — the file emission step then writes
+        nothing rather than an empty stub.
+
+        Must be called after :meth:`serialize` since the build is
+        what populates the underlying state.
+        """
+        return dict(self._codegen_name_mappings)
+
+    def emit_name_mappings(self) -> str:
+        """Render the rename map as ``--name-mappings`` file content.
+
+        Format is openapi-generator's expected layout — one
+        ``wire-name=codegen-name`` pair per line. Pass to
+        ``openapi-generator-cli`` via::
+
+            openapi-generator generate -i spec.yaml -g spring \\
+              --name-mappings @name-mappings.txt
+
+        Returns an empty string when no overrides were declared, so
+        callers can write the file unconditionally without polluting
+        the repo with empty hint files.
+        """
+        if not self._codegen_name_mappings:
+            return ""
+        lines = [
+            f"{wire}={codegen}"
+            for wire, codegen in sorted(self._codegen_name_mappings.items())
+        ]
+        return "\n".join(lines) + "\n"
 
     @staticmethod
     def _strip_invalid_parameter_fields(spec: dict) -> None:
@@ -308,6 +369,7 @@ class OpenAPIGenerator(Generator):
     def _build_openapi(self) -> OpenAPI:
         """Build the complete OpenAPI model."""
         sv = self.schemaview
+        self._validate_inlined_recursion()
         title = self.api_title or str(sv.schema.name) or "API"
 
         info = Info(title=title, version=self.api_version)
@@ -467,8 +529,59 @@ class OpenAPIGenerator(Generator):
 
     # --- Schema generation ---
 
+    def _class_description(self, cls: ClassDefinition) -> str | None:
+        """Compose the OpenAPI ``description`` for a class.
+
+        Combines the LinkML ``description`` with an "RDF class:
+        ``<curie>``" footer when the class declares ``class_uri``.
+        Putting the RDF identity in the description (not just in the
+        ``x-rdf-class`` extension) makes it visible directly in
+        Swagger UI's schema panel — extensions are only shown by
+        scrolling to the small footer area, while ``description`` is
+        the prominent text under the schema title.
+        """
+        parts: list[str] = []
+        if cls.description:
+            parts.append(cls.description.strip())
+        if cls.class_uri:
+            parts.append(f"RDF class: `{cls.class_uri}`")
+        return "\n\n".join(parts) or None
+
+    def _slot_description(self, slot: SlotDefinition) -> str | None:
+        """Compose the OpenAPI ``description`` for a slot, with the
+        RDF predicate footer when ``slot_uri`` is set."""
+        parts: list[str] = []
+        if slot.description:
+            parts.append(slot.description.strip())
+        if slot.slot_uri:
+            parts.append(f"RDF property: `{slot.slot_uri}`")
+        return "\n\n".join(parts) or None
+
     def _class_to_schema(self, cls: ClassDefinition) -> Schema:
-        """Convert a LinkML class to a JSON Schema object."""
+        """Convert a LinkML class to a JSON Schema object.
+
+        Inheritance is emitted via ``allOf: [{$ref: parent},
+        {properties}]`` so codegens (notably openapi-generator's
+        Spring template) produce idiomatic
+        ``Catalog extends Dataset extends Resource`` with proper
+        polymorphic Jackson dispatch — and the round-trip survives
+        when a Spring service re-publishes the spec via springdoc.
+
+        ``flatten_inheritance=True`` overrides this and inlines all
+        inherited properties at every concrete class (no ``allOf``).
+        Useful for codegens that don't handle ``allOf`` well, or for
+        producing a self-contained Swagger-UI-friendly view.
+
+        Note: under standard JSON Schema ``allOf`` is intersection,
+        so per-class enum pins on a discriminator field (Dataset's
+        ``enum: [Dataset]``, Catalog's ``enum: [Catalog]``) intersect
+        to ``∅``. That's a JSON Schema purity vs codegen ergonomics
+        trade-off — Spring/openapi-generator doesn't run JSON Schema
+        validation; it dispatches via the discriminator at the
+        slot/path level and Jackson polymorphism, both of which work
+        correctly. Strict-validator environments should switch to
+        ``flatten_inheritance``.
+        """
         if cls.is_a and not self.flatten_inheritance:
             parent_slot_names = set(self._induced_slots_by_name(cls.is_a))
             local_properties: dict[str, Schema | Reference] = {}
@@ -495,8 +608,7 @@ class OpenAPIGenerator(Generator):
                 ]
             )
             schema.title = cls.name
-            if cls.description:
-                schema.description = cls.description
+            schema.description = self._class_description(cls)
             return schema
 
         # Flat schema: every induced slot (inherited and local) as a
@@ -515,8 +627,7 @@ class OpenAPIGenerator(Generator):
 
         schema = Schema(type=DataType.OBJECT, additionalProperties=False)
         schema.title = cls.name
-        if cls.description:
-            schema.description = cls.description
+        schema.description = self._class_description(cls)
         if properties:
             schema.properties = properties
         if required:
@@ -530,7 +641,7 @@ class OpenAPIGenerator(Generator):
 
         # Determine the base schema/ref
         if sv.get_class(range_name) or sv.get_enum(range_name):
-            ref = Reference(ref=f"#/components/schemas/{range_name}")
+            ref = self._class_range_ref(slot, range_name)
             if slot.multivalued:
                 base = Schema(type=DataType.ARRAY, items=ref)
             else:
@@ -550,16 +661,17 @@ class OpenAPIGenerator(Generator):
             or slot.minimum_value is not None
             or slot.maximum_value is not None
         )
-        if isinstance(base, Reference) and has_extras:
+        slot_description = self._slot_description(slot)
+        if isinstance(base, Reference) and (slot_description or has_extras):
             # Wrap in allOf to add constraints alongside a $ref
             schema = Schema(allOf=[base])
-            if slot.description:
-                schema.description = slot.description
+            if slot_description:
+                schema.description = slot_description
             return schema
 
         if isinstance(base, Schema):
-            if slot.description:
-                base.description = slot.description
+            if slot_description:
+                base.description = slot_description
             if slot.pattern:
                 base.pattern = slot.pattern
             if slot.minimum_value is not None:
@@ -920,12 +1032,21 @@ class OpenAPIGenerator(Generator):
             )
 
     def _inject_rdf_extensions(self, raw: dict) -> None:
-        """Walk the dumped spec and decorate schemas with x-rdf-* extensions."""
+        """Walk the dumped spec and decorate schemas with x-rdf-* extensions.
+
+        Emits both ``x-rdf-class`` (our existing custom name, what the
+        spec-driven serdes runtime reads) and ``x-jsonld-type`` (the
+        IETF draft-polli-restapi-ld-keywords-02 standard name). Both
+        carry the same value — the class's expanded RDF IRI. Any
+        consumer implementing the IETF draft picks up the standard
+        keyword; our existing tooling continues to read the original.
+        """
         schemas = (raw.get("components") or {}).get("schemas") or {}
         for class_name, schema in schemas.items():
             class_uri = self._x_rdf_class.get(class_name)
             if class_uri:
                 schema["x-rdf-class"] = class_uri
+                schema["x-jsonld-type"] = class_uri
             # Properties may live at top level or inside the inline schema half
             # of an `allOf` (used for inheritance).
             holders: list[dict] = []
@@ -936,8 +1057,10 @@ class OpenAPIGenerator(Generator):
                     holders.append(sub["properties"])
             for props in holders:
                 for slot_name, slot_schema in props.items():
+                    if not isinstance(slot_schema, dict):
+                        continue
                     slot_uri = self._x_rdf_property.get((class_name, slot_name))
-                    if slot_uri and isinstance(slot_schema, dict):
+                    if slot_uri:
                         slot_schema["x-rdf-property"] = slot_uri
 
     # --- Operation builders ------------------------------------------------
@@ -1185,6 +1308,160 @@ class OpenAPIGenerator(Generator):
             return designates_slot.name
         return None
 
+    def _class_response_ref(self, class_name: str) -> Schema | Reference:
+        """Schema or ``$ref`` for the ``class_name`` payload in a path op.
+
+        When the class has 2+ concrete descendants (it's polymorphic),
+        emit ``oneOf: [$ref each concrete option]`` plus the inherited
+        ``discriminator`` so a GET on /datasets/{id} can legitimately
+        return a ``DatasetSeries`` and the spec advertises it. This is
+        what openapi-generator's Spring template needs to wire up
+        Jackson polymorphic deserialization on the response side.
+
+        Used uniformly across list, read, create, update, patch, and
+        nested-collection responses — any place a class is the body
+        shape of a path operation.
+        """
+        sv = self.schemaview
+        descendants = self._concrete_descendants_including_self(class_name)
+        if len(descendants) <= 1:
+            return Reference(ref=f"#/components/schemas/{class_name}")
+        oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
+        schema = Schema(oneOf=oneof)
+        field = self._inherited_discriminator_field(class_name)
+        if field is not None:
+            mapping = {
+                self._type_value(sv.get_class(n)): f"#/components/schemas/{n}"
+                for n in descendants
+            }
+            schema.discriminator = Discriminator(propertyName=field, mapping=mapping)
+        return schema
+
+    def _validate_inlined_recursion(self) -> None:
+        """Reject inlined-composition cycles unless explicitly acknowledged.
+
+        An inlined cycle (e.g., a class with an ``inlined: true`` slot whose
+        range transitively reaches the class itself) inflates JSON payloads
+        infinitely and makes most codegens spin during DTO generation. The
+        author has to make an explicit choice:
+
+          * drop ``inlined: true`` on the offending slot so it becomes a
+            reference (the default for identifier-bearing classes —
+            target's IRI is sent on the wire), OR
+          * annotate any class on the cycle with
+            ``openapi.recurse_max_depth: <int>`` to acknowledge the cycle
+            is intentional. The annotation is opt-in; the integer is
+            currently informational (no depth bound is enforced) — the
+            point is to make the failure loud and deliberate, not silent.
+
+        Reference cycles (``inlined: false``) are fine: they're IRI
+        strings on the wire, no expansion happens.
+        """
+        sv = self.schemaview
+
+        # Build the composition adjacency:  class → [(slot, range), ...]
+        composition: dict[str, list[tuple[str, str]]] = {}
+        for class_name in sv.all_classes():
+            edges: list[tuple[str, str]] = []
+            for slot in self._induced_slots_iter(class_name):
+                if (
+                    slot.range
+                    and sv.get_class(slot.range)
+                    and self._is_composition(slot)
+                ):
+                    edges.append((slot.name, slot.range))
+            if edges:
+                composition[class_name] = edges
+
+        if not composition:
+            return
+
+        # 3-color DFS for back-edge detection. ``stack`` records the chain
+        # of edges (parent, slot, child) currently being visited; on a back
+        # edge to a node already on the stack we extract the cycle for
+        # error reporting.
+        in_stack: dict[str, int] = {}
+        visited: set[str] = set()
+        edge_stack: list[tuple[str, str, str]] = []
+
+        def find_cycle(node: str) -> list[tuple[str, str, str]] | None:
+            in_stack[node] = len(edge_stack)
+            for slot_name, target in composition.get(node, []):
+                if target in in_stack:
+                    return edge_stack[in_stack[target]:] + [(node, slot_name, target)]
+                if target not in visited and target in composition:
+                    edge_stack.append((node, slot_name, target))
+                    cycle = find_cycle(target)
+                    edge_stack.pop()
+                    if cycle is not None:
+                        return cycle
+            del in_stack[node]
+            visited.add(node)
+            return None
+
+        for class_name in composition:
+            if class_name in visited:
+                continue
+            cycle = find_cycle(class_name)
+            if cycle is None:
+                continue
+            cycle_classes = {parent for parent, _, _ in cycle} | {
+                child for _, _, child in cycle
+            }
+            if any(
+                self._class_annotation(sv.get_class(n), "openapi.recurse_max_depth")
+                is not None
+                for n in cycle_classes
+            ):
+                continue
+            path = (
+                " -> ".join(f"{parent}.{slot}" for parent, slot, _ in cycle)
+                + f" -> {cycle[-1][2]}"
+            )
+            raise ValueError(
+                f"Inlined composition cycle detected: {path}. Inlined cycles "
+                f"cause infinite expansion in generated JSON payloads. "
+                f"Resolve by setting `inlined: false` on one of the slots in "
+                f"the cycle (the on-the-wire shape becomes a reference IRI), "
+                f"or by adding `openapi.recurse_max_depth: <N>` as a class "
+                f"annotation on a class in the cycle to acknowledge it is "
+                f"intentional."
+            )
+
+    def _is_in_polymorphic_chain(self, cls: ClassDefinition) -> bool:
+        """True if ``cls`` or any ancestor declares a discriminator.
+
+        Drives the flatten-vs-allOf decision in :meth:`_class_to_schema`:
+        polymorphic chains flatten so each concrete schema can pin its
+        own discriminator without ``allOf`` intersection conflicts.
+        """
+        sv = self.schemaview
+        cur: ClassDefinition | None = cls
+        while cur is not None:
+            if self._discriminator_field(cur) is not None:
+                return True
+            cur = sv.get_class(cur.is_a) if cur.is_a else None
+        return False
+
+    def _inherited_discriminator_field(self, class_name: str) -> str | None:
+        """Walk the ``is_a`` chain looking for a discriminator declaration.
+
+        ``_discriminator_field`` only inspects a single class — it does
+        not see annotations on ancestors. For property-level polymorphism
+        (e.g., a slot ranging on ``Dataset`` when the discriminator is
+        declared on ``Resource``) we need the chain walk so the
+        property's ``oneOf`` can carry the same ``discriminator``
+        block the schema-level emission already uses.
+        """
+        sv = self.schemaview
+        cls = sv.get_class(class_name)
+        while cls is not None:
+            field = self._discriminator_field(cls)
+            if field is not None:
+                return field
+            cls = sv.get_class(cls.is_a) if cls.is_a else None
+        return None
+
     def _is_discriminator_root(self, cls: ClassDefinition, field: str) -> bool:
         """True when ``cls`` is the topmost class declaring ``field`` as discriminator.
 
@@ -1213,7 +1490,18 @@ class OpenAPIGenerator(Generator):
 
         Mixins are excluded entirely from polymorphic mappings — they're
         trait composition, not subtyping.
+
+        Cached per build because ``_class_response_ref`` calls this
+        for every operation on every resource class (5+ calls per
+        class). Without caching, ``sv.class_descendants`` re-walks the
+        full class graph on every call.
         """
+        cache = getattr(self, "_concrete_descendants_cache", None)
+        if cache is None:
+            cache = {}
+            self._concrete_descendants_cache = cache
+        if class_name in cache:
+            return cache[class_name]
         sv = self.schemaview
         out: list[str] = []
         for name in sv.class_descendants(class_name, reflexive=False):
@@ -1221,7 +1509,22 @@ class OpenAPIGenerator(Generator):
             if cls is None or cls.abstract or cls.mixin:
                 continue
             out.append(name)
+        cache[class_name] = out
         return out
+
+    def _concrete_descendants_including_self(self, class_name: str) -> list[str]:
+        """Concrete descendants prepended with the root when concrete.
+
+        Used at *use sites* (path responses, slot ranges) where the
+        polymorphic union must include the root itself as one of the
+        addressable types — opposite of the discriminator-root case
+        handled by :meth:`_concrete_descendants_excluding_self`.
+        """
+        descendants = self._concrete_descendants_excluding_self(class_name)
+        cls = self.schemaview.get_class(class_name)
+        if cls is None or cls.abstract or cls.mixin:
+            return descendants
+        return [class_name] + descendants
 
     def _type_value(self, cls: ClassDefinition) -> str:
         """The discriminator value for a concrete subclass.
@@ -1272,61 +1575,34 @@ class OpenAPIGenerator(Generator):
                 seen[tv] = sub_name
                 mapping[tv] = f"#/components/schemas/{sub_name}"
 
-            self._inject_discriminator_on_parent(
-                schemas, class_name, field, list(mapping.keys()), mapping
-            )
             for tv, sub_name in seen.items():
                 self._inject_subclass_type_value(schemas, sub_name, field, tv)
 
-    def _inject_discriminator_on_parent(
-        self,
-        schemas: dict[str, Schema | Reference],
-        class_name: str,
-        field: str,
-        type_values: list[str],
-        mapping: dict[str, str],
-    ) -> None:
-        schema = schemas.get(class_name)
-        if not isinstance(schema, Schema):
-            return  # Reference — nothing to patch
-
-        # The discriminator goes at the schema-object level so it applies to
-        # any $ref that resolves to this schema.
-        schema.discriminator = Discriminator(propertyName=field, mapping=mapping)
-
-        # `oneOf` array of $refs to every concrete subclass — what
-        # Swagger UI and most codegens (openapi-generator's TS / Java /
-        # Spring) need to offer polymorphic selection. The discriminator
-        # tells consumers how to *interpret* a payload; oneOf tells them
-        # which subclasses are *possible*.
-        #
-        # The parent's own shape (`type: object`, properties, required)
-        # is preserved in *both* flatten and non-flatten modes because
-        # the parent is a concrete schema in its own right — codegens
-        # use `type: object` as the signal to generate a class for it,
-        # and dropping it makes openapi-generator (Spring server, in
-        # particular) skip the parent class entirely. The
-        # `flatten_inheritance` flag affects subclass shapes (no
-        # ``allOf`` back-reference), not the parent's own emission.
-        schema.oneOf = [Reference(ref=ref) for ref in mapping.values()]
-
-        # Locate or synthesise the discriminator field. With `is_a`
-        # inheritance the local properties live under `allOf[1]`; for
-        # standalone classes they're at the top level.
-        local = self._writable_local_schema(schema)
-        properties = local.properties or {}
-        existing = properties.get(field)
-        if existing is None or not isinstance(existing, Schema):
-            properties[field] = Schema(type=DataType.STRING, enum=type_values)
-        else:
-            existing.type = DataType.STRING
-            existing.enum = type_values
-        local.properties = properties
-
-        required = list(local.required or [])
-        if field not in required:
-            required.append(field)
-        local.required = required
+            # Optional back-compat field: `openapi.legacy_type_field` on
+            # the polymorphic root names a per-class constant property
+            # (e.g. `#type` carrying a Java FQN like
+            # `com.xyz.dcat.Catalog`). The value comes from each
+            # concrete class's `openapi.legacy_type_value`. Coexists
+            # with the proper discriminator — codegen uses the latter
+            # for polymorphic dispatch; the former is just a stable
+            # opaque marker for legacy consumers.
+            #
+            # ``openapi.legacy_type_codegen_name`` (optional) — supplies
+            # a clean target-language identifier via ``x-codegen-name``
+            # so openapi-generator's Java/Spring/TS templates produce
+            # ``private String legacyType`` with ``@JsonProperty("#type")``
+            # rather than the auto-mangled ``hashType``/``atType`` form.
+            legacy_field = self._class_annotation(cls, "openapi.legacy_type_field")
+            if legacy_field is not None:
+                legacy_field = legacy_field.strip()
+                codegen_name = self._class_annotation(
+                    cls, "openapi.legacy_type_codegen_name"
+                )
+                codegen_name = codegen_name.strip() if codegen_name else None
+                for sub_name in seen.values():
+                    self._inject_legacy_type_value(
+                        schemas, sub_name, legacy_field, codegen_name
+                    )
 
     @staticmethod
     def _writable_local_schema(schema: Schema) -> Schema:
@@ -1348,29 +1624,122 @@ class OpenAPIGenerator(Generator):
         field: str,
         type_value: str,
     ) -> None:
+        """Pin the discriminator field on a concrete class to its single
+        type value: ``enum: [<self>], default: <self>``.
+
+        Every concrete class — leaf or intermediate — gets the same
+        treatment. A ``Dataset`` payload always carries
+        ``resourceType: "Dataset"``; a ``Catalog`` payload always
+        carries ``resourceType: "Catalog"``. That's what the wire
+        format means in DCAT-3 (and in JSON-LD ``@type`` aliasing
+        generally), and it's what openapi-generator's Spring template
+        wires through Jackson's ``@JsonTypeInfo`` /
+        ``@JsonSubTypes`` so each generated DTO has a final
+        ``resourceType`` constant.
+
+        Trade-off — JSON Schema purity vs codegen ergonomics: under
+        strict ``allOf``-as-intersection semantics, ``Catalog``
+        inherits ``Dataset``'s ``enum: [Dataset]`` via its
+        ``allOf[0] = {$ref: Dataset}`` and intersects with its own
+        ``enum: [Catalog]`` to ``∅``. A pure JSON Schema validator
+        would reject every ``Catalog`` payload. Spring codegen
+        doesn't run JSON Schema validation — it dispatches via the
+        discriminator at the slot/path level (``oneOf`` + ``mapping``)
+        and relies on Jackson polymorphic deserialization, both of
+        which work correctly here. The per-class pin is what makes
+        the DTOs and Swagger UI display say what they should: every
+        concrete class has a fixed ``resourceType``.
+        """
         schema = schemas.get(class_name)
         if not isinstance(schema, Schema):
             return
         local = self._writable_local_schema(schema)
         properties = dict(local.properties or {})
-        # Single-value enum so a hand-written client reading the spec sees
-        # exactly what to send for this concrete subclass.
-        properties[field] = Schema(
+        disc = Schema(
             type=DataType.STRING,
             enum=[type_value],
             default=type_value,
+        )
+        properties[field] = disc
+        local.properties = properties
+        # The discriminator's RDF identity belongs to the *class*, not
+        # to a wire-format field. Class-level ``x-rdf-class`` (graph
+        # emission) and ``x-jsonld-type`` (IETF JSON-LD alignment)
+        # already convey it; attaching ``x-rdf-property: rdf:type`` to
+        # this field would tempt RDF runtimes to emit a malformed
+        # ``<subject> rdf:type "Dataset"`` literal triple.
+        required = list(local.required or [])
+        if field not in required:
+            required.append(field)
+        local.required = required
+
+    def _inject_legacy_type_value(
+        self,
+        schemas: dict[str, Schema | Reference],
+        class_name: str,
+        field: str,
+        codegen_name: str | None = None,
+    ) -> None:
+        """Inject an opaque per-class constant for back-compat consumers.
+
+        The value comes from ``openapi.legacy_type_value`` on the
+        concrete class — required when the polymorphic root declared
+        ``openapi.legacy_type_field``. Format is up to the author
+        (Java FQN, custom IRI, anything stable). No RDF mapping is
+        attached: this is a local convention, not a real predicate.
+        Errors loudly if a concrete class is missing the value, since
+        silent omission would leave gaps in the wire payload.
+
+        ``codegen_name`` (optional) is recorded on the generator
+        instance for :meth:`emit_name_mappings` to dump to a sibling
+        ``name-mappings.txt`` file the user passes to
+        ``openapi-generator-cli --name-mappings @<file>``. That CLI
+        option is the reliable way to rename an awkward JSON property
+        (``#type``) onto a clean target-language identifier
+        (``legacyType``) while preserving the wire name via
+        ``@JsonProperty``. The spec itself stays unannotated —
+        openapi-generator's Java/Spring/TS templates do **not** have
+        a universal property-renaming vendor extension, despite some
+        documentation suggesting otherwise.
+        """
+        sv = self.schemaview
+        cls = sv.get_class(class_name)
+        if cls is None:
+            return
+        value = self._class_annotation(cls, "openapi.legacy_type_value")
+        if value is None:
+            raise ValueError(
+                f"Class {class_name!r} is on a polymorphic chain that declares "
+                f"`openapi.legacy_type_field: {field!r}` but does not set "
+                f"`openapi.legacy_type_value` on this class. Each concrete "
+                f"class in the chain must specify the legacy type value "
+                f"explicitly — the format is up to you (Java FQN, custom "
+                f"IRI, etc.) and there is deliberately no fallback."
+            )
+        value = value.strip()
+        schema = schemas.get(class_name)
+        if not isinstance(schema, Schema):
+            return
+        local = self._writable_local_schema(schema)
+        properties = dict(local.properties or {})
+        properties[field] = Schema(
+            type=DataType.STRING,
+            enum=[value],
+            default=value,
         )
         local.properties = properties
         required = list(local.required or [])
         if field not in required:
             required.append(field)
         local.required = required
+        if codegen_name:
+            self._codegen_name_mappings[field] = codegen_name
 
     def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
         array_schema = Schema(
             type=DataType.ARRAY,
-            items=Reference(ref=f"#/components/schemas/{class_name}"),
+            items=self._class_response_ref(class_name),
         )
         return Operation(
             summary=f"List {_to_path_segment(class_name).replace('_', ' ')}",
@@ -1387,7 +1756,7 @@ class OpenAPIGenerator(Generator):
 
     def _make_create_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
-        ref = Reference(ref=f"#/components/schemas/{class_name}")
+        ref = self._class_response_ref(class_name)
         return Operation(
             summary=f"Create a {class_name}",
             operationId=f"create_{_to_snake_case(class_name)}",
@@ -1407,7 +1776,7 @@ class OpenAPIGenerator(Generator):
 
     def _make_read_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
-        ref = Reference(ref=f"#/components/schemas/{class_name}")
+        ref = self._class_response_ref(class_name)
         return Operation(
             summary=f"Get a {class_name}",
             operationId=f"get_{_to_snake_case(class_name)}",
@@ -1423,7 +1792,7 @@ class OpenAPIGenerator(Generator):
 
     def _make_update_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
-        ref = Reference(ref=f"#/components/schemas/{class_name}")
+        ref = self._class_response_ref(class_name)
         return Operation(
             summary=f"Update a {class_name}",
             operationId=f"update_{_to_snake_case(class_name)}",
@@ -1464,7 +1833,7 @@ class OpenAPIGenerator(Generator):
         class schema and honours ``openapi.media_types`` as usual.
         """
         media_types = self._get_media_types(cls)
-        full_ref = Reference(ref=f"#/components/schemas/{class_name}")
+        full_ref = self._class_response_ref(class_name)
         patch_ref = Reference(ref=f"#/components/schemas/{class_name}Patch")
         return Operation(
             summary=f"Patch a {class_name}",
@@ -1563,6 +1932,59 @@ class OpenAPIGenerator(Generator):
         (composition is the only option), False when it does (reference).
         """
         return bool(slot.inlined)
+
+    def _class_range_ref(self, slot: SlotDefinition, range_name: str) -> Schema | Reference:
+        """Build the schema or ``$ref`` for a class- or enum-ranged slot.
+
+        Three branches, in priority order:
+
+        1. **Reference** (``inlined: false`` against an identifier-bearing
+           class) → plain IRI string (``type: string, format: uri``).
+           RDF-roundtrippable: the same value is valid when a content
+           negotiation layer renders ``application/ld+json`` or
+           ``text/turtle`` from the same response.
+
+        2. **Polymorphic composition** (``inlined: true``, range has 2+
+           concrete descendants) → ``oneOf: [$ref each concrete option]``
+           at the property level, carrying the inherited
+           ``discriminator`` + ``mapping`` if one exists in the chain.
+           This is the shape openapi-generator's Spring template wires
+           to Jackson ``@JsonSubTypes`` for polymorphic deserialization.
+           The schema-level ``discriminator`` + ``oneOf`` on the
+           polymorphic root remains; this property-level emission gives
+           codegens the join-point information they need at the slot.
+
+        3. **Plain composition** (everything else) → ``$ref <Range>``.
+
+        Enum ranges always go through branch 3.
+        """
+        sv = self.schemaview
+        target_cls = sv.get_class(range_name)
+
+        if (
+            target_cls is not None
+            and not self._is_composition(slot)
+            and self._identifier_slot(range_name) is not None
+        ):
+            return Schema(type=DataType.STRING, schema_format="uri")
+
+        if target_cls is not None and self._is_composition(slot):
+            descendants = self._concrete_descendants_including_self(range_name)
+            if len(descendants) > 1:
+                oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
+                schema = Schema(oneOf=oneof)
+                field = self._inherited_discriminator_field(range_name)
+                if field is not None:
+                    mapping = {
+                        self._type_value(sv.get_class(n)): f"#/components/schemas/{n}"
+                        for n in descendants
+                    }
+                    schema.discriminator = Discriminator(
+                        propertyName=field, mapping=mapping
+                    )
+                return schema
+
+        return Reference(ref=f"#/components/schemas/{range_name}")
 
     @staticmethod
     def _build_resource_link_schema() -> Schema:
@@ -2090,7 +2512,7 @@ class OpenAPIGenerator(Generator):
             return
         target_cls = self.schemaview.get_class(target_class_name)
         media_types = self._get_media_types(target_cls)
-        target_ref = Reference(ref=f"#/components/schemas/{target_class_name}")
+        target_ref = self._class_response_ref(target_class_name)
         array_schema = Schema(type=DataType.ARRAY, items=target_ref)
         op_tag = self._class_tag(target_class_name)
         slot_seg = slot.name
@@ -2262,7 +2684,7 @@ class OpenAPIGenerator(Generator):
 
         target_cls = self.schemaview.get_class(target_class_name)
         media_types = self._get_media_types(target_cls)
-        target_ref = Reference(ref=f"#/components/schemas/{target_class_name}")
+        target_ref = self._class_response_ref(target_class_name)
         array_schema = Schema(type=DataType.ARRAY, items=target_ref)
 
         link_ref = Reference(ref="#/components/schemas/ResourceLink")

--- a/src/linkml_openapi/post_processors/__init__.py
+++ b/src/linkml_openapi/post_processors/__init__.py
@@ -37,10 +37,7 @@ def apply(spec: dict, names: list[str]) -> dict:
         processor = REGISTRY.get(name)
         if processor is None:
             available = ", ".join(sorted(REGISTRY))
-            raise ValueError(
-                f"Unknown post-processor {name!r}. "
-                f"Available: {available}"
-            )
+            raise ValueError(f"Unknown post-processor {name!r}. Available: {available}")
         spec = processor(spec)
     return spec
 

--- a/src/linkml_openapi/post_processors/__init__.py
+++ b/src/linkml_openapi/post_processors/__init__.py
@@ -1,0 +1,48 @@
+"""Spec post-processors that rewrite the generated OpenAPI dict.
+
+Each post-processor is a pure function ``dict -> dict`` (in-place
+mutation is fine; return is for chaining). They run after
+:meth:`OpenAPIGenerator.serialize` builds the spec but before
+serialisation, in the order the user supplies via
+``--post-process NAME[,NAME...]`` on the CLI.
+
+The split between post-processors and the core generator is
+deliberate: the generator emits a *canonical* spec optimised for
+authoring clarity (allOf inheritance, inline oneOfs at use sites,
+RDF metadata), and post-processors adapt that canonical form to
+specific consumer needs (openapi-generator codegens, validator
+quirks, JSON-LD adapters, etc.). Adding a new post-processor never
+requires touching the generator.
+"""
+
+from collections.abc import Callable
+
+from .extract_inline_oneof import extract_inline_oneof
+
+PostProcessor = Callable[[dict], dict]
+
+REGISTRY: dict[str, PostProcessor] = {
+    "extract-inline-oneof": extract_inline_oneof,
+}
+
+
+def apply(spec: dict, names: list[str]) -> dict:
+    """Run a sequence of registered post-processors against ``spec``.
+
+    ``names`` come from the CLI in declared order. Unknown names raise
+    ``ValueError`` so typos surface immediately rather than silently
+    skipping a transformation.
+    """
+    for name in names:
+        processor = REGISTRY.get(name)
+        if processor is None:
+            available = ", ".join(sorted(REGISTRY))
+            raise ValueError(
+                f"Unknown post-processor {name!r}. "
+                f"Available: {available}"
+            )
+        spec = processor(spec)
+    return spec
+
+
+__all__ = ["apply", "REGISTRY", "extract_inline_oneof"]

--- a/src/linkml_openapi/post_processors/extract_inline_oneof.py
+++ b/src/linkml_openapi/post_processors/extract_inline_oneof.py
@@ -1,0 +1,143 @@
+"""Hoist inline ``oneOf`` schemas in path operations to named components.
+
+openapi-generator and similar codegens treat inline ``oneOf`` schemas
+in path responses or request bodies as anonymous types. They
+auto-name them (``ListDatasets200ResponseInner``), and several
+templates flatten the union into a single DTO that carries every
+branch's properties — losing the discriminator dispatch and
+per-branch pinning.
+
+Hoisting each unique inline ``oneOf`` to a named entry under
+``components/schemas`` and replacing the inline shape with a
+``$ref`` makes the polymorphic structure persist across the
+LinkML → OpenAPI → openapi-generator → Spring → springdoc round
+trip with the discriminator intact.
+
+Naming: derived from the first ``$ref`` branch's class name plus a
+``Variant`` suffix (e.g. ``DatasetVariant`` for an inline ``oneOf``
+over Dataset/Catalog/DatasetSeries). Identical inline shapes
+deduplicate to a single component; near-duplicates are
+disambiguated with a numeric tail. The empty-string fallback
+``PolymorphicVariant`` covers degenerate cases where no branches
+have ``$ref``s.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any
+
+
+def extract_inline_oneof(spec: dict) -> dict:
+    """Rewrite ``spec`` so every inline ``oneOf`` in a path operation
+    becomes ``$ref`` to a named component schema.
+
+    Mutates and returns ``spec``. Idempotent — running twice is a
+    no-op because the second pass finds no remaining inline oneOfs.
+    """
+    components = spec.setdefault("components", {})
+    schemas = components.setdefault("schemas", {})
+
+    # Maps canonical-content-key → component name, so the same inline
+    # oneOf appearing in N paths hoists to a single named component.
+    seen: dict[str, str] = {}
+
+    def _hoist(node: Any) -> Any:
+        if isinstance(node, dict):
+            if _is_inline_polymorphic_schema(node):
+                return _hoist_one(node, seen, schemas)
+            return {k: _hoist(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_hoist(item) for item in node]
+        return node
+
+    paths = spec.get("paths") or {}
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        for method_key in (
+            "get", "put", "post", "delete", "patch", "options", "head", "trace"
+        ):
+            op = path_item.get(method_key)
+            if not isinstance(op, dict):
+                continue
+            _walk_op(op, _hoist)
+
+    return spec
+
+
+def _is_inline_polymorphic_schema(node: dict) -> bool:
+    """An inline ``oneOf`` schema worth hoisting.
+
+    We only hoist polymorphic unions — those carrying a discriminator —
+    since the codegen pain is around discriminator dispatch. A bare
+    ``oneOf`` without a discriminator is structurally simpler and most
+    codegens handle the inline form fine.
+    """
+    return "oneOf" in node and "discriminator" in node and "$ref" not in node
+
+
+def _walk_op(op: dict, hoist) -> None:
+    """Apply ``hoist`` to every inline schema reachable inside an
+    operation: request body content schemas and response content
+    schemas. Other operation fields (parameters, security, etc.) keep
+    their inline schemas — those rarely use polymorphic ``oneOf``."""
+    request_body = op.get("requestBody")
+    if isinstance(request_body, dict):
+        _hoist_content(request_body.get("content"), hoist)
+    responses = op.get("responses") or {}
+    for response in responses.values():
+        if isinstance(response, dict):
+            _hoist_content(response.get("content"), hoist)
+
+
+def _hoist_content(content: Any, hoist) -> None:
+    if not isinstance(content, dict):
+        return
+    for media in content.values():
+        if not isinstance(media, dict):
+            continue
+        if "schema" in media:
+            media["schema"] = hoist(media["schema"])
+
+
+def _hoist_one(node: dict, seen: dict[str, str], schemas: dict) -> dict:
+    """Replace ``node`` with a ``$ref`` and register the named component.
+
+    The original ``node`` is what gets stored as the component (deep-
+    copied so subsequent walks of the same path don't double-process
+    it). The caller receives a fresh ``$ref`` dict.
+    """
+    key = json.dumps(node, sort_keys=True)
+    if key in seen:
+        return {"$ref": f"#/components/schemas/{seen[key]}"}
+
+    name = _derive_name(node, schemas)
+    schemas[name] = deepcopy(node)
+    seen[key] = name
+    return {"$ref": f"#/components/schemas/{name}"}
+
+
+def _derive_name(node: dict, schemas: dict) -> str:
+    """Pick a stable, descriptive component name for an inline oneOf.
+
+    The first ``$ref`` branch usually points at the polymorphic root
+    (the most general type in the union), so its class name is the
+    natural seed: ``Dataset`` + ``Variant`` → ``DatasetVariant``.
+    Falls back to ``PolymorphicVariant`` when no branches are
+    ``$ref``s.
+    """
+    seed = "Polymorphic"
+    for branch in node.get("oneOf") or []:
+        if isinstance(branch, dict) and "$ref" in branch:
+            ref = branch["$ref"]
+            seed = ref.rsplit("/", 1)[-1]
+            break
+    base = f"{seed}Variant"
+    candidate = base
+    counter = 2
+    while candidate in schemas:
+        candidate = f"{base}{counter}"
+        counter += 1
+    return candidate

--- a/src/linkml_openapi/post_processors/extract_inline_oneof.py
+++ b/src/linkml_openapi/post_processors/extract_inline_oneof.py
@@ -56,9 +56,7 @@ def extract_inline_oneof(spec: dict) -> dict:
     for path_item in paths.values():
         if not isinstance(path_item, dict):
             continue
-        for method_key in (
-            "get", "put", "post", "delete", "patch", "options", "head", "trace"
-        ):
+        for method_key in ("get", "put", "post", "delete", "patch", "options", "head", "trace"):
             op = path_item.get(method_key)
             if not isinstance(op, dict):
                 continue

--- a/tests/test_dcat3.py
+++ b/tests/test_dcat3.py
@@ -1,0 +1,558 @@
+"""DCAT-3 (W3C, https://www.w3.org/TR/vocab-dcat-3/) generation tests.
+
+Pins the OpenAPI shape emitted from the DCAT-3 core fixture against the
+behaviours that openapi-generator's Spring template (and other Java/TS
+codegens) need:
+
+  * Multi-level ``is_a`` chains stay chained.  Resource → Dataset → Catalog
+    must emit three separate ``allOf: [{$ref: <parent>}, {properties}]``
+    schemas, not a flattened single layer.
+  * The discriminator hoists once.  ``openapi.discriminator: resourceType``
+    on Resource produces a ``discriminator`` + ``oneOf`` block on the
+    Resource schema only; subclasses inherit it via the ``$ref``.
+  * Polymorphic slot ranges resolve through the discriminator-bearing
+    schema.  ``CatalogRecord.primaryTopic: Resource`` is a bare ``$ref``
+    to Resource — Spring codegen relies on this so its generated DTO has
+    a single Resource interface, not a duplicated oneOf.
+  * Recursive slot ranges become ``$ref`` loops.  ``Catalog.catalog`` →
+    ``$ref Catalog`` (no inlining, no infinite expansion).
+  * ``class_uri`` lands on every emitted schema as ``x-rdf-class``,
+    preserving DCAT-3 RDF identity even though the field name on the
+    wire is ``resourceType`` (not ``@type``).
+  * Abstract classes do not emit resource paths.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from linkml_openapi.generator import OpenAPIGenerator
+
+FIXTURE = str(Path(__file__).parent / "fixtures" / "dcat3.yaml")
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict:
+    return yaml.safe_load(OpenAPIGenerator(FIXTURE).serialize())
+
+
+@pytest.fixture(scope="module")
+def schemas(spec) -> dict:
+    return spec["components"]["schemas"]
+
+
+def _props(schema: dict) -> dict:
+    """Return a class schema's properties regardless of whether it uses
+    ``allOf`` (inherited form, ``allOf[1]['properties']``) or is flat
+    (top-level ``properties``).
+
+    Polymorphic class chains use ``allOf`` so codegens like
+    openapi-generator's Spring template produce idiomatic Java
+    inheritance — Catalog extends Dataset extends Resource — and the
+    spec round-trips through Spring + springdoc with full polymorphic
+    dispatch preserved. Tests use this helper so they don't break when
+    ``flatten_inheritance`` is toggled.
+    """
+    if "allOf" in schema:
+        for part in schema["allOf"]:
+            if isinstance(part, dict) and "properties" in part:
+                return part["properties"]
+        return {}
+    return schema.get("properties") or {}
+
+
+def _required(schema: dict) -> list:
+    """Return a class schema's required list, regardless of allOf shape."""
+    if "allOf" in schema:
+        for part in schema["allOf"]:
+            if isinstance(part, dict) and "required" in part:
+                return part["required"]
+        return []
+    return schema.get("required") or []
+
+
+class TestDiscriminatorPlacement:
+    """Polymorphism lives at points-of-use, not at the schema level.
+
+    A schema-level ``discriminator`` + ``oneOf`` on the polymorphic root
+    bleeds into every subclass via ``allOf: [{$ref: <root>}]`` — Swagger
+    UI and several codegens render it as if every subclass also offers
+    the polymorphic union. The cleanest fix is to express polymorphism
+    *only* at the join points: slot ranges (when composition reaches a
+    polymorphic class) and path responses. Both are already done by
+    :meth:`_class_range_ref` and :meth:`_class_response_ref`. The
+    discriminator field itself still lives on the root schema as a
+    plain property (``type: string, enum: […]``) so the wire payload
+    is unambiguous.
+    """
+
+    def test_resource_has_no_schema_level_discriminator(self, schemas):
+        assert "discriminator" not in schemas["Resource"]
+
+    def test_resource_has_no_schema_level_oneof(self, schemas):
+        assert "oneOf" not in schemas["Resource"]
+
+    def test_resource_does_not_carry_discriminator_field_itself(self, schemas):
+        """An abstract polymorphic root has no instances on the wire, so it
+        doesn't need ``resourceType`` in its own properties either. Each
+        concrete subclass declares its own pinned ``resourceType`` in
+        its local block via ``_inject_subclass_type_value``."""
+        assert "resourceType" not in _props(schemas["Resource"])
+        assert "resourceType" not in _required(schemas["Resource"])
+
+    @pytest.mark.parametrize("subclass", ["Dataset", "Catalog", "DatasetSeries", "DataService"])
+    def test_subclass_has_no_schema_level_polymorphism(self, schemas, subclass):
+        """Subclass schemas stay clean: no inherited discriminator+oneOf
+        bleeding through allOf — the subclass's display in Swagger UI
+        shows just its own and inherited properties, no sibling list."""
+        assert "discriminator" not in schemas[subclass]
+        assert "oneOf" not in schemas[subclass]
+
+    @pytest.mark.parametrize(
+        "concrete",
+        ["Dataset", "Catalog", "DatasetSeries", "DataService"],
+    )
+    def test_every_concrete_class_pins_resource_type_to_self(self, schemas, concrete):
+        """Each concrete class declares its own ``resourceType`` pinned
+        to ``enum: [<self>]`` with a matching ``default`` in its local
+        block. Under the ``allOf``-based inheritance shape, the parent
+        Dataset's pin and Catalog's pin theoretically intersect to ∅
+        for JSON Schema purists — but openapi-generator's Spring
+        template doesn't run JSON Schema validation; it dispatches via
+        the discriminator at slot/path joins and Jackson polymorphism,
+        which preserves the per-class identity at the codegen layer."""
+        prop = _props(schemas[concrete])["resourceType"]
+        assert prop["enum"] == [concrete]
+        assert prop["default"] == concrete
+        assert "resourceType" in _required(schemas[concrete])
+
+    def test_resource_type_carries_no_field_level_rdf_property(self, schemas):
+        """The discriminator's RDF identity belongs to the class
+        (``x-rdf-class`` + ``x-jsonld-type``), not to the field — so
+        no field-level ``x-rdf-property`` is emitted, otherwise an
+        RDF runtime would synthesise a malformed
+        ``<subject> rdf:type "Dataset"`` literal triple."""
+        for cls in ("Dataset", "Catalog", "DatasetSeries", "DataService"):
+            prop = _props(schemas[cls])["resourceType"]
+            assert "x-rdf-property" not in prop
+
+    @pytest.mark.parametrize(
+        "concrete,legacy_value",
+        [
+            ("Dataset", "com.xyz.dcat.Dataset"),
+            ("Catalog", "com.xyz.dcat.Catalog"),
+            ("DatasetSeries", "com.xyz.dcat.DatasetSeries"),
+            ("DataService", "com.xyz.dcat.DataService"),
+        ],
+    )
+    def test_legacy_type_field_pins_per_class_constant(self, schemas, concrete, legacy_value):
+        """``openapi.legacy_type_field: "#type"`` on the polymorphic root
+        synthesises a back-compat marker on every concrete class. Each
+        class's ``openapi.legacy_type_value`` becomes the pinned constant
+        — values can be opaque (Java FQN, custom IRI, anything stable)
+        because the field is for back-compat, not RDF semantics."""
+        prop = _props(schemas[concrete])["#type"]
+        assert prop["enum"] == [legacy_value]
+        assert prop["default"] == legacy_value
+        assert prop["type"] == "string"
+        assert "#type" in _required(schemas[concrete])
+
+    def test_legacy_type_field_carries_no_rdf_property(self, schemas):
+        """The legacy field is a back-compat convention, not an RDF
+        predicate — no ``x-rdf-property`` should be attached to it."""
+        for cls in ("Dataset", "Catalog", "DatasetSeries", "DataService"):
+            assert "x-rdf-property" not in _props(schemas[cls])["#type"]
+
+    def test_legacy_type_field_carries_no_x_codegen_name_extension(self, schemas):
+        """openapi-generator does not have a universal property-renaming
+        vendor extension, so we deliberately do not emit one. The rename
+        is captured separately via :meth:`emit_name_mappings` and lands
+        in a sibling file the user passes to
+        ``openapi-generator --name-mappings @<file>``."""
+        for cls in ("Dataset", "Catalog", "DatasetSeries", "DataService"):
+            assert "x-codegen-name" not in _props(schemas[cls])["#type"]
+
+    def test_distribution_does_not_carry_legacy_type_field(self, schemas):
+        """Distribution is outside the polymorphic chain, so neither
+        the proper discriminator nor the legacy field appears on it."""
+        props = _props(schemas["Distribution"])
+        assert "#type" not in props
+        assert "resourceType" not in props
+
+    def test_distribution_does_not_carry_discriminator(self, schemas):
+        """Distribution is outside the Resource hierarchy. The discriminator
+        must not leak across hierarchies."""
+        assert "discriminator" not in schemas["Distribution"]
+        assert "oneOf" not in schemas["Distribution"]
+        assert "resourceType" not in _props(schemas["Distribution"])
+
+
+class TestPolymorphicInheritance:
+    """Polymorphic class chains use ``allOf: [{$ref: parent}, {local}]``
+    so codegens (notably openapi-generator's Spring template) produce
+    idiomatic ``Catalog extends Dataset extends Resource`` Java
+    inheritance with proper Jackson polymorphic dispatch — and the
+    spec round-trips through Spring + springdoc with discriminator
+    handling preserved. Use ``flatten_inheritance`` to inline if a
+    consumer prefers self-contained schemas.
+    """
+
+    @pytest.mark.parametrize(
+        "concrete,parent",
+        [
+            ("Dataset", "Resource"),
+            ("Catalog", "Dataset"),
+            ("DatasetSeries", "Dataset"),
+            ("DataService", "Resource"),
+        ],
+    )
+    def test_polymorphic_class_extends_parent_via_allof(self, schemas, concrete, parent):
+        """Each concrete polymorphic class chains to its immediate
+        ancestor via ``allOf[0]`` — the chain isn't collapsed to the
+        root Resource. Codegen produces matching Java inheritance."""
+        sch = schemas[concrete]
+        assert "allOf" in sch
+        assert sch["allOf"][0] == {"$ref": f"#/components/schemas/{parent}"}
+
+    def test_resource_remains_concrete_object_for_codegen(self, schemas):
+        """``Resource`` is abstract in LinkML, but emitted as
+        ``type: object`` with its own properties so codegen produces a
+        Resource base class that subclasses extend."""
+        sch = schemas["Resource"]
+        assert sch["type"] == "object"
+        assert "id" in (sch.get("properties") or {})
+
+
+class TestComposition:
+    """Composition vs reference distinguishes ownership.
+
+    * ``Dataset.distribution`` (``inlined: true``) — distributions are
+      part of the parent dataset payload.
+    * ``Location`` and ``PeriodOfTime`` have no identifier slot, so
+      LinkML defaults their ranges to composition; ``Dataset.spatial``
+      and ``Dataset.temporal`` embed structured value objects.
+    * Everything else (``publisher``, ``creator``, ``catalog``,
+      ``inSeries``, …) is a reference IRI — LinkML's default for
+      identifier-bearing target classes.
+    """
+
+    def test_dataset_distribution_items_embed_distribution_schema(self, schemas):
+        prop = _props(schemas["Dataset"])["distribution"]
+        assert prop["type"] == "array"
+        # Distribution has no concrete descendants, so items are a plain
+        # $ref — not a oneOf wrapper.
+        assert prop["items"] == {"$ref": "#/components/schemas/Distribution"}
+
+    def test_nested_distribution_collection_path_emitted(self, spec):
+        """Composition produces nested CRUD paths under the parent."""
+        assert "/datasets/{id}/distribution" in spec["paths"]
+        assert "/datasets/{id}/distribution/{distribution_id}" in spec["paths"]
+
+    @staticmethod
+    def _ref_target(prop: dict) -> str | None:
+        """Resolve the target of a property whether emitted as a bare
+        ``$ref`` or wrapped in ``allOf: [{$ref: …}]`` (the wrapper form
+        is used when the slot also carries a description / pattern /
+        bounds — the wrapper lets those sit alongside the reference)."""
+        if "$ref" in prop:
+            return prop["$ref"]
+        if "allOf" in prop:
+            for part in prop["allOf"]:
+                if isinstance(part, dict) and "$ref" in part:
+                    return part["$ref"]
+        return None
+
+    def test_dataset_spatial_embeds_location_object(self, schemas):
+        """``Location`` has no identifier slot, so the LinkML default
+        is composition — the spatial value travels embedded in the
+        dataset payload, not as an IRI."""
+        prop = _props(schemas["Dataset"])["spatial"]
+        assert self._ref_target(prop) == "#/components/schemas/Location"
+
+    def test_dataset_temporal_embeds_period_object(self, schemas):
+        prop = _props(schemas["Dataset"])["temporal"]
+        assert self._ref_target(prop) == "#/components/schemas/PeriodOfTime"
+
+    def test_distribution_checksum_embeds_checksum_object(self, schemas):
+        """SPDX-style checksum is structured but not identified — composed."""
+        prop = _props(schemas["Distribution"])["checksum"]
+        assert self._ref_target(prop) == "#/components/schemas/Checksum"
+
+    @pytest.mark.parametrize(
+        "embedded_class,property_name,property_type",
+        [
+            ("Location", "geometry", "string"),
+            ("Location", "bbox", "string"),
+            ("PeriodOfTime", "startDate", "string"),
+            ("PeriodOfTime", "endDate", "string"),
+            ("Checksum", "checksumValue", "string"),
+        ],
+    )
+    def test_embedded_value_class_has_no_identifier(
+        self, schemas, embedded_class, property_name, property_type
+    ):
+        """Embedded classes deliberately omit any identifier so LinkML
+        defaults them to composition. Spec-side: no ``id`` in
+        properties, no ``id`` in required."""
+        sch = schemas[embedded_class]
+        assert "id" not in (sch.get("properties") or {})
+        assert "id" not in (sch.get("required") or [])
+        assert property_name in sch["properties"]
+
+
+class TestAgentClass:
+    """``Agent`` is a top-level resource (``foaf:Agent``) with its own
+    CRUD endpoints. Resource-level slots (``publisher``, ``creator``,
+    ``contributor``, ``contactPoint``) reference Agent by IRI, not
+    embedded — the LinkML default for identifier-bearing target
+    classes."""
+
+    @staticmethod
+    def _is_iri_string(prop: dict) -> bool:
+        return prop.get("type") == "string" and prop.get("format") == "uri"
+
+    def test_agent_endpoints_emitted(self, spec):
+        assert "/agents" in spec["paths"]
+        assert "/agents/{id}" in spec["paths"]
+
+    def test_agent_schema_carries_foaf_class_uri(self, schemas):
+        assert schemas["Agent"]["x-rdf-class"] == "http://xmlns.com/foaf/0.1/Agent"
+
+    @pytest.mark.parametrize("agent_slot", ["publisher", "creator", "contributor", "contactPoint"])
+    def test_dataset_agent_slots_are_iri_references(self, schemas, agent_slot):
+        # Dataset inherits these from Resource via allOf, so they live
+        # on Resource's local schema, not Dataset's. Use a chain walk.
+        prop = _props(schemas["Resource"])[agent_slot]
+        if prop.get("type") == "array":
+            assert self._is_iri_string(prop["items"])
+        else:
+            assert self._is_iri_string(prop)
+
+    def test_agent_inherited_into_every_polymorphic_class(self, schemas):
+        """Resource defines the agent slots → Dataset, Catalog, etc.
+        inherit them via ``allOf [{$ref: Resource}, ...]``. The
+        properties live on Resource itself; subclass DTOs see them
+        through the chain."""
+        resource_props = _props(schemas["Resource"])
+        assert "publisher" in resource_props
+        assert "creator" in resource_props
+        for cls in ("Dataset", "Catalog", "DatasetSeries", "DataService"):
+            assert schemas[cls]["allOf"][0]["$ref"].startswith("#/components/schemas/")
+
+
+class TestVersioning:
+    """DCAT-3 versioning slots all reference Resource (the polymorphic
+    root) via IRI — they don't embed full payloads."""
+
+    @staticmethod
+    def _is_iri_string(prop: dict) -> bool:
+        return prop.get("type") == "string" and prop.get("format") == "uri"
+
+    @pytest.mark.parametrize(
+        "version_slot,multivalued",
+        [
+            ("isVersionOf", False),
+            ("hasVersion", True),
+            ("hasCurrentVersion", False),
+            ("previousVersion", False),
+            ("replaces", False),
+            ("isReplacedBy", False),
+        ],
+    )
+    def test_versioning_slot_is_iri_reference(self, schemas, version_slot, multivalued):
+        # Defined on Resource → inherited via allOf into Dataset etc.
+        prop = _props(schemas["Resource"])[version_slot]
+        if multivalued:
+            assert prop["type"] == "array"
+            assert self._is_iri_string(prop["items"])
+        else:
+            assert self._is_iri_string(prop)
+
+    def test_version_string_slots_are_plain_strings(self, schemas):
+        """``version`` and ``versionNotes`` are literal strings (adms:),
+        not URIs."""
+        version = _props(schemas["Resource"])["version"]
+        assert version["type"] == "string"
+        assert "format" not in version
+
+
+class TestReferenceSlots:
+    """Class-ranged slots default to ``inlined: false`` — they emit a
+    plain IRI string (``type: string, format: uri``), not a full
+    embedded copy.
+
+    DCAT-3 is RDF-first: every slot above is a *relation*, not
+    composition. The wire JSON is ``{"dataset": ["https://…/d/1"]}``,
+    never an embedded Dataset payload. The same shape stays valid when
+    a content-negotiated ``application/ld+json`` or ``text/turtle``
+    response is rendered from the same data, because in RDF a relation
+    is always an IRI — wrapping it in ``{id: …}`` would be invalid.
+    """
+
+    URI = {"type": "string", "format": "uri"}
+
+    def test_catalog_record_primary_topic_is_iri_string(self, schemas):
+        prop = _props(schemas["CatalogRecord"])["primaryTopic"]
+        assert prop["type"] == "string"
+        assert prop["format"] == "uri"
+
+    def test_catalog_dataset_array_items_are_iri_strings(self, schemas):
+        prop = _props(schemas["Catalog"])["dataset"]
+        assert prop["type"] == "array"
+        assert prop["items"] == self.URI
+
+    def test_data_service_serves_dataset_array_items_are_iri_strings(self, schemas):
+        prop = _props(schemas["DataService"])["servesDataset"]
+        assert prop["type"] == "array"
+        assert prop["items"] == self.URI
+
+
+class TestRecursionDissolves:
+    """When ``Catalog.catalog`` is treated as a relation (the LinkML default
+    for identifier-bearing target classes), the self-cycle in the spec
+    disappears: the items are IRI strings, not embedded ``Catalog``
+    payloads. Swagger UI no longer renders an infinite expansion."""
+
+    URI = {"type": "string", "format": "uri"}
+
+    def test_catalog_self_reference_does_not_recurse(self, schemas):
+        prop = _props(schemas["Catalog"])["catalog"]
+        assert prop["type"] == "array"
+        assert prop["items"] == self.URI
+
+    def test_dataset_in_series_is_iri_string(self, schemas):
+        """The W3C DCAT-3 link goes from a Dataset to its DatasetSeries
+        via ``dcat:inSeries`` — there is no inverse ``seriesMember``
+        slot on the series. The dataset side carries the IRI reference;
+        the series's members are recovered by querying datasets whose
+        ``inSeries`` includes the series IRI."""
+        prop = _props(schemas["Dataset"])["inSeries"]
+        assert prop["type"] == "array"
+        assert prop["items"] == self.URI
+        # No forward seriesMember on DatasetSeries.
+        assert "seriesMember" not in _props(schemas["DatasetSeries"])
+
+
+class TestRdfIdentity:
+    """`class_uri: dcat:*` survives the round-trip as `x-rdf-class`."""
+
+    @pytest.mark.parametrize(
+        "class_name,curie",
+        [
+            ("Resource", "http://www.w3.org/ns/dcat#Resource"),
+            ("Dataset", "http://www.w3.org/ns/dcat#Dataset"),
+            ("Catalog", "http://www.w3.org/ns/dcat#Catalog"),
+            ("DatasetSeries", "http://www.w3.org/ns/dcat#DatasetSeries"),
+            ("DataService", "http://www.w3.org/ns/dcat#DataService"),
+            ("Distribution", "http://www.w3.org/ns/dcat#Distribution"),
+            ("CatalogRecord", "http://www.w3.org/ns/dcat#CatalogRecord"),
+        ],
+    )
+    def test_x_rdf_class_matches_expanded_curie(self, schemas, class_name, curie):
+        assert schemas[class_name]["x-rdf-class"] == curie
+
+    def test_slot_uri_lands_as_x_rdf_property(self, schemas):
+        """`slot_uri` round-trips through `x-rdf-property` so JSON-LD
+        consumers can map ``resourceType`` → ``@type`` and inherited slots
+        to their RDF predicates without needing the LinkML schema."""
+        assert (
+            _props(schemas["Dataset"])["distribution"]["x-rdf-property"]
+            == "http://www.w3.org/ns/dcat#distribution"
+        )
+
+
+class TestPolymorphicResponses:
+    """Path operations targeting a polymorphic class emit ``oneOf`` +
+    ``discriminator`` in the response (and request) schema, so a GET on
+    ``/datasets/{id}`` can legitimately return a ``DatasetSeries`` or
+    ``Catalog`` and the spec advertises that fact. Spring/openapi-
+    generator wires this into Jackson polymorphic deserialization.
+    """
+
+    def test_get_dataset_response_is_polymorphic_oneof(self, spec):
+        body = spec["paths"]["/datasets/{id}"]["get"]["responses"]["200"]
+        schema = body["content"]["application/json"]["schema"]
+        refs = {item["$ref"] for item in schema["oneOf"]}
+        assert refs == {
+            "#/components/schemas/Dataset",
+            "#/components/schemas/Catalog",
+            "#/components/schemas/DatasetSeries",
+        }
+        assert schema["discriminator"]["propertyName"] == "resourceType"
+
+    def test_list_datasets_items_are_polymorphic(self, spec):
+        body = spec["paths"]["/datasets"]["get"]["responses"]["200"]
+        schema = body["content"]["application/json"]["schema"]
+        assert schema["type"] == "array"
+        items = schema["items"]
+        refs = {item["$ref"] for item in items["oneOf"]}
+        assert refs == {
+            "#/components/schemas/Dataset",
+            "#/components/schemas/Catalog",
+            "#/components/schemas/DatasetSeries",
+        }
+
+    def test_create_dataset_request_body_accepts_subclasses(self, spec):
+        body = spec["paths"]["/datasets"]["post"]["requestBody"]
+        schema = body["content"]["application/json"]["schema"]
+        refs = {item["$ref"] for item in schema["oneOf"]}
+        assert refs == {
+            "#/components/schemas/Dataset",
+            "#/components/schemas/Catalog",
+            "#/components/schemas/DatasetSeries",
+        }
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/catalogs/{id}",
+            "/data_services/{id}",
+            # Distribution is `nested_only`: the canonical URL is the deep
+            # chained one under its parent Catalog → Dataset, not a flat
+            # `/distributions/{id}`.
+            "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution/{id}",
+        ],
+    )
+    def test_non_polymorphic_class_endpoint_uses_plain_ref(self, spec, path):
+        """A class with no concrete descendants gets a bare ``$ref`` —
+        no spurious oneOf wrapping."""
+        body = spec["paths"][path]["get"]["responses"]["200"]
+        schema = body["content"]["application/json"]["schema"]
+        assert "oneOf" not in schema
+        assert schema["$ref"].startswith("#/components/schemas/")
+
+
+class TestPathEmission:
+    def test_abstract_resource_has_no_path(self, spec):
+        assert "/resources" not in spec["paths"]
+        assert "/resource" not in spec["paths"]
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/datasets",
+            "/datasets/{id}",
+            "/catalogs",
+            "/catalogs/{id}",
+            "/dataset_series",
+            "/dataset_series/{id}",
+            "/data_services",
+            "/data_services/{id}",
+            # Distribution carries `openapi.nested_only: "true"` — the
+            # canonical URL is the deep chain under Catalog → Dataset, and
+            # the flat `/distributions[/...]` surface is suppressed.
+            "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution/{id}",
+            "/catalog_records",
+            "/catalog_records/{id}",
+        ],
+    )
+    def test_concrete_resource_path_exists(self, spec, path):
+        assert path in spec["paths"], f"missing path: {path}"
+
+    def test_distribution_flat_paths_suppressed_by_nested_only(self, spec):
+        """``openapi.nested_only: "true"`` on Distribution drops the flat
+        collection and item paths — Distributions are meaningless outside
+        their parent Dataset, so the canonical URL is the deep chained one."""
+        assert "/distributions" not in spec["paths"]
+        assert "/distributions/{id}" not in spec["paths"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -198,7 +198,10 @@ class TestComponentSchemas:
         spec = _generate()
         person_props = spec["components"]["schemas"]["Person"]["allOf"][1]["properties"]
         assert person_props["addresses"]["type"] == "array"
-        assert person_props["addresses"]["items"] == {"$ref": "#/components/schemas/Address"}
+        # Address has an identifier and the slot defaults to `inlined: false`
+        # in LinkML, so the on-the-wire shape is a plain IRI string — the
+        # form that survives content negotiation to RDF media types.
+        assert person_props["addresses"]["items"] == {"type": "string", "format": "uri"}
 
     def test_enum_ref(self):
         spec = _generate()
@@ -1773,14 +1776,22 @@ classes:
         assert "/books" not in spec["paths"]  # also no auto-pluralised flat
 
     def test_multi_level_composition_cycle_protection(self):
-        """Mutual composition (`A.bs[B].as[A]`) terminates without infinite recursion."""
+        """Mutual composition (`A.bs[B].as[A]`) terminates without infinite recursion.
+
+        ``openapi.recurse_max_depth`` on either class acknowledges the
+        cycle so the generator's upfront recursion guard lets the build
+        proceed; the path-emission stack guard is what's actually under
+        test here.
+        """
         spec = _generate_from_string("""
 id: https://example.org/cycle
 name: cy
 default_range: string
 classes:
   A:
-    annotations: { openapi.resource: "true" }
+    annotations:
+      openapi.resource: "true"
+      openapi.recurse_max_depth: "1"
     attributes:
       id: { identifier: true, required: true }
       bs:
@@ -1810,42 +1821,51 @@ classes:
 class TestDiscriminator:
     """Coverage for issue #20 — discriminator + polymorphism."""
 
-    def test_explicit_discriminator_field_synthesised(self):
-        """`openapi.discriminator: kind` synthesises the field on the parent."""
+    def test_abstract_parent_does_not_carry_discriminator_field(self):
+        """An abstract parent (Product is abstract) has no wire instances,
+        so the discriminator field is not injected into its properties.
+        Doing so would inherit through ``allOf`` and pollute every
+        subclass's display with the union enum of all siblings."""
         spec = _generate()
         product = spec["components"]["schemas"]["Product"]
-        assert "kind" in product["properties"]
-        assert product["properties"]["kind"]["type"] == "string"
-        assert "kind" in product["required"]
+        assert "kind" not in (product.get("properties") or {})
+        assert "kind" not in (product.get("required") or [])
 
-    def test_explicit_discriminator_mapping_uses_type_value(self):
-        """Type values from `openapi.type_value` flow into the mapping."""
+    def test_subclass_carries_pinned_discriminator_value(self):
+        """Each concrete subclass uses ``allOf [{$ref: parent},
+        {properties: {kind: enum=[<self>], default: <self>}}]`` so
+        codegens emit Java/TS DTOs that extend the parent and wire
+        the discriminator value automatically on construction."""
         spec = _generate()
-        product = spec["components"]["schemas"]["Product"]
-        assert product["discriminator"]["propertyName"] == "kind"
-        assert product["discriminator"]["mapping"] == {
-            "BOOK": "#/components/schemas/Book",
-            "VINYL": "#/components/schemas/Vinyl",
-        }
-        assert set(product["properties"]["kind"]["enum"]) == {"BOOK", "VINYL"}
+        book_local = spec["components"]["schemas"]["Book"]["allOf"][1]
+        vinyl_local = spec["components"]["schemas"]["Vinyl"]["allOf"][1]
+        assert book_local["properties"]["kind"]["enum"] == ["BOOK"]
+        assert book_local["properties"]["kind"]["default"] == "BOOK"
+        assert vinyl_local["properties"]["kind"]["enum"] == ["VINYL"]
+        assert vinyl_local["properties"]["kind"]["default"] == "VINYL"
 
     def test_subclass_redeclares_field_with_single_value_enum(self):
-        """A concrete subclass's local schema pins the discriminator to its value."""
+        """A concrete subclass's local block (``allOf[1]``) pins the
+        discriminator to its single value with a matching default."""
         spec = _generate()
         book_local = spec["components"]["schemas"]["Book"]["allOf"][1]
         assert book_local["properties"]["kind"]["enum"] == ["BOOK"]
         assert book_local["properties"]["kind"]["default"] == "BOOK"
         assert "kind" in book_local["required"]
 
-    def test_designates_type_drives_discriminator(self):
-        """LinkML's `designates_type: true` produces an OpenAPI discriminator block."""
+    def test_designates_type_does_not_pollute_abstract_parent(self):
+        """`designates_type: true` is a discriminator declaration. The
+        abstract parent (Animal) carries no instances, so the
+        synthesised single-value enum lives on each concrete
+        subclass's ``allOf[1]`` local block, not on the parent."""
         spec = _generate()
         animal = spec["components"]["schemas"]["Animal"]
-        assert animal["discriminator"]["propertyName"] == "species"
-        assert animal["discriminator"]["mapping"] == {
-            "Dog": "#/components/schemas/Dog",
-            "Cat": "#/components/schemas/Cat",
-        }
+        assert "discriminator" not in animal
+        assert "oneOf" not in animal
+        dog_local = spec["components"]["schemas"]["Dog"]["allOf"][1]
+        cat_local = spec["components"]["schemas"]["Cat"]["allOf"][1]
+        assert dog_local["properties"]["species"]["enum"] == ["Dog"]
+        assert cat_local["properties"]["species"]["enum"] == ["Cat"]
 
     def test_designates_type_default_value_is_class_name_as_is(self):
         """Without openapi.type_value, the default matches LinkML's `designates_type` behaviour."""
@@ -1937,114 +1957,49 @@ classes:
         finally:
             Path(tmp).unlink(missing_ok=True)
 
-    # --- oneOf alongside discriminator (issue #47) ---------------------
+    # --- Polymorphism at points-of-use (no schema-level oneOf) ---------
 
-    def test_discriminator_parent_emits_oneof_array(self):
-        """Parent schema with a discriminator gets a `oneOf` $ref array."""
+    def test_polymorphic_root_keeps_parent_properties(self):
+        """The polymorphic root remains a concrete schema in its own right
+        (``type: object``, properties, required) so codegens generate a
+        class for it. The discriminator field is not injected on the
+        abstract root — that's handled by each concrete subclass — but
+        the root's own ``sku`` etc. survive."""
         spec = _generate()
         product = spec["components"]["schemas"]["Product"]
-        assert "oneOf" in product
-        refs = {entry["$ref"] for entry in product["oneOf"]}
-        assert refs == {
-            "#/components/schemas/Book",
-            "#/components/schemas/Vinyl",
-        }
-
-    def test_discriminator_oneof_uses_designates_type_signal(self):
-        """`designates_type: true` on a slot also drives oneOf emission."""
-        spec = _generate()
-        animal = spec["components"]["schemas"]["Animal"]
-        assert "oneOf" in animal
-        refs = {entry["$ref"] for entry in animal["oneOf"]}
-        assert refs == {
-            "#/components/schemas/Dog",
-            "#/components/schemas/Cat",
-        }
+        assert product["type"] == "object"
+        assert "sku" in product["properties"]
+        assert "oneOf" not in product
+        assert "discriminator" not in product
 
     def test_discriminator_default_keeps_parent_properties(self):
-        """Without --flatten-inheritance, the parent keeps its own properties."""
+        """Without --flatten-inheritance, the parent keeps its own
+        non-discriminator properties (sku, the identifier slot)."""
         spec = _generate()
         product = spec["components"]["schemas"]["Product"]
-        # `kind` is the discriminator field; `sku` is the parent's identifier.
         assert "type" in product and product["type"] == "object"
         assert "properties" in product
-        assert "kind" in product["properties"]
         assert "sku" in product["properties"]
-        assert "kind" in product["required"]
 
     def test_discriminator_flatten_preserves_parent_type_and_properties(self):
-        """Flatten mode must keep `type: object` and parent properties (issue #50).
-
-        Codegens (openapi-generator's Spring server in particular) skip
-        generating a class for the parent when `type: object` is missing.
-        Polymorphism is orthogonal to whether the parent is a concrete
-        schema, so `type` / `properties` / `required` are preserved alongside
-        `oneOf` / `discriminator` regardless of the flatten flag.
-        """
+        """Flatten mode must keep `type: object` and the parent's own
+        properties (issue #50). Codegens (openapi-generator's Spring
+        server in particular) skip generating a class for the parent
+        when `type: object` is missing."""
         spec = _generate(flatten_inheritance=True)
         product = spec["components"]["schemas"]["Product"]
         assert product.get("type") == "object"
         assert "properties" in product
         # Parent's own identifier slot survives.
         assert "sku" in product["properties"]
-        # Discriminator field is added by `_inject_subclass_type_value`.
-        assert "kind" in product["properties"]
-        assert "kind" in product.get("required", [])
-        # And the polymorphic union is still emitted.
-        assert "oneOf" in product
-        assert "discriminator" in product
 
-    def test_discriminator_oneof_targets_match_mapping_targets(self):
-        """Every `mapping` target appears as a `oneOf` $ref, no more no less."""
-        spec = _generate()
-        product = spec["components"]["schemas"]["Product"]
-        mapping_targets = set(product["discriminator"]["mapping"].values())
-        oneof_targets = {entry["$ref"] for entry in product["oneOf"]}
-        assert mapping_targets == oneof_targets
-
-    # --- Non-abstract discriminator parent (issue #52) -----------------
-
-    def test_non_abstract_parent_excluded_from_oneof(self):
-        """A non-abstract discriminator parent must not self-ref in its `oneOf`."""
-        spec = _generate()
-        vehicle = spec["components"]["schemas"]["Vehicle"]
-        oneof_refs = {entry["$ref"] for entry in vehicle["oneOf"]}
-        assert "#/components/schemas/Vehicle" not in oneof_refs
-        assert oneof_refs == {
-            "#/components/schemas/Car",
-            "#/components/schemas/Truck",
-        }
-
-    def test_non_abstract_parent_excluded_from_mapping(self):
-        """The discriminator mapping must not key on the parent class itself."""
-        spec = _generate()
-        vehicle = spec["components"]["schemas"]["Vehicle"]
-        mapping = vehicle["discriminator"]["mapping"]
-        # The parent's class-name default ("Vehicle") shouldn't be a key.
-        assert "Vehicle" not in mapping
-        # Concrete subclasses are present with their explicit type_values.
-        assert mapping == {
-            "car": "#/components/schemas/Car",
-            "truck": "#/components/schemas/Truck",
-        }
-
-    def test_abstract_parent_unchanged(self):
-        """Abstract parents (Animal, Product) still produce the right group."""
-        spec = _generate()
-        # Animal uses `designates_type: true`; Dog/Cat are auto-mapped.
-        animal = spec["components"]["schemas"]["Animal"]
-        animal_targets = set(animal["discriminator"]["mapping"].values())
-        assert animal_targets == {
-            "#/components/schemas/Dog",
-            "#/components/schemas/Cat",
-        }
-        # Product uses `openapi.discriminator` + per-subclass `openapi.type_value`.
-        product = spec["components"]["schemas"]["Product"]
-        product_targets = set(product["discriminator"]["mapping"].values())
-        assert product_targets == {
-            "#/components/schemas/Book",
-            "#/components/schemas/Vinyl",
-        }
+    # NOTE: Main's "non-abstract parent excluded from oneOf/mapping" tests
+    # (added in 8811dad / PR #52) are not asserted here. This branch's
+    # architecture moves polymorphic dispatch from the parent's component
+    # schema to the *use sites* (path responses via `_class_response_ref`,
+    # slot ranges via `_class_range_ref`), with the union *including* the
+    # root itself. See `test_polymorphic_root_keeps_parent_properties`,
+    # `test_oneof_lists_concrete_descendants_at_property`, and similar.
 
 
 class TestProfiles:
@@ -2236,3 +2191,366 @@ class TestMediaTypes:
                 "application/ld+json",
                 "text/turtle",
             }
+
+
+class TestLegacyTypeField:
+    """``openapi.legacy_type_field`` synthesises a back-compat constant
+    field on every concrete class in a polymorphic chain. The value
+    comes from each concrete class's ``openapi.legacy_type_value`` —
+    no fallback, since the value's format is opaque (Java FQN, custom
+    IRI, anything stable) and silently substituting one form for
+    another would be a footgun."""
+
+    BASE = """
+id: https://example.org/legacy
+name: legacy
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Item:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+      openapi.legacy_type_field: "#type"
+    attributes:
+      sku:
+        identifier: true
+        required: true
+  Widget:
+    is_a: Item
+    annotations:
+      openapi.type_value: WIDGET
+      openapi.legacy_type_value: "com.acme.Widget"
+  Gadget:
+    is_a: Item
+    annotations:
+      openapi.type_value: GADGET
+      openapi.legacy_type_value: "com.acme.Gadget"
+"""
+
+    def test_legacy_field_pinned_per_concrete_class(self):
+        spec = _generate_from_string(self.BASE)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        gadget_local = spec["components"]["schemas"]["Gadget"]["allOf"][1]
+        assert widget_local["properties"]["#type"]["enum"] == ["com.acme.Widget"]
+        assert widget_local["properties"]["#type"]["default"] == "com.acme.Widget"
+        assert gadget_local["properties"]["#type"]["enum"] == ["com.acme.Gadget"]
+        assert gadget_local["properties"]["#type"]["default"] == "com.acme.Gadget"
+        assert "#type" in widget_local["required"]
+        assert "#type" in gadget_local["required"]
+
+    def test_proper_discriminator_coexists_with_legacy_field(self):
+        """Both ``kind`` (discriminator) and ``#type`` (legacy) appear on
+        every concrete class's local block with their respective
+        pinned values."""
+        spec = _generate_from_string(self.BASE)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        assert widget_local["properties"]["kind"]["enum"] == ["WIDGET"]
+        assert widget_local["properties"]["#type"]["enum"] == ["com.acme.Widget"]
+
+    def test_missing_legacy_value_errors_loudly(self):
+        """Polymorphic root declares the legacy field, but a concrete
+        class doesn't set its value → ValueError naming the class."""
+        broken = self.BASE.replace(
+            'openapi.legacy_type_value: "com.acme.Gadget"', ""
+        )
+        _generate_from_string_raises(
+            broken, match=r"Class 'Gadget'.*openapi.legacy_type_value"
+        )
+
+    def test_no_legacy_field_declared_means_no_synthesis(self):
+        """Without ``openapi.legacy_type_field`` on the root, the
+        ``openapi.legacy_type_value`` annotations on subclasses are
+        ignored — the field doesn't exist on the wire."""
+        no_root = self.BASE.replace(
+            '      openapi.legacy_type_field: "#type"\n', ""
+        )
+        spec = _generate_from_string(no_root)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        gadget_local = spec["components"]["schemas"]["Gadget"]["allOf"][1]
+        assert "#type" not in widget_local.get("properties", {})
+        assert "#type" not in gadget_local.get("properties", {})
+
+    def test_legacy_field_never_carries_x_codegen_name(self):
+        """Even with ``openapi.legacy_type_codegen_name`` declared, the
+        rename does not appear as a vendor extension on the property —
+        openapi-generator's templates don't have a universal property-
+        renaming extension. The value flows through
+        :meth:`emit_name_mappings` instead."""
+        with_codegen = self.BASE.replace(
+            '      openapi.legacy_type_field: "#type"\n',
+            '      openapi.legacy_type_field: "#type"\n'
+            '      openapi.legacy_type_codegen_name: legacyType\n',
+        )
+        spec = _generate_from_string(with_codegen)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        assert "x-codegen-name" not in widget_local["properties"]["#type"]
+
+    def test_emit_name_mappings_returns_wire_to_codegen_pairs(self):
+        """``emit_name_mappings`` returns ``--name-mappings`` file
+        content — one ``wire-name=codegen-name`` per line, sorted."""
+        import tempfile
+
+        with_codegen = self.BASE.replace(
+            '      openapi.legacy_type_field: "#type"\n',
+            '      openapi.legacy_type_field: "#type"\n'
+            '      openapi.legacy_type_codegen_name: legacyType\n',
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(with_codegen)
+            path = f.name
+        try:
+            gen = OpenAPIGenerator(path)
+            gen.serialize()  # build state populates the mapping
+            assert gen.emit_name_mappings() == "#type=legacyType\n"
+            assert gen.name_mappings() == {"#type": "legacyType"}
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_emit_name_mappings_empty_when_no_renames(self):
+        """No ``legacy_type_codegen_name`` → empty string, so callers
+        can write the file unconditionally without polluting the repo."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(self.BASE)
+            path = f.name
+        try:
+            gen = OpenAPIGenerator(path)
+            gen.serialize()
+            assert gen.emit_name_mappings() == ""
+            assert gen.name_mappings() == {}
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+class TestInlinedPolymorphicRange:
+    """When a slot is composition (``inlined: true``) and its range has
+    concrete descendants, the property emits ``oneOf`` at the join point.
+
+    Codegens (notably openapi-generator's Spring template) translate
+    property-level ``oneOf`` + ``discriminator`` into Jackson
+    ``@JsonSubTypes`` — without it, the generated DTO ends up with a
+    bare ``Dataset`` field even when the wire payload is a
+    ``DatasetSeries``. The schema-level ``discriminator`` on the
+    polymorphic root remains; this is the *additional* signal the
+    codegen needs at the slot.
+    """
+
+    SCHEMA = """
+id: https://example.org/poly
+name: poly
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.discriminator: resourceType
+    attributes:
+      id:
+        identifier: true
+        required: true
+  Dataset:
+    is_a: Resource
+    annotations:
+      openapi.type_value: Dataset
+  DatasetSeries:
+    is_a: Dataset
+    annotations:
+      openapi.type_value: DatasetSeries
+  Catalog:
+    is_a: Dataset
+    annotations:
+      openapi.type_value: Catalog
+    attributes:
+      # `inlined: true` forces composition. Range Dataset has 3 concrete
+      # descendants (Dataset, DatasetSeries, Catalog); slot must emit
+      # oneOf + discriminator at the property level.
+      members:
+        range: Dataset
+        multivalued: true
+        inlined: true
+"""
+
+    def test_oneof_lists_concrete_descendants_at_property(self):
+        spec = _generate_from_string(self.SCHEMA)
+        catalog_local = spec["components"]["schemas"]["Catalog"]["allOf"][1]
+        items = catalog_local["properties"]["members"]["items"]
+        refs = {r["$ref"] for r in items["oneOf"]}
+        assert refs == {
+            "#/components/schemas/Dataset",
+            "#/components/schemas/DatasetSeries",
+            "#/components/schemas/Catalog",
+        }
+
+    def test_property_carries_inherited_discriminator(self):
+        spec = _generate_from_string(self.SCHEMA)
+        catalog_local = spec["components"]["schemas"]["Catalog"]["allOf"][1]
+        items = catalog_local["properties"]["members"]["items"]
+        disc = items["discriminator"]
+        assert disc["propertyName"] == "resourceType"
+        assert disc["mapping"] == {
+            "Dataset": "#/components/schemas/Dataset",
+            "DatasetSeries": "#/components/schemas/DatasetSeries",
+            "Catalog": "#/components/schemas/Catalog",
+        }
+
+    def test_inlined_false_still_emits_uri_string_not_oneof(self):
+        """The polymorphic oneOf only fires for composition. Reference slots
+        (the LinkML default) stay as IRI strings regardless of how rich the
+        target hierarchy is — RDF-roundtrippable wins."""
+        schema = self.SCHEMA.replace("inlined: true", "inlined: false")
+        spec = _generate_from_string(schema)
+        catalog_local = spec["components"]["schemas"]["Catalog"]["allOf"][1]
+        items = catalog_local["properties"]["members"]["items"]
+        assert items == {"type": "string", "format": "uri"}
+
+    def test_non_polymorphic_inlined_range_still_uses_plain_ref(self):
+        """No descendants → no oneOf, just `$ref`."""
+        schema = """
+id: https://example.org/plain
+name: plain
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Note:
+    attributes:
+      id:
+        identifier: true
+        required: true
+      text:
+        range: string
+  Document:
+    attributes:
+      id:
+        identifier: true
+        required: true
+      annotation:
+        range: Note
+        inlined: true
+"""
+        spec = _generate_from_string(schema)
+        prop = spec["components"]["schemas"]["Document"]["properties"]["annotation"]
+        assert prop == {"$ref": "#/components/schemas/Note"}
+
+    def test_inlined_self_cycle_without_acknowledgement_raises(self):
+        """A class with an ``inlined: true`` slot ranging on itself must
+        either drop the inlining (becoming a reference IRI) or
+        acknowledge the cycle via ``openapi.recurse_max_depth``."""
+        _generate_from_string_raises(
+            """
+id: https://example.org/self-cycle
+name: self_cycle
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+imports: [linkml:types]
+classes:
+  Catalog:
+    attributes:
+      id: { identifier: true, required: true }
+      sub:
+        range: Catalog
+        multivalued: true
+        inlined: true
+""",
+            match=r"Inlined composition cycle",
+        )
+
+    def test_inlined_self_cycle_passes_when_acknowledged(self):
+        """``openapi.recurse_max_depth`` lets the build through; the cycle
+        is the author's explicit choice."""
+        spec = _generate_from_string("""
+id: https://example.org/ack-cycle
+name: ack_cycle
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+imports: [linkml:types]
+classes:
+  Catalog:
+    annotations:
+      openapi.recurse_max_depth: "3"
+    attributes:
+      id: { identifier: true, required: true }
+      sub:
+        range: Catalog
+        multivalued: true
+        inlined: true
+""")
+        local = spec["components"]["schemas"]["Catalog"]
+        # No descendants → plain $ref to self (the recursion is acknowledged
+        # but not bound — the integer is informational for now).
+        assert local["properties"]["sub"]["items"] == {
+            "$ref": "#/components/schemas/Catalog"
+        }
+
+    def test_reference_self_cycle_is_fine(self):
+        """``inlined: false`` cycles are not real cycles on the wire — the
+        target IRI is a string, no expansion happens. No annotation required."""
+        spec = _generate_from_string("""
+id: https://example.org/ref-cycle
+name: ref_cycle
+prefixes: { linkml: https://w3id.org/linkml/ }
+default_range: string
+imports: [linkml:types]
+classes:
+  Catalog:
+    attributes:
+      id: { identifier: true, required: true }
+      sub:
+        range: Catalog
+        multivalued: true
+        inlined: false
+""")
+        items = spec["components"]["schemas"]["Catalog"]["properties"]["sub"]["items"]
+        assert items == {"type": "string", "format": "uri"}
+
+    def test_no_discriminator_in_chain_still_emits_oneof_without_mapping(self):
+        """If the polymorphic root has no discriminator declared, the
+        property-level ``oneOf`` is still useful for codegen — it just
+        omits the discriminator block. Validation still works (the
+        payload must match exactly one branch); polymorphic
+        deserialization in the codegen needs a manual hint, but at
+        least the spec records the join."""
+        schema = """
+id: https://example.org/no-disc
+name: no_disc
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Animal:
+    abstract: true
+    attributes:
+      id:
+        identifier: true
+        required: true
+  Dog:
+    is_a: Animal
+  Cat:
+    is_a: Animal
+  Owner:
+    attributes:
+      id:
+        identifier: true
+        required: true
+      pet:
+        range: Animal
+        inlined: true
+"""
+        spec = _generate_from_string(schema)
+        prop = spec["components"]["schemas"]["Owner"]["properties"]["pet"]
+        refs = {r["$ref"] for r in prop["oneOf"]}
+        assert refs == {"#/components/schemas/Dog", "#/components/schemas/Cat"}
+        assert "discriminator" not in prop

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2254,20 +2254,14 @@ classes:
     def test_missing_legacy_value_errors_loudly(self):
         """Polymorphic root declares the legacy field, but a concrete
         class doesn't set its value → ValueError naming the class."""
-        broken = self.BASE.replace(
-            'openapi.legacy_type_value: "com.acme.Gadget"', ""
-        )
-        _generate_from_string_raises(
-            broken, match=r"Class 'Gadget'.*openapi.legacy_type_value"
-        )
+        broken = self.BASE.replace('openapi.legacy_type_value: "com.acme.Gadget"', "")
+        _generate_from_string_raises(broken, match=r"Class 'Gadget'.*openapi.legacy_type_value")
 
     def test_no_legacy_field_declared_means_no_synthesis(self):
         """Without ``openapi.legacy_type_field`` on the root, the
         ``openapi.legacy_type_value`` annotations on subclasses are
         ignored — the field doesn't exist on the wire."""
-        no_root = self.BASE.replace(
-            '      openapi.legacy_type_field: "#type"\n', ""
-        )
+        no_root = self.BASE.replace('      openapi.legacy_type_field: "#type"\n', "")
         spec = _generate_from_string(no_root)
         widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
         gadget_local = spec["components"]["schemas"]["Gadget"]["allOf"][1]
@@ -2283,7 +2277,7 @@ classes:
         with_codegen = self.BASE.replace(
             '      openapi.legacy_type_field: "#type"\n',
             '      openapi.legacy_type_field: "#type"\n'
-            '      openapi.legacy_type_codegen_name: legacyType\n',
+            "      openapi.legacy_type_codegen_name: legacyType\n",
         )
         spec = _generate_from_string(with_codegen)
         widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
@@ -2297,7 +2291,7 @@ classes:
         with_codegen = self.BASE.replace(
             '      openapi.legacy_type_field: "#type"\n',
             '      openapi.legacy_type_field: "#type"\n'
-            '      openapi.legacy_type_codegen_name: legacyType\n',
+            "      openapi.legacy_type_codegen_name: legacyType\n",
         )
         with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
             f.write(with_codegen)
@@ -2489,9 +2483,7 @@ classes:
         local = spec["components"]["schemas"]["Catalog"]
         # No descendants → plain $ref to self (the recursion is acknowledged
         # but not bound — the integer is informational for now).
-        assert local["properties"]["sub"]["items"] == {
-            "$ref": "#/components/schemas/Catalog"
-        }
+        assert local["properties"]["sub"]["items"] == {"$ref": "#/components/schemas/Catalog"}
 
     def test_reference_self_cycle_is_fine(self):
         """``inlined: false`` cycles are not real cycles on the wire — the

--- a/tests/test_post_processors.py
+++ b/tests/test_post_processors.py
@@ -50,33 +50,31 @@ class TestExtractInlineOneof:
     it into a synthetic union DTO."""
 
     def _spec_with_inline_oneof(self) -> dict:
+        ds_ref = "#/components/schemas/Dataset"
+        cat_ref = "#/components/schemas/Catalog"
+        series_ref = "#/components/schemas/DatasetSeries"
+        inline_schema = {
+            "oneOf": [
+                {"$ref": ds_ref},
+                {"$ref": cat_ref},
+                {"$ref": series_ref},
+            ],
+            "discriminator": {
+                "propertyName": "resourceType",
+                "mapping": {
+                    "Dataset": ds_ref,
+                    "Catalog": cat_ref,
+                    "DatasetSeries": series_ref,
+                },
+            },
+        }
         return {
             "openapi": "3.0.3",
             "paths": {
                 "/datasets/{id}": {
                     "get": {
                         "responses": {
-                            "200": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "oneOf": [
-                                                {"$ref": "#/components/schemas/Dataset"},
-                                                {"$ref": "#/components/schemas/Catalog"},
-                                                {"$ref": "#/components/schemas/DatasetSeries"},
-                                            ],
-                                            "discriminator": {
-                                                "propertyName": "resourceType",
-                                                "mapping": {
-                                                    "Dataset": "#/components/schemas/Dataset",
-                                                    "Catalog": "#/components/schemas/Catalog",
-                                                    "DatasetSeries": "#/components/schemas/DatasetSeries",
-                                                },
-                                            },
-                                        }
-                                    }
-                                }
-                            }
+                            "200": {"content": {"application/json": {"schema": inline_schema}}}
                         }
                     }
                 }
@@ -86,9 +84,9 @@ class TestExtractInlineOneof:
 
     def test_inline_oneof_in_response_becomes_ref(self):
         spec = extract_inline_oneof(self._spec_with_inline_oneof())
-        schema = spec["paths"]["/datasets/{id}"]["get"]["responses"]["200"][
-            "content"
-        ]["application/json"]["schema"]
+        schema = spec["paths"]["/datasets/{id}"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]
         assert schema == {"$ref": "#/components/schemas/DatasetVariant"}
 
     def test_named_component_carries_full_oneof_shape(self):
@@ -120,9 +118,7 @@ class TestExtractInlineOneof:
         }
         out = extract_inline_oneof(spec)
         # Only one Variant component, both call sites $ref to it.
-        variant_keys = [
-            k for k in out["components"]["schemas"] if "Variant" in k
-        ]
+        variant_keys = [k for k in out["components"]["schemas"] if "Variant" in k]
         assert variant_keys == ["DatasetVariant"]
 
     def test_different_inline_shapes_get_distinct_components(self):
@@ -156,9 +152,7 @@ class TestExtractInlineOneof:
             }
         }
         out = extract_inline_oneof(spec)
-        names = sorted(
-            k for k in out["components"]["schemas"] if "Variant" in k
-        )
+        names = sorted(k for k in out["components"]["schemas"] if "Variant" in k)
         assert names == ["DatasetVariant", "DatasetVariant2"]
 
     def test_does_not_touch_inline_oneof_without_discriminator(self):
@@ -190,12 +184,10 @@ class TestExtractInlineOneof:
         before = copy.deepcopy(spec)
         out = extract_inline_oneof(spec)
         assert (
-            out["paths"]["/x"]["get"]["responses"]["200"]["content"][
-                "application/json"
-            ]["schema"]
-            == before["paths"]["/x"]["get"]["responses"]["200"]["content"][
-                "application/json"
-            ]["schema"]
+            out["paths"]["/x"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+            == before["paths"]["/x"]["get"]["responses"]["200"]["content"]["application/json"][
+                "schema"
+            ]
         )
 
     def test_does_not_recurse_into_existing_component_schemas(self):
@@ -221,9 +213,9 @@ class TestExtractInlineOneof:
         }
         before = copy.deepcopy(spec)
         out = extract_inline_oneof(spec)
-        assert out["components"]["schemas"]["Resource"] == before["components"][
-            "schemas"
-        ]["Resource"]
+        assert (
+            out["components"]["schemas"]["Resource"] == before["components"]["schemas"]["Resource"]
+        )
 
 
 class TestPostProcessorViaGenerator:
@@ -263,9 +255,7 @@ classes:
         import tempfile
         from pathlib import Path
 
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
             f.write(self.SCHEMA)
             path = f.name
         try:
@@ -277,9 +267,7 @@ classes:
     def test_post_processor_runs_on_dcat3_fixture(self):
         from pathlib import Path
 
-        fixture = str(
-            Path(__file__).parent / "fixtures" / "dcat3.yaml"
-        )
+        fixture = str(Path(__file__).parent / "fixtures" / "dcat3.yaml")
         canonical = yaml.safe_load(OpenAPIGenerator(fixture).serialize())
         processed = yaml.safe_load(
             OpenAPIGenerator(
@@ -289,12 +277,12 @@ classes:
         )
 
         # /datasets/{id} GET 200 went from inline oneOf to $ref.
-        canon_schema = canonical["paths"]["/datasets/{id}"]["get"][
-            "responses"
-        ]["200"]["content"]["application/json"]["schema"]
-        proc_schema = processed["paths"]["/datasets/{id}"]["get"][
-            "responses"
-        ]["200"]["content"]["application/json"]["schema"]
+        canon_schema = canonical["paths"]["/datasets/{id}"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]
+        proc_schema = processed["paths"]["/datasets/{id}"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]
         assert "oneOf" in canon_schema
         assert "$ref" in proc_schema
         # The named component carries the polymorphic shape.

--- a/tests/test_post_processors.py
+++ b/tests/test_post_processors.py
@@ -1,0 +1,304 @@
+"""Tests for the spec post-processor framework.
+
+Each post-processor is a pure ``dict -> dict`` function. Tests are
+input/output dict pairs — no LinkML required, no generator
+required. Keeps the post-processor surface independently testable
+and lets us pin specific transformations (hoist behaviour, dedup,
+naming) with surgical assertions.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import yaml
+
+from linkml_openapi.generator import OpenAPIGenerator
+from linkml_openapi.post_processors import REGISTRY, apply
+from linkml_openapi.post_processors.extract_inline_oneof import (
+    extract_inline_oneof,
+)
+
+
+class TestRegistry:
+    def test_known_post_processors_registered(self):
+        assert "extract-inline-oneof" in REGISTRY
+
+    def test_apply_unknown_name_raises_with_listing(self):
+        with pytest.raises(ValueError, match=r"Unknown post-processor"):
+            apply({}, ["does-not-exist"])
+
+    def test_apply_runs_post_processors_in_declared_order(self):
+        """Order matters — a contrived A→B test ensures the registry
+        respects the user-supplied sequence."""
+        record: list[str] = []
+        REGISTRY["__test_a"] = lambda s: (record.append("a"), s)[1]
+        REGISTRY["__test_b"] = lambda s: (record.append("b"), s)[1]
+        try:
+            apply({}, ["__test_b", "__test_a"])
+            assert record == ["b", "a"]
+        finally:
+            REGISTRY.pop("__test_a", None)
+            REGISTRY.pop("__test_b", None)
+
+
+class TestExtractInlineOneof:
+    """Hoist inline ``oneOf`` + discriminator schemas to named
+    components so codegens (openapi-generator's Spring template in
+    particular) preserve the polymorphic shape rather than collapsing
+    it into a synthetic union DTO."""
+
+    def _spec_with_inline_oneof(self) -> dict:
+        return {
+            "openapi": "3.0.3",
+            "paths": {
+                "/datasets/{id}": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {"$ref": "#/components/schemas/Dataset"},
+                                                {"$ref": "#/components/schemas/Catalog"},
+                                                {"$ref": "#/components/schemas/DatasetSeries"},
+                                            ],
+                                            "discriminator": {
+                                                "propertyName": "resourceType",
+                                                "mapping": {
+                                                    "Dataset": "#/components/schemas/Dataset",
+                                                    "Catalog": "#/components/schemas/Catalog",
+                                                    "DatasetSeries": "#/components/schemas/DatasetSeries",
+                                                },
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {"schemas": {"Dataset": {}, "Catalog": {}, "DatasetSeries": {}}},
+        }
+
+    def test_inline_oneof_in_response_becomes_ref(self):
+        spec = extract_inline_oneof(self._spec_with_inline_oneof())
+        schema = spec["paths"]["/datasets/{id}"]["get"]["responses"]["200"][
+            "content"
+        ]["application/json"]["schema"]
+        assert schema == {"$ref": "#/components/schemas/DatasetVariant"}
+
+    def test_named_component_carries_full_oneof_shape(self):
+        spec = extract_inline_oneof(self._spec_with_inline_oneof())
+        variant = spec["components"]["schemas"]["DatasetVariant"]
+        assert {item["$ref"] for item in variant["oneOf"]} == {
+            "#/components/schemas/Dataset",
+            "#/components/schemas/Catalog",
+            "#/components/schemas/DatasetSeries",
+        }
+        assert variant["discriminator"]["propertyName"] == "resourceType"
+
+    def test_idempotent(self):
+        """Running twice is a no-op — second pass finds no inline
+        oneOfs because the first hoisted them all."""
+        once = extract_inline_oneof(self._spec_with_inline_oneof())
+        twice = extract_inline_oneof(copy.deepcopy(once))
+        assert once == twice
+
+    def test_dedupe_identical_inline_shapes_to_single_component(self):
+        """The same inline oneOf appearing in multiple operations
+        should hoist to a single named component."""
+        spec = self._spec_with_inline_oneof()
+        # Drop the same shape into a request body too.
+        spec["paths"]["/datasets/{id}"]["get"]["requestBody"] = {
+            "content": copy.deepcopy(
+                spec["paths"]["/datasets/{id}"]["get"]["responses"]["200"]["content"]
+            )
+        }
+        out = extract_inline_oneof(spec)
+        # Only one Variant component, both call sites $ref to it.
+        variant_keys = [
+            k for k in out["components"]["schemas"] if "Variant" in k
+        ]
+        assert variant_keys == ["DatasetVariant"]
+
+    def test_different_inline_shapes_get_distinct_components(self):
+        """Two genuinely different inline oneOfs must not collide on
+        a single component — names disambiguate with a numeric tail."""
+        spec = self._spec_with_inline_oneof()
+        # Swap the request body for a different oneOf (Catalog as seed).
+        spec["paths"]["/catalogs/{id}"] = {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {"$ref": "#/components/schemas/Dataset"},
+                                        {"$ref": "#/components/schemas/Catalog"},
+                                    ],
+                                    "discriminator": {
+                                        "propertyName": "resourceType",
+                                        "mapping": {
+                                            "Dataset": "#/components/schemas/Dataset",
+                                            "Catalog": "#/components/schemas/Catalog",
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out = extract_inline_oneof(spec)
+        names = sorted(
+            k for k in out["components"]["schemas"] if "Variant" in k
+        )
+        assert names == ["DatasetVariant", "DatasetVariant2"]
+
+    def test_does_not_touch_inline_oneof_without_discriminator(self):
+        """A bare oneOf (no discriminator) is structurally simple; we
+        leave it inline so we don't generate noise component schemas."""
+        spec = {
+            "paths": {
+                "/x": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {"$ref": "#/components/schemas/A"},
+                                                {"$ref": "#/components/schemas/B"},
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {"schemas": {"A": {}, "B": {}}},
+        }
+        before = copy.deepcopy(spec)
+        out = extract_inline_oneof(spec)
+        assert (
+            out["paths"]["/x"]["get"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"]
+            == before["paths"]["/x"]["get"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"]
+        )
+
+    def test_does_not_recurse_into_existing_component_schemas(self):
+        """Component schemas that already host oneOfs (e.g. a
+        polymorphic root) are intentionally left alone — they're
+        the targets of $refs from path operations, not inline shapes
+        themselves. Only path-level inlines are hoisted."""
+        spec = {
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Resource": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/A"},
+                            {"$ref": "#/components/schemas/B"},
+                        ],
+                        "discriminator": {"propertyName": "kind"},
+                    },
+                    "A": {},
+                    "B": {},
+                }
+            },
+        }
+        before = copy.deepcopy(spec)
+        out = extract_inline_oneof(spec)
+        assert out["components"]["schemas"]["Resource"] == before["components"][
+            "schemas"
+        ]["Resource"]
+
+
+class TestPostProcessorViaGenerator:
+    """End-to-end check: the CLI/Generator wiring runs registered
+    post-processors against the generated spec."""
+
+    SCHEMA = """
+id: https://example.org/poly
+name: poly
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_range: string
+imports:
+  - linkml:types
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+    attributes:
+      id:
+        identifier: true
+        required: true
+  Widget:
+    is_a: Resource
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: WIDGET
+  Gadget:
+    is_a: Resource
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: GADGET
+"""
+
+    def _generate(self, **kwargs) -> dict:
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".yaml", delete=False
+        ) as f:
+            f.write(self.SCHEMA)
+            path = f.name
+        try:
+            gen = OpenAPIGenerator(path, **kwargs)
+            return yaml.safe_load(gen.serialize())
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_post_processor_runs_on_dcat3_fixture(self):
+        from pathlib import Path
+
+        fixture = str(
+            Path(__file__).parent / "fixtures" / "dcat3.yaml"
+        )
+        canonical = yaml.safe_load(OpenAPIGenerator(fixture).serialize())
+        processed = yaml.safe_load(
+            OpenAPIGenerator(
+                fixture,
+                post_processors=["extract-inline-oneof"],
+            ).serialize()
+        )
+
+        # /datasets/{id} GET 200 went from inline oneOf to $ref.
+        canon_schema = canonical["paths"]["/datasets/{id}"]["get"][
+            "responses"
+        ]["200"]["content"]["application/json"]["schema"]
+        proc_schema = processed["paths"]["/datasets/{id}"]["get"][
+            "responses"
+        ]["200"]["content"]["application/json"]["schema"]
+        assert "oneOf" in canon_schema
+        assert "$ref" in proc_schema
+        # The named component carries the polymorphic shape.
+        target_name = proc_schema["$ref"].rsplit("/", 1)[-1]
+        target = processed["components"]["schemas"][target_name]
+        assert "oneOf" in target
+        assert target["discriminator"]["propertyName"] == "resourceType"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1104 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "curies"
+version = "0.13.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pystow" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/3e/b8a1ae5b85eaf1af994641dee46effbc6fb4d8f7df3074146a0ae1af1227/curies-0.13.8.tar.gz", hash = "sha256:85349db98ed1851bcb04a36419e54f5dcd9461225c33fe4ebb1bdc4e84946956", size = 70481, upload-time = "2026-04-24T11:47:58.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/16/9dab08acd9e203e3aa337a4e973b91e46821b8061013681b700b0c3f19c3/curies-0.13.8-py3-none-any.whl", hash = "sha256:0e8e5bd99b02063651fbafbe655a00afa185972d08b314dcc97a22747df2ef05", size = 79740, upload-time = "2026-04-24T11:47:56.791Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "hbreader"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/66/3a649ce125e03d1d43727a8b833cd211f0b9fe54a7e5be326f50d6f1d951/hbreader-0.9.1.tar.gz", hash = "sha256:d2c132f8ba6276d794c66224c3297cec25c8079d0a4cf019c061611e0a3b94fa", size = 19016, upload-time = "2021-02-25T19:22:32.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/24/61844afbf38acf419e01ca2639f7bd079584523d34471acbc4152ee991c5/hbreader-0.9.1-py3-none-any.whl", hash = "sha256:9a6e76c9d1afc1b977374a5dc430a1ebb0ea0488205546d4678d6e31cc5f6801", size = 7595, upload-time = "2021-02-25T19:22:31.944Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json-flattener"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/77/b00e46d904818826275661a690532d3a3a43a4ded0264b2d7fcdb5c0feea/json_flattener-0.1.9.tar.gz", hash = "sha256:84cf8523045ffb124301a602602201665fcb003a171ece87e6f46ed02f7f0c15", size = 11479, upload-time = "2022-02-26T01:36:04.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/cc/7fbd75d3362e939eb98bcf9bd22f3f7df8c237a85148899ed3d38e5614e5/json_flattener-0.1.9-py3-none-any.whl", hash = "sha256:6b027746f08bf37a75270f30c6690c7149d5f704d8af1740c346a3a1236bc941", size = 10799, upload-time = "2022-02-26T01:36:03.06Z" },
+]
+
+[[package]]
+name = "jsonasobj2"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hbreader" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/3a/feb245b755f7a47a0df4f30be645e8485d15ff13d0c95e018e4505a8811f/jsonasobj2-1.0.4.tar.gz", hash = "sha256:f50b1668ef478004aa487b2d2d094c304e5cb6b79337809f4a1f2975cc7fbb4e", size = 95522, upload-time = "2021-06-02T17:43:28.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/90/0d93963711f811efe528e3cead2f2bfb78c196df74d8a24fe8d655288e50/jsonasobj2-1.0.4-py3-none-any.whl", hash = "sha256:12e86f86324d54fcf60632db94ea74488d5314e3da554c994fe1e2c6f29acb79", size = 6324, upload-time = "2021-06-02T17:43:27.126Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/86/cfee6dd25843bec0760f456599a4f7e7e40221a934b9229fda0662c859bc/jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b", size = 15302, upload-time = "2026-04-27T18:57:08.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/43/3d3065c05a04bb550c143bfbb8e4fd7022cd327e1082bf257bac74923783/jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9", size = 19565, upload-time = "2026-04-27T18:57:06.792Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/b3/4684b1e128a87821e485f5a901b179790e6b5bc02f89b7ee19c23be36ef3/lazy_object_proxy-1.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1cf69cd1a6c7fe2dbcc3edaa017cf010f4192e53796538cc7d5e1fedbfa4bcff", size = 26656, upload-time = "2025-08-22T13:42:30.605Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/03/1bdc21d9a6df9ff72d70b2ff17d8609321bea4b0d3cffd2cea92fb2ef738/lazy_object_proxy-1.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efff4375a8c52f55a145dc8487a2108c2140f0bec4151ab4e1843e52eb9987ad", size = 68832, upload-time = "2025-08-22T13:42:31.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4b/5788e5e8bd01d19af71e50077ab020bc5cce67e935066cd65e1215a09ff9/lazy_object_proxy-1.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1192e8c2f1031a6ff453ee40213afa01ba765b3dc861302cd91dbdb2e2660b00", size = 69148, upload-time = "2025-08-22T13:42:32.876Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0e/090bf070f7a0de44c61659cb7f74c2fe02309a77ca8c4b43adfe0b695f66/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3605b632e82a1cbc32a1e5034278a64db555b3496e0795723ee697006b980508", size = 67800, upload-time = "2025-08-22T13:42:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d2/b320325adbb2d119156f7c506a5fbfa37fcab15c26d13cf789a90a6de04e/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a61095f5d9d1a743e1e20ec6d6db6c2ca511961777257ebd9b288951b23b44fa", size = 68085, upload-time = "2025-08-22T13:42:35.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/4b718c937004bf71cd82af3713874656bcb8d0cc78600bf33bb9619adc6c/lazy_object_proxy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:997b1d6e10ecc6fb6fe0f2c959791ae59599f41da61d652f6c903d1ee58b7370", size = 26535, upload-time = "2025-08-22T13:42:36.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/b5f5bd6bda26f1e15cd3232b223892e4498e34ec70a7f4f11c401ac969f1/lazy_object_proxy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee0d6027b760a11cc18281e702c0309dd92da458a74b4c15025d7fc490deede", size = 26746, upload-time = "2025-08-22T13:42:37.572Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/314889b618075c2bfc19293ffa9153ce880ac6153aacfd0a52fcabf21a66/lazy_object_proxy-1.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ab2c584e3cc8be0dfca422e05ad30a9abe3555ce63e9ab7a559f62f8dbc6ff9", size = 71457, upload-time = "2025-08-22T13:42:38.743Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/857fc2827fc1e13fbdfc0ba2629a7d2579645a06192d5461809540b78913/lazy_object_proxy-1.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14e348185adbd03ec17d051e169ec45686dcd840a3779c9d4c10aabe2ca6e1c0", size = 71036, upload-time = "2025-08-22T13:42:40.184Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/24/e581ffed864cd33c1b445b5763d617448ebb880f48675fc9de0471a95cbc/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c4fcbe74fb85df8ba7825fa05eddca764138da752904b378f0ae5ab33a36c308", size = 69329, upload-time = "2025-08-22T13:42:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/15f8f5a0b0b2e668e756a152257d26370132c97f2f1943329b08f057eff0/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:563d2ec8e4d4b68ee7848c5ab4d6057a6d703cb7963b342968bb8758dda33a23", size = 70690, upload-time = "2025-08-22T13:42:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/aa/f02be9bbfb270e13ee608c2b28b8771f20a5f64356c6d9317b20043c6129/lazy_object_proxy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:53c7fd99eb156bbb82cbc5d5188891d8fdd805ba6c1e3b92b90092da2a837073", size = 26563, upload-time = "2025-08-22T13:42:43.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
+    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a0/b91504515c1f9a299fc157967ffbd2f0321bce0516a3d5b89f6f4cad0355/lazy_object_proxy-1.12.0-pp39.pp310.pp311.graalpy311-none-any.whl", hash = "sha256:c3b2e0af1f7f77c4263759c4824316ce458fabe0fceadcd24ef8ca08b2d1e402", size = 15072, upload-time = "2025-08-22T13:50:05.498Z" },
+]
+
+[[package]]
+name = "linkml-openapi"
+version = "0.8.1"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "jinja2" },
+    { name = "linkml-runtime" },
+    { name = "openapi-pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "openapi-spec-validator" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.0" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "linkml-runtime", specifier = ">=1.7.0" },
+    { name = "openapi-pydantic", specifier = ">=0.5.0" },
+    { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "linkml-runtime"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "curies" },
+    { name = "deprecated" },
+    { name = "hbreader" },
+    { name = "json-flattener" },
+    { name = "jsonasobj2" },
+    { name = "jsonschema" },
+    { name = "prefixcommons" },
+    { name = "prefixmaps" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "rdflib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957, upload-time = "2026-02-25T17:13:34.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001, upload-time = "2026-02-25T17:13:30.603Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/4b/67b24b2b23d96ea862be2cca3632a546f67a22461200831213e80c3c6011/openapi_schema_validator-0.8.1.tar.gz", hash = "sha256:4c57266ce8cbfa37bb4eb4d62cdb7d19356c3a468e3535743c4562863e1790da", size = 23134, upload-time = "2026-03-02T08:46:29.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/87/e9f29f463b230d4b47d65e17858c595153a8ca8c1775f16e406aa82d455d/openapi_schema_validator-0.8.1-py3-none-any.whl", hash = "sha256:0f5859794c5bfa433d478dc5ac5e5768d50adc56b14380c8a6fd3a8113e89c9b", size = 19211, upload-time = "2026-03-02T08:46:28.154Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3f/aa0c1150627b4e683ae5673486b7d5cf2623a8821601863ee389e430965a/openapi_spec_validator-0.8.5.tar.gz", hash = "sha256:93b04ef5321d5866b2502371123d86333e5c1444f051d323e02525d9e83c7622", size = 1756845, upload-time = "2026-04-24T15:25:21.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/96/d7dfe1cc0be2df22d7a97ffb0f8bb00b10d92749aa6e64ffa7cc9a041580/openapi_spec_validator-0.8.5-py3-none-any.whl", hash = "sha256:3669106361856934153991e30714616a294865a33f6411a4c25d1dc2d08cfbc2", size = 50334, upload-time = "2026-04-24T15:25:19.65Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prefixcommons"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pytest-logging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b5/c5b63a4bf5dedb36567181fdb98dbcc7aaa025faebabaaffa2f5eb4b8feb/prefixcommons-0.1.12.tar.gz", hash = "sha256:22c4e2d37b63487b3ab48f0495b70f14564cb346a15220f23919eb0c1851f69f", size = 24063, upload-time = "2022-07-19T00:06:12.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/e8/715b09df3dab02b07809d812042dc47a46236b5603d9d3a2572dbd1d8a97/prefixcommons-0.1.12-py3-none-any.whl", hash = "sha256:16dbc0a1f775e003c724f19a694fcfa3174608f5c8b0e893d494cf8098ac7f8b", size = 29482, upload-time = "2022-07-19T00:06:08.709Z" },
+]
+
+[[package]]
+name = "prefixmaps"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "curies" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/cf/f588bcdfd2c841839b9d59ce219a46695da56aa2805faff937bbafb9ee2b/prefixmaps-0.2.6.tar.gz", hash = "sha256:7421e1244eea610217fa1ba96c9aebd64e8162a930dc0626207cd8bf62ecf4b9", size = 709899, upload-time = "2024-10-17T16:30:57.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/b2/2b2153173f2819e3d7d1949918612981bc6bd895b75ffa392d63d115f327/prefixmaps-0.2.6-py3-none-any.whl", hash = "sha256:f6cef28a7320fc6337cf411be212948ce570333a0ce958940ef684c7fb192a62", size = 754732, upload-time = "2024-10-17T16:30:55.731Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a2/1ba90a83e85a3f94c796b184f3efde9c72f2830dcda493eea8d59ba78e6d/pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5", size = 2106740, upload-time = "2026-04-20T14:41:20.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f6/99ae893c89a0b9d3daec9f95487aa676709aa83f67643b3f0abaf4ab628a/pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c", size = 1948293, upload-time = "2026-04-20T14:43:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b8/2e8e636dc9e3f16c2e16bf0849e24be82c5ee82c603c65fc0326666328fc/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e", size = 1973222, upload-time = "2026-04-20T14:41:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/0e730beec4d83c5306f417afbd82ff237d9a21e83c5edf675f31ed84c1fe/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6645ce7eec4928e29a1e3b3d5c946621d105d3e79f0c9cddf07c2a9770949287", size = 2053852, upload-time = "2026-04-20T14:40:43.077Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/3071131f47e39136a17814576e0fada9168569f7f8c0e6ac4d1ede6a4958/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a712c7118e6c5ea96562f7b488435172abb94a3c53c22c9efc1412264a45cbbe", size = 2221134, upload-time = "2026-04-20T14:43:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a9/a2dc023eec5aa4b02a467874bad32e2446957d2adcab14e107eab502e978/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69a868ef3ff206343579021c40faf3b1edc64b1cc508ff243a28b0a514ccb050", size = 2279785, upload-time = "2026-04-20T14:41:19.285Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/44/93f489d16fb63fbd41c670441536541f6e8cfa1e5a69f40bc9c5d30d8c90/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc7e8c32db809aa0f6ea1d6869ebc8518a65d5150fdfad8bcae6a49ae32a22e2", size = 2089404, upload-time = "2026-04-20T14:43:10.108Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/78/8692e3aa72b2d004f7a5d937f1dfdc8552ba26caf0bec75f342c40f00dec/pydantic_core-2.46.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3481bd1341dc85779ee506bc8e1196a277ace359d89d28588a9468c3ecbe63fa", size = 2114898, upload-time = "2026-04-20T14:44:51.475Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/62/e83133f2e7832532060175cebf1f13748f4c7e7e7165cdd1f611f174494b/pydantic_core-2.46.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8690eba565c6d68ffd3a8655525cbdd5246510b44a637ee2c6c03a7ebfe64d3c", size = 2157856, upload-time = "2026-04-20T14:43:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ec/6a500e3ad7718ee50583fae79c8651f5d37e3abce1fa9ae177ae65842c53/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4de88889d7e88d50d40ee5b39d5dac0bcaef9ba91f7e536ac064e6b2834ecccf", size = 2180168, upload-time = "2026-04-20T14:42:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/53/8267811054b1aa7fc1dc7ded93812372ef79a839f5e23558136a6afbfde1/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e480080975c1ef7f780b8f99ed72337e7cc5efea2e518a20a692e8e7b278eb8b", size = 2322885, upload-time = "2026-04-20T14:41:05.253Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/1c0acdb3aa0856ddc4ecc55214578f896f2de16f400cf51627eb3c26c1c4/pydantic_core-2.46.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:de3a5c376f8cd94da9a1b8fd3dd1c16c7a7b216ed31dc8ce9fd7a22bf13b836e", size = 2360328, upload-time = "2026-04-20T14:41:43.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/ef39cd0f4a926814f360e71c1adeab48ad214d9727e4deb48eedfb5bce1a/pydantic_core-2.46.3-cp311-cp311-win32.whl", hash = "sha256:fc331a5314ffddd5385b9ee9d0d2fee0b13c27e0e02dad71b1ae5d6561f51eeb", size = 1979464, upload-time = "2026-04-20T14:43:12.215Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9c/f41951b0d858e343f1cf09398b2a7b3014013799744f2c4a8ad6a3eec4f2/pydantic_core-2.46.3-cp311-cp311-win_amd64.whl", hash = "sha256:b5b9c6cf08a8a5e502698f5e153056d12c34b8fb30317e0c5fd06f45162a6346", size = 2070837, upload-time = "2026-04-20T14:41:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/264a17cd582f6ed50950d4d03dd5fefd84e570e238afe1cb3e25cf238769/pydantic_core-2.46.3-cp311-cp311-win_arm64.whl", hash = "sha256:5dfd51cf457482f04ec49491811a2b8fd5b843b64b11eecd2d7a1ee596ea78a6", size = 2053647, upload-time = "2026-04-20T14:42:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7f/03dbad45cd3aa9083fbc93c210ae8b005af67e4136a14186950a747c6874/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46", size = 2105683, upload-time = "2026-04-20T14:42:19.779Z" },
+    { url = "https://files.pythonhosted.org/packages/26/22/4dc186ac8ea6b257e9855031f51b62a9637beac4d68ac06bee02f046f836/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874", size = 1940052, upload-time = "2026-04-20T14:43:59.274Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/d376391a5aff1f2e8188960d7873543608130a870961c2b6b5236627c116/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76", size = 1988172, upload-time = "2026-04-20T14:41:17.469Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6b/523b9f85c23788755d6ab949329de692a2e3a584bc6beb67fef5e035aa9d/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e9d76736da5f362fabfeea6a69b13b7f2be405c6d6966f06b2f6bfff7e64531", size = 2128596, upload-time = "2026-04-20T14:40:41.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/da/99d40830684f81dec901cac521b5b91c095394cc1084b9433393cde1c2df/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:13afdd885f3d71280cf286b13b310ee0f7ccfefd1dbbb661514a474b726e2f25", size = 2107973, upload-time = "2026-04-20T14:42:06.175Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a5/87024121818d75bbb2a98ddbaf638e40e7a18b5e0f5492c9ca4b1b316107/pydantic_core-2.46.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f91c0aff3e3ee0928edd1232c57f643a7a003e6edf1860bc3afcdc749cb513f3", size = 1947191, upload-time = "2026-04-20T14:43:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/60/62/0c1acfe10945b83a6a59d19fbaa92f48825381509e5701b855c08f13db76/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6529d1d128321a58d30afcc97b49e98836542f68dd41b33c2e972bb9e5290536", size = 2123791, upload-time = "2026-04-20T14:43:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/3b2393b4c8f44285561dc30b00cf307a56a2eff7c483a824db3b8221ca51/pydantic_core-2.46.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:975c267cff4f7e7272eacbe50f6cc03ca9a3da4c4fbd66fffd89c94c1e311aa1", size = 2153197, upload-time = "2026-04-20T14:44:27.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/5af02fb35505051eee727c061f2881c555ab4f8ddb2d42da715a42c9731b/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2b8e4f2bbdf71415c544b4b1138b8060db7b6611bc927e8064c769f64bed651c", size = 2181073, upload-time = "2026-04-20T14:43:20.729Z" },
+    { url = "https://files.pythonhosted.org/packages/10/92/7e0e1bd9ca3c68305db037560ca2876f89b2647deb2f8b6319005de37505/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e61ea8e9fff9606d09178f577ff8ccdd7206ff73d6552bcec18e1033c4254b85", size = 2315886, upload-time = "2026-04-20T14:44:04.826Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d8/101655f27eaf3e44558ead736b2795d12500598beed4683f279396fa186e/pydantic_core-2.46.3-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b504bda01bafc69b6d3c7a0c7f039dcf60f47fab70e06fe23f57b5c75bdc82b8", size = 2360528, upload-time = "2026-04-20T14:40:47.431Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0f/1c34a74c8d07136f0d729ffe5e1fdab04fbdaa7684f61a92f92511a84a15/pydantic_core-2.46.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b00b76f7142fc60c762ce579bd29c8fa44aaa56592dd3c54fab3928d0d4ca6ff", size = 2184144, upload-time = "2026-04-20T14:42:57Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pystow"
+version = "0.8.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/73/0f45f2883bfb0a0cb9c146a8e38722dfe24d3c95a5e7b46fa9082a6409bb/pystow-0.8.11.tar.gz", hash = "sha256:efedb5b4b3a23afa116237ba470f4abd2ef7bae452aef71dd1a7ba2a8338ffe0", size = 52415, upload-time = "2026-04-24T14:44:31.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/f7/94fa6c32572fdc3b801ae4086e3271f6c32145ea11f6ebe78592d6d1fdfe/pystow-0.8.11-py3-none-any.whl", hash = "sha256:baeb6e6471863d411a84efeca8188eb5471b587689b3bda73ede0397162c4576", size = 59399, upload-time = "2026-04-24T14:44:29.8Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-logging"
+version = "2015.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/1e/fb11174c9eaebcec27d36e9e994b90ffa168bc3226925900b9dbbf16c9da/pytest-logging-2015.11.4.tar.gz", hash = "sha256:cec5c85ecf18aab7b2ead5498a31b9f758680ef5a902b9054ab3f2bdbb77c896", size = 3916, upload-time = "2015-11-04T12:15:54.122Z" }
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]


### PR DESCRIPTION
## Summary

Three intertwined feature streams plus two new runtime example projects that prove the LinkML → OpenAPI → Spring → RDF round-trip works end-to-end on a real W3C standard (DCAT-3).

### Post-processors framework

New module \`linkml_openapi.post_processors\` with an \`apply()\` registry and the first concrete pass, **\`extract_inline_oneof\`**. Hoists every inline polymorphic \`oneOf\` in path operations to a named component schema so openapi-generator's Spring template preserves discriminator dispatch instead of flattening the union into a single anonymous DTO.

- \`OpenAPIGenerator.post_processors: list[str]\` field threaded through \`serialize()\`
- \`--post-process\` CLI flag

### Name-mappings for openapi-generator field renames

- \`name_mappings()\` / \`emit_name_mappings()\` methods on the generator
- New \`openapi.legacy_type_codegen_name\` annotation: paired with \`openapi.legacy_type_field\`, supplies a clean target-language identifier (e.g. \`legacyType\`) for openapi-generator's \`--name-mappings @file\` mechanism. Avoids the auto-mangled \`hashType\` / \`atType\` names for awkward wire names like \`#type\`
- \`--emit-name-mappings PATH\` CLI flag

### Discriminator architecture pivot

Polymorphic dispatch moves from the parent's component schema (main's approach) to *use sites* — path responses (\`_class_response_ref\`) and slot ranges (\`_class_range_ref\`) — with the union *including* the root itself when concrete. Adds \`_concrete_descendants_including_self\` as a companion to \`_concrete_descendants_excluding_self\`. Parent component schemas carry only the discriminator field + per-subclass type-value pinning; oneOf lives at the use sites.

### Examples

- **\`examples/dcat3-demo/\`** — Spring Boot service that runs \`gen-spring-server\` against \`tests/fixtures/dcat3.yaml\` during Maven's \`generate-sources\` phase, then boots Spring Boot with springdoc serving \`/v3/api-docs\` and \`/swagger-ui/index.html\`.
- **\`examples/spring-rdf-runtime/\`** — Spring Boot library that registers an \`HttpMessageConverter\` for RDF media types (\`text/turtle\`, \`application/ld+json\`, \`application/rdf+xml\`, \`application/n-triples\`). Reads \`classpath:openapi.yaml\`, indexes \`x-rdf-class\` / \`x-rdf-property\` extensions at startup, and marshals DTOs to RDF graphs via Apache Jena. Drop-in via Spring Boot AutoConfiguration. Consumed by \`dcat3-demo\` to demonstrate end-to-end LinkML → OpenAPI → Spring → RDF round-tripping.

### Other

- \`tests/fixtures/dcat3.yaml\` — full DCAT-3 fixture
- \`examples/bookstore/openapi.yaml\`, \`examples/petstore/openapi.yaml\` — regenerated under the use-site polymorphic-dispatch policy
- \`uv.lock\` — committed for reproducibility

## Test plan

- [ ] \`pytest tests/test_generator.py tests/test_post_processors.py -v\` — 200+ tests
- [ ] Build the dcat3-demo: \`cd examples/dcat3-demo && mvn package\`
- [ ] Run the dcat3-demo: \`mvn spring-boot:run\` — visit \`http://localhost:8080/swagger-ui/index.html\`
- [ ] RDF round-trip: \`curl -H 'Accept: text/turtle' http://localhost:8080/...\` returns Turtle; \`Accept: application/ld+json\` returns JSON-LD
- [ ] \`cd examples/spring-rdf-runtime && mvn test\` — RdfMapperTest + SpecRegistryTest pass

## Note on inter-PR dependency

This branch's \`tests/fixtures/dcat3.yaml\` is a baseline; the \`feat/spring-query-params-deep-chains\` branch (#54) adds annotations on top (\`openapi.query_param\`, \`openapi.nested_only\`). If both PRs are merging in sequence, whichever lands second will need a small rebase on \`tests/fixtures/dcat3.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)