### PR TITLE
feat: add `openapi.path_prefix` to OpenAPI + Spring emitters (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [Unreleased]
+
+### Added
+
+- **URL path prefix on both emitters** — `--path-prefix /PREFIX`
+  (CLI) / `path_prefix=` (Python) / schema-level
+  `openapi.path_prefix` annotation. Resolution order: kwarg → schema
+  annotation → no prefix. The prefix must start with `/`, must not
+  contain `{…}` placeholders, and trailing `/` is normalised.
+  ([#61](https://github.com/jackhiggs/linkml-openapi/issues/61))
+  - **OpenAPI generator** prepends the prefix to every key under
+    `paths:`. Validates that no class-level `openapi.path` /
+    `openapi.path_template` already starts with the prefix
+    (catches doubled-prefix configs at build time). `servers[0].url`
+    is left untouched — pass `--server-url` separately if you want
+    the prefix in the server URL too.
+  - **Spring server emitter** renders a class-level
+    `@RequestMapping("<prefix>")` on every controller interface
+    (Spring idiom — method-level mappings stay relative). The
+    sidecar `resources/openapi.yaml` adopts the same prefix on its
+    `paths:` keys so springdoc's runtime view matches the static
+    spec.
+
 ## [0.9.0] — 2026-05-04
 
 The ship-it release for the **LinkML → Spring server emitter** —

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ json_str = gen.serialize(format="json")
 | `openapi_version` | `str` | `"3.0.3"` | OpenAPI dialect to emit (`"3.0.3"` or `"3.1.0"`) |
 | `flatten_inheritance` | `bool` | `False` | Inline parent properties instead of using `allOf` |
 | `error_schema` | `bool` | `True` | Synthesize an RFC 7807 `Problem` schema and reference it from non-2xx responses |
+| `path_style` | `str` | `None` (→ `snake_case`) | URL path-segment convention (`"snake_case"` or `"kebab-case"`) — overrides `openapi.path_style` |
+| `path_prefix` | `str` | `None` | URL path prefix prepended to every `paths:` key (e.g. `/api/v1`) — overrides `openapi.path_prefix` |
 
 > **Why default to 3.0.3?** Several popular codegens — notably
 > `openapi-generator`'s Spring server library — still mishandle `allOf`-based
@@ -193,6 +195,37 @@ Does **not** apply to:
 
 The Python API and CLI both expose a `path_style` / `--path-style`
 override that wins over the schema annotation.
+
+#### `openapi.path_prefix`
+
+URL path prefix prepended to every endpoint in the generated spec
+(e.g. `/api/v1`). Default: no prefix.
+
+```yaml
+annotations:
+  openapi.path_prefix: /api/v1
+```
+
+* **OpenAPI generator** prepends the prefix to every key under
+  `paths:` (so `/catalogs` becomes `/api/v1/catalogs`). Build-time
+  validation: a class whose `openapi.path` /
+  `openapi.path_template` already starts with the prefix raises an
+  error so the schema author picks one source of truth instead of
+  silently doubling.
+* **Spring server emitter** renders a class-level
+  `@RequestMapping("<prefix>")` on every controller interface (Spring
+  idiom — method-level mappings stay relative). The sidecar
+  `resources/openapi.yaml` adopts the same prefix on its `paths:`
+  keys so springdoc's runtime view matches the static spec.
+
+The prefix must start with `/`, must not contain `{…}` placeholders
+(parameterised prefixes belong to runtime routing / API gateways),
+and trailing `/` is normalised. `servers[0].url` is left
+untouched — pass `--server-url` separately if you want the prefix in
+the server URL too.
+
+The Python API and both CLIs expose a `path_prefix` /
+`--path-prefix` override that wins over the schema annotation.
 
 ### Class-level annotations
 
@@ -994,6 +1027,7 @@ endpoints regardless of any of these annotations.
 | `openapi.media_types` | class | comma-separated list | `application/json` |
 | `openapi.tag` | class | string | Class name (composition-derived ops inherit from the target) |
 | `openapi.path_style` | schema | `snake_case` / `kebab-case` | `snake_case` |
+| `openapi.path_prefix` | schema | `/PREFIX` (e.g. `/api/v1`) | No prefix |
 | `openapi.auto_query_params` | schema or class | `"true"` / `"false"` | `"true"` (auto-infer scalar slots) |
 | `openapi.path_id` | class | identifier name | `<class_snake>_id` (e.g. `catalog_id`) |
 | `openapi.parent_path` | class | `Class.slot/Class.slot/...` | Auto-derive when chain is unambiguous |

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -82,6 +82,20 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
     ),
 )
 @click.option(
+    "--path-prefix",
+    default=None,
+    metavar="/PREFIX",
+    help=(
+        "URL path prefix prepended to every emitted `paths:` key "
+        "(e.g. `/api/v1`). Defaults to the schema-level "
+        "`openapi.path_prefix` annotation; CLI flag wins. Validation "
+        "errors if a class's `openapi.path` already starts with the "
+        "prefix (would double up). `servers[0].url` is left alone — "
+        "pass `--server-url` separately if you want the prefix in the "
+        "server URL too."
+    ),
+)
+@click.option(
     "--emit-name-mappings",
     type=click.Path(dir_okay=False, writable=True, path_type=Path),
     default=None,

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -207,6 +207,14 @@ class OpenAPIGenerator(Generator):
     # identifiers in the OpenAPI body, operation IDs, tags, and RDF
     # extensions are unaffected — only the URL segment changes.
     path_style: str | None = None
+    # URL path prefix prepended to every emitted ``paths:`` key. None
+    # falls back to the schema-level ``openapi.path_prefix`` annotation,
+    # then no prefix. Single transformation point — applied at the end
+    # of ``_build_openapi`` so every emitter (composition, chain,
+    # templated, synthetic-inverse) picks it up uniformly. ``servers[0].url``
+    # is intentionally left alone; if a deployment wants the prefix in
+    # the server URL too, pass ``--server-url`` explicitly.
+    path_prefix: str | None = None
     # Names of registered post-processors to apply (in order) after the
     # canonical spec is built but before serialisation. See
     # ``linkml_openapi.post_processors`` for the registry. Each
@@ -251,6 +259,10 @@ class OpenAPIGenerator(Generator):
         # validate once here so per-call-site renderers can just check the
         # cached value without re-parsing.
         self._effective_path_style = self._resolve_path_style()
+        # Resolve the active path prefix (CLI / Python kwarg → schema
+        # annotation → none). Stored as the canonical normalised form
+        # (leading "/", no trailing "/") or empty string for "no prefix".
+        self._effective_path_prefix = self._resolve_path_prefix()
         # Resolve the active profile (or no-op when self.profile is None).
         # `_resolve_profile_filter` also runs drift detection — failing
         # loudly if an excluded slot is referenced by another annotation.
@@ -514,6 +526,15 @@ class OpenAPIGenerator(Generator):
 
         if self._needs_resource_link and "ResourceLink" not in schemas:
             schemas["ResourceLink"] = self._build_resource_link_schema()
+
+        # Apply the path prefix to every emitted `paths:` key. Single
+        # transformation point so composition / chain / templated /
+        # synthetic-inverse paths all pick it up uniformly. Validates
+        # that no class-level ``openapi.path`` already includes the
+        # prefix (would produce a doubled prefix like
+        # ``/api/v1/api/v1/catalogs``).
+        if self._effective_path_prefix:
+            paths = self._apply_path_prefix(paths)
 
         # openapi-pydantic restricts the `openapi` field to 3.1.x literals;
         # we build the model with 3.1.0 and then rewrite the version string
@@ -927,6 +948,69 @@ class OpenAPIGenerator(Generator):
             return annotated
         fallback = identifier_slot or id_named_slot
         return [(fallback, "iri")] if fallback else []
+
+    def _resolve_path_prefix(self) -> str:
+        """Pick the effective URL path prefix for this build.
+
+        Resolution order: CLI / Python ``path_prefix`` kwarg, then the
+        schema-level ``openapi.path_prefix`` annotation, then no prefix.
+
+        Normalisation: must start with ``/``; trailing ``/`` is stripped;
+        no ``{…}`` placeholders (literal only — parameterised prefixes
+        are a runtime / tenancy concern, not a spec one). Returns ``""``
+        when no prefix is configured (caller treats that as no-op).
+        """
+        candidate = self.path_prefix
+        if candidate is None:
+            candidate = self._schema_annotation("openapi.path_prefix")
+        if not candidate:
+            return ""
+        normalised = str(candidate).strip()
+        if not normalised:
+            return ""
+        if not normalised.startswith("/"):
+            raise ValueError(
+                f"`openapi.path_prefix` {candidate!r} must start with `/` "
+                "(use the absolute form, e.g. `/api/v1`)."
+            )
+        if "{" in normalised or "}" in normalised:
+            raise ValueError(
+                f"`openapi.path_prefix` {candidate!r} contains a `{{…}}` "
+                "placeholder. Path prefixes must be literal — parameterised "
+                "prefixes belong to runtime routing / API gateways."
+            )
+        # Strip a single trailing `/` (the prepend step adds back the
+        # separator before each path key).
+        if normalised != "/" and normalised.endswith("/"):
+            normalised = normalised[:-1]
+        return normalised
+
+    def _apply_path_prefix(self, paths: dict[str, PathItem]) -> dict[str, PathItem]:
+        """Prepend ``self._effective_path_prefix`` to every key in ``paths``.
+
+        Validates: no key already starts with the prefix (would double
+        up like ``/api/v1/api/v1/catalogs``). The most likely cause is
+        a class-level ``openapi.path`` annotation that already includes
+        the prefix — the error names the offending path so the schema
+        author can pick one source.
+        """
+        prefix = self._effective_path_prefix
+        prefixed: dict[str, PathItem] = {}
+        for original_path, path_item in paths.items():
+            # The doubled-prefix check fires when the class-level
+            # ``openapi.path`` (or a user-authored ``openapi.path_template``)
+            # already begins with the prefix. Either is fine on its own;
+            # combining them silently is not.
+            if original_path == prefix or original_path.startswith(prefix + "/"):
+                raise ValueError(
+                    f"Path {original_path!r} already starts with the "
+                    f"configured path prefix {prefix!r}. Pick one source: "
+                    "either drop the prefix from the class-level "
+                    "`openapi.path` / `openapi.path_template` annotation, "
+                    "or drop `--path-prefix` / `openapi.path_prefix`."
+                )
+            prefixed[f"{prefix}{original_path}"] = path_item
+        return prefixed
 
     def _resolve_path_style(self) -> str:
         """Pick the effective URL path-segment convention for this build.

--- a/src/linkml_openapi/spring/cli.py
+++ b/src/linkml_openapi/spring/cli.py
@@ -25,10 +25,23 @@ from linkml_openapi.spring.generator import SpringServerGenerator
         "Java root package. Models go in <package>.model, controller interfaces in <package>.api."
     ),
 )
+@click.option(
+    "--path-prefix",
+    default=None,
+    metavar="/PREFIX",
+    help=(
+        "URL path prefix prepended to every controller. Defaults to the "
+        "schema-level `openapi.path_prefix` annotation; CLI flag wins. "
+        'Emitted as a class-level `@RequestMapping(value = "<prefix>")` '
+        "on every controller interface — method-level mappings stay "
+        "relative. The sidecar `resources/openapi.yaml` adopts the same "
+        "prefix on its `paths:` keys to match springdoc's runtime view."
+    ),
+)
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, output: Path, package: str) -> None:
+def cli(yamlfile, output: Path, package: str, path_prefix: str | None) -> None:
     """Generate Spring server source files directly from a LinkML schema."""
-    gen = SpringServerGenerator(yamlfile, package=package)
+    gen = SpringServerGenerator(yamlfile, package=package, path_prefix=path_prefix)
     written = gen.emit(output)
     for path in written:
         click.echo(str(path))

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -86,6 +86,14 @@ class SpringServerGenerator:
 
     schema_path: str
     package: str = "io.example"
+    # URL path prefix prepended to every emitted controller path. None
+    # falls back to the schema-level ``openapi.path_prefix`` annotation,
+    # then no prefix. Emitted as a class-level ``@RequestMapping`` on
+    # every controller interface (Spring idiom — method-level mappings
+    # stay relative). The sidecar OpenAPI spec uses the same prefix on
+    # its ``paths:`` keys so springdoc's runtime view matches the
+    # static spec.
+    path_prefix: str | None = None
 
     _sv: SchemaView = field(init=False)
     _env: Environment = field(init=False)
@@ -108,6 +116,42 @@ class SpringServerGenerator:
             get_slot_annotation=self._get_slot_annotation_compat,
             induced_slots=self._induced_slots,
         )
+        self._effective_path_prefix = self._resolve_path_prefix()
+
+    def _resolve_path_prefix(self) -> str:
+        """Pick the effective URL path prefix for this build.
+
+        Resolution order: ``path_prefix`` kwarg → schema-level
+        ``openapi.path_prefix`` annotation → no prefix. Normalisation
+        matches the OpenAPI generator: must start with ``/``, trailing
+        ``/`` stripped, no ``{…}`` placeholders.
+        """
+        candidate = self.path_prefix
+        if candidate is None:
+            schema_anns = getattr(self._sv.schema, "annotations", None) or {}
+            for ann in schema_anns.values() if hasattr(schema_anns, "values") else schema_anns:
+                if getattr(ann, "tag", None) == "openapi.path_prefix":
+                    candidate = str(ann.value)
+                    break
+        if not candidate:
+            return ""
+        normalised = str(candidate).strip()
+        if not normalised:
+            return ""
+        if not normalised.startswith("/"):
+            raise ValueError(
+                f"`openapi.path_prefix` {candidate!r} must start with `/` "
+                "(use the absolute form, e.g. `/api/v1`)."
+            )
+        if "{" in normalised or "}" in normalised:
+            raise ValueError(
+                f"`openapi.path_prefix` {candidate!r} contains a `{{…}}` "
+                "placeholder. Path prefixes must be literal — parameterised "
+                "prefixes belong to runtime routing / API gateways."
+            )
+        if normalised != "/" and normalised.endswith("/"):
+            normalised = normalised[:-1]
+        return normalised
 
     # --- Public API ---------------------------------------------------
 
@@ -153,7 +197,13 @@ class SpringServerGenerator:
         emitter produces."""
         from linkml_openapi.generator import OpenAPIGenerator
 
-        return OpenAPIGenerator(self.schema_path).serialize()
+        # Pass the prefix through so the sidecar's `paths:` keys match
+        # springdoc's runtime view (which is built from the live
+        # class-level `@RequestMapping` + relative method mappings).
+        return OpenAPIGenerator(
+            self.schema_path,
+            path_prefix=self._effective_path_prefix or None,
+        ).serialize()
 
     def build(self) -> dict[str, str]:
         """In-memory rendering. Returns {relative_path: java_source}."""
@@ -502,12 +552,15 @@ public class Problem {
             op.setdefault("method_annotations", []).extend(
                 _success_and_problem_responses(op["return_type"], media_types)
             )
+        if self._effective_path_prefix:
+            imports.add("org.springframework.web.bind.annotation.RequestMapping")
         return self._env.get_template("api.java.jinja").render(
             package=self.package,
             resource_class=cls.name,
             class_uri=self._expand_curie(cls.class_uri) if cls.class_uri else "",
             imports=sorted(imports),
             operations=ops,
+            request_mapping_base=self._effective_path_prefix,
         )
 
     def _top_level_ops(

--- a/src/linkml_openapi/spring/templates/api.java.jinja
+++ b/src/linkml_openapi/spring/templates/api.java.jinja
@@ -16,6 +16,9 @@ import {{ imp }};
  * <p>Covers the {@code {{ class_uri }}} resource and its relationships.
 {%- endif %}
  */
+{%- if request_mapping_base %}
+@RequestMapping("{{ request_mapping_base }}")
+{%- endif %}
 public interface {{ resource_class }}Api {
 
 {%- for op in operations %}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2091,6 +2091,98 @@ classes:
     # `test_oneof_lists_concrete_descendants_at_property`, and similar.
 
 
+class TestPathPrefix:
+    """Coverage for issue #61 — `openapi.path_prefix` on the OpenAPI spec."""
+
+    _PREFIX_SCHEMA = """
+id: https://example.org/prefix
+name: prefix
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      datasets: { range: Dataset, multivalued: true }
+  Dataset:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+
+    def test_prefix_from_schema_annotation_applies_to_every_path(self):
+        spec = _generate_from_string(
+            self._PREFIX_SCHEMA.replace(
+                "default_range: string",
+                "default_range: string\nannotations:\n  openapi.path_prefix: /api/v1",
+            )
+        )
+        assert all(p.startswith("/api/v1/") for p in spec["paths"]), sorted(spec["paths"])
+
+    def test_kwarg_overrides_schema_annotation(self):
+        spec = _generate_from_string(
+            self._PREFIX_SCHEMA.replace(
+                "default_range: string",
+                "default_range: string\nannotations:\n  openapi.path_prefix: /from-schema",
+            ),
+            path_prefix="/from-kwarg",
+        )
+        assert all(p.startswith("/from-kwarg/") for p in spec["paths"])
+        assert not any("from-schema" in p for p in spec["paths"])
+
+    def test_no_prefix_keeps_paths_unchanged(self):
+        """Default behaviour (no annotation, no kwarg) leaves paths at the root."""
+        spec = _generate_from_string(self._PREFIX_SCHEMA)
+        # Catalog's flat collection is at /catalogs, not /<anything>/catalogs.
+        assert "/catalogs" in spec["paths"]
+        assert not any(p.startswith("/api/") for p in spec["paths"])
+
+    def test_trailing_slash_normalised(self):
+        spec = _generate_from_string(self._PREFIX_SCHEMA, path_prefix="/api/v1/")
+        # Trailing `/` stripped → `/api/v1/catalogs`, not `/api/v1//catalogs`.
+        assert "/api/v1/catalogs" in spec["paths"]
+        assert not any("//" in p for p in spec["paths"])
+
+    def test_missing_leading_slash_raises(self):
+        _generate_from_string_raises(
+            self._PREFIX_SCHEMA, match="must start with `/`", path_prefix="api/v1"
+        )
+
+    def test_placeholder_in_prefix_raises(self):
+        _generate_from_string_raises(
+            self._PREFIX_SCHEMA,
+            match="contains a `\\{…\\}` placeholder",
+            path_prefix="/{tenant}/api/v1",
+        )
+
+    def test_double_prefix_in_class_path_raises(self):
+        """A class with `openapi.path: /api/v1/foo` and `--path-prefix /api/v1` must error."""
+        schema = """
+id: https://example.org/double
+name: double
+default_range: string
+classes:
+  Already:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: /api/v1/already
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        _generate_from_string_raises(
+            schema,
+            match="already starts with the configured path prefix",
+            path_prefix="/api/v1",
+        )
+
+    def test_servers_url_not_modified(self):
+        """`servers[0].url` is left alone — separate concern from path prefix."""
+        spec = _generate_from_string(
+            self._PREFIX_SCHEMA, path_prefix="/api/v1", server_url="https://api.example.com"
+        )
+        assert spec["servers"] == [{"url": "https://api.example.com"}]
+
+
 class TestProfiles:
     """Coverage for issue #17 — multi-view profile filtering."""
 

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -968,3 +968,160 @@ class TestParityWithOpenApiSide:
                     f"{url}: spec={sorted(spec_names)}, spring={sorted(spring_names)}"
                 )
         assert not mismatches, "Query-param drift detected:\n" + "\n".join(mismatches)
+
+
+class TestPathPrefix:
+    """Coverage for issue #61 — `openapi.path_prefix` on the Spring emitter.
+
+    Idiomatic Spring places the shared base path on a class-level
+    ``@RequestMapping`` so method-level mappings stay relative — the
+    sidecar OpenAPI spec adopts the same prefix on its ``paths:`` keys
+    so springdoc's runtime view matches the static spec.
+    """
+
+    @pytest.fixture(scope="class")
+    def prefixed_files(self) -> dict:
+        return SpringServerGenerator(
+            FIXTURE, package="io.example.dcat", path_prefix="/api/v1"
+        ).build()
+
+    def test_class_level_request_mapping_on_every_controller(self, prefixed_files):
+        api_files = {p: s for p, s in prefixed_files.items() if p.endswith("Api.java")}
+        assert api_files, "expected at least one *Api.java to be emitted"
+        for path, source in api_files.items():
+            assert '@RequestMapping("/api/v1")' in source, (
+                f"{path} missing class-level @RequestMapping for /api/v1"
+            )
+
+    def test_request_mapping_import_is_added(self, prefixed_files):
+        for path, source in prefixed_files.items():
+            if not path.endswith("Api.java"):
+                continue
+            assert "import org.springframework.web.bind.annotation.RequestMapping;" in source, (
+                f"{path} missing RequestMapping import"
+            )
+
+    def test_method_level_mappings_stay_relative(self, prefixed_files):
+        """Spring composes class + method mappings — method-level paths must
+        not also include the prefix or the runtime URL doubles up."""
+        for path, source in prefixed_files.items():
+            if not path.endswith("Api.java"):
+                continue
+            # No method-level mapping value should start with the prefix.
+            for line in source.splitlines():
+                stripped = line.strip()
+                if stripped.startswith(
+                    (
+                        "@GetMapping",
+                        "@PostMapping",
+                        "@PutMapping",
+                        "@PatchMapping",
+                        "@DeleteMapping",
+                    )
+                ):
+                    assert "/api/v1" not in stripped, (
+                        f"{path}: method-level mapping should be prefix-relative: {stripped}"
+                    )
+
+    def test_no_request_mapping_when_prefix_unset(self, files):
+        """Default fixture build has no prefix → no class-level @RequestMapping
+        and no RequestMapping import on the controller interfaces."""
+        for path, source in files.items():
+            if not path.endswith("Api.java"):
+                continue
+            assert "@RequestMapping(" not in source, (
+                f"{path} should not carry @RequestMapping when prefix is unset"
+            )
+            assert "import org.springframework.web.bind.annotation.RequestMapping;" not in source, (
+                f"{path} should not import RequestMapping when prefix is unset"
+            )
+
+    def test_sidecar_openapi_spec_adopts_prefix(self, tmp_path):
+        """The sidecar `resources/openapi.yaml` must carry the same prefix on
+        its `paths:` keys so springdoc's runtime view matches the static spec."""
+        import yaml as _yaml
+
+        gen = SpringServerGenerator(FIXTURE, package="io.example.dcat", path_prefix="/api/v1")
+        java_dir = tmp_path / "java"
+        gen.emit(java_dir)
+        spec = _yaml.safe_load((tmp_path / "resources" / "openapi.yaml").read_text())
+        assert spec["paths"], "sidecar spec has no paths"
+        assert all(p.startswith("/api/v1/") for p in spec["paths"]), sorted(spec["paths"])
+
+    def test_schema_annotation_resolves_when_no_kwarg(self, tmp_path):
+        """A schema with `openapi.path_prefix` annotation drives the prefix
+        even when the kwarg is not passed — same resolution order as the
+        OpenAPI generator."""
+        schema = """
+id: https://example.org/anns
+name: anns
+default_range: string
+annotations:
+  openapi.path_prefix: /annotated
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        schema_path = tmp_path / "schema.yaml"
+        schema_path.write_text(schema)
+        files = SpringServerGenerator(str(schema_path), package="io.example.x").build()
+        api_src = files["io/example/x/api/CatalogApi.java"]
+        assert '@RequestMapping("/annotated")' in api_src
+
+    def test_kwarg_overrides_schema_annotation(self, tmp_path):
+        schema = """
+id: https://example.org/anns
+name: anns
+default_range: string
+annotations:
+  openapi.path_prefix: /from-schema
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        schema_path = tmp_path / "schema.yaml"
+        schema_path.write_text(schema)
+        files = SpringServerGenerator(
+            str(schema_path), package="io.example.x", path_prefix="/from-kwarg"
+        ).build()
+        api_src = files["io/example/x/api/CatalogApi.java"]
+        assert '@RequestMapping("/from-kwarg")' in api_src
+        assert "from-schema" not in api_src
+
+    def test_missing_leading_slash_raises(self, tmp_path):
+        schema = """
+id: https://example.org/x
+name: x
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        schema_path = tmp_path / "schema.yaml"
+        schema_path.write_text(schema)
+        with pytest.raises(ValueError, match="must start with `/`"):
+            SpringServerGenerator(str(schema_path), package="io.example.x", path_prefix="api/v1")
+
+    def test_placeholder_in_prefix_raises(self, tmp_path):
+        schema = """
+id: https://example.org/x
+name: x
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        schema_path = tmp_path / "schema.yaml"
+        schema_path.write_text(schema)
+        with pytest.raises(ValueError, match=r"contains a `\{…\}` placeholder"):
+            SpringServerGenerator(
+                str(schema_path), package="io.example.x", path_prefix="/{tenant}/api"
+            )


### PR DESCRIPTION
Both emitters now honour a URL path prefix, resolved from a CLI flag
(`--path-prefix`) / Python kwarg (`path_prefix=`) / schema-level
`openapi.path_prefix` annotation, in that order.

* OpenAPI generator prepends the prefix to every key under `paths:`.
  Build-time validation rejects class-level `openapi.path` /
  `openapi.path_template` values that already start with the prefix
  to catch doubled-prefix configs at the source.
* Spring server emitter renders a class-level
  `@RequestMapping("<prefix>")` on every controller interface (Spring
  idiom — method-level mappings stay relative). The sidecar
  `resources/openapi.yaml` adopts the same prefix on its `paths:`
  keys so springdoc's runtime view matches the static spec.

Prefix must start with `/`, must not contain `{…}` placeholders, and
trailing `/` is normalised. `servers[0].url` is intentionally left
untouched — pass `--server-url` separately if you want the prefix in
the server URL too.