### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.10.0] — 2026-05-04
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.9.0"
+version = "0.10.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
## Summary

Cuts 0.10.0.

### Highlights

- **URL path prefix on both emitters** (#61) — `--path-prefix /PREFIX`
  / `path_prefix=` kwarg / schema-level `openapi.path_prefix`.
  - OpenAPI: prepends to every `paths:` key, validates against
    doubled prefixes from class-level `openapi.path` /
    `openapi.path_template`, leaves `servers[0].url` untouched.
  - Spring: class-level `@RequestMapping("<prefix>")` on every
    controller (Spring idiom — method mappings stay relative). The
    sidecar `resources/openapi.yaml` adopts the same prefix so
    springdoc's runtime view matches the static spec.

### Test plan

- [x] 400 / 400 tests pass (4 docker-only e2e tests deselected; 1 skip)
- [x] `ruff check` + `ruff format --check` clean
- [x] No byte-drift on `examples/{bookstore,minimal,petstore}/openapi.yaml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_