### PR TITLE
fix(spring): emit @Valid on @RequestBody so bean validation actually runs

### DIFF
--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -458,6 +458,7 @@ public class Problem {
             "org.springframework.web.bind.annotation.PutMapping",
             "org.springframework.web.bind.annotation.RequestBody",
             "org.springframework.web.bind.annotation.RequestParam",
+            "jakarta.validation.Valid",
             "io.swagger.v3.oas.annotations.responses.ApiResponse",
             "io.swagger.v3.oas.annotations.media.ArraySchema",
             "io.swagger.v3.oas.annotations.media.Content",
@@ -539,7 +540,7 @@ public class Problem {
                 "method_name": f"create{cn}",
                 "return_type": cn,
                 "params": [
-                    {"annotation": "@RequestBody", "java_type": cn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
                 ],
             },
             {
@@ -568,7 +569,7 @@ public class Problem {
                         "java_type": "String",
                         "java_name": "id",
                     },
-                    {"annotation": "@RequestBody", "java_type": cn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
                 ],
             },
             {
@@ -671,7 +672,7 @@ public class Problem {
                 "return_type": tn,
                 "params": [
                     _path_param("id"),
-                    {"annotation": "@RequestBody", "java_type": tn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": tn, "java_name": "body"},
                 ],
             },
             {
@@ -694,7 +695,7 @@ public class Problem {
                 "params": [
                     _path_param("id"),
                     _path_param(target_id_var),
-                    {"annotation": "@RequestBody", "java_type": tn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": tn, "java_name": "body"},
                 ],
             },
             {
@@ -750,7 +751,7 @@ public class Problem {
                 "params": [
                     _path_param("id"),
                     {
-                        "annotation": "@RequestBody",
+                        "annotation": "@Valid @RequestBody",
                         "java_type": "URI",
                         "java_name": "targetIri",
                     },
@@ -850,7 +851,7 @@ public class Problem {
                 "params": [
                     *chain_path_params,
                     leaf_path_param,
-                    {"annotation": "@RequestBody", "java_type": cn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
                 ],
             },
             {
@@ -941,7 +942,7 @@ public class Problem {
                 "return_type": cn,
                 "params": [
                     *item_params,
-                    {"annotation": "@RequestBody", "java_type": cn, "java_name": "body"},
+                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
                 ],
             },
             {
@@ -993,7 +994,7 @@ public class Problem {
                                 "params": [
                                     *collection_params,
                                     {
-                                        "annotation": "@RequestBody",
+                                        "annotation": "@Valid @RequestBody",
                                         "java_type": cn,
                                         "java_name": "body",
                                     },

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -215,7 +215,7 @@ class TestApiSurface:
         src = files["io/example/dcat/api/CatalogApi.java"]
         assert "attachCatalogDataset" in src
         assert "detachCatalogDataset" in src
-        assert "@RequestBody URI targetIri" in src
+        assert "@Valid @RequestBody URI targetIri" in src
         # Reference list returns IRIs, not embedded objects.
         assert "List<URI>" in src
 
@@ -294,6 +294,19 @@ class TestValidationAndTypes:
         src = files["io/example/dcat/model/Resource.java"]
         assert "private java.time.OffsetDateTime issued" in src
         assert "private java.time.OffsetDateTime modified" in src
+
+    def test_request_bodies_carry_at_valid_for_bean_validation(self, files):
+        """``@Valid @RequestBody`` triggers Spring's bean-validation pass
+        on the body, so the DTO's ``@NotNull`` / ``@Pattern`` / ``@Min`` /
+        ``@Max`` constraints are actually enforced. Without ``@Valid`` the
+        constraints are silent and the documented 422 response contract
+        is unreachable."""
+        src = files["io/example/dcat/api/CatalogApi.java"]
+        # createCatalog and updateCatalog both take a @RequestBody Catalog.
+        assert "@Valid @RequestBody Catalog body" in src
+        # Verify the import landed too — without it the annotation is a
+        # compile error.
+        assert "import jakarta.validation.Valid;" in src
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The DTOs the Spring emitter generates carry the right Jakarta Bean Validation constraints — \`@NotNull\` flows from LinkML's \`required: true\`, \`@Pattern\` from \`pattern\`, \`@Min\` / \`@Max\` from \`minimum_value\` / \`maximum_value\`. But the controller interfaces declared:

\`\`\`java
default ResponseEntity<Catalog> createCatalog(@RequestBody Catalog body) { ... }
\`\`\`

— without \`@Valid\` on the parameter. Spring's bean-validation pass silently didn't run, which means:

- Clients could POST malformed bodies (missing required fields, regex-violating patterns, out-of-range numbers) and Spring accepted them.
- Every mutating operation already declared \`@ApiResponse(responseCode = \"422\", ..., schema = @Schema(implementation = Problem.class))\` — a documented contract the framework never actually emitted.

## Fix

Add \`@Valid\` to every \`@RequestBody\` parameter generated in \`spring/generator.py\` and add \`jakarta.validation.Valid\` to the controller imports set. Five emission sites in \`_top_level_ops\`, \`_composition_ops\`, \`_reference_ops\`, \`_deep_chained_ops\`, and \`_deep_templated_ops\` (plus the templated-collection POST inside the latter).

The reference \`@RequestBody URI targetIri\` in \`_reference_ops\` also picks up \`@Valid\` — no-op for \`java.net.URI\` (no bean constraints), but keeps the emission shape uniform and means future attach payloads (e.g. a \`ResourceLink\` with constraints) get validation for free.

## Effect

\`@Valid\` triggers Spring's validation at request-binding time. Constraint violations become \`MethodArgumentNotValidException\` → 400 Bad Request by default (or 422 if a \`@ControllerAdvice\` is wired up to translate). Either way, the documented \`Problem\` contract on the 422 response is now reachable.

## Test plan

- [x] \`pytest tests/\` — 370 pass (+1: \`TestValidationAndTypes::test_request_bodies_carry_at_valid_for_bean_validation\`)
- [x] Existing \`TestApiSurface::test_reference_slot_emits_attach_detach\` updated for the new annotation shape
- [x] \`mvn -B clean compile\` on \`examples/dcat3-demo\` — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)