### PR TITLE
feat(gen-spring-server): `--path-style` kebab-case parity (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `openapi.error_class` is also set (user class wins; `UserWarning`
   fires).
   ([#67](https://github.com/jackhiggs/linkml-openapi/issues/67))
+- **`gen-spring-server` `--path-style` flag (kebab-case parity with
+  gen-openapi).** Resolution order: CLI / `path_style=` kwarg →
+  schema-level `openapi.path_style` annotation → `snake_case`. Threads
+  through to controller `@*Mapping` URLs and the sidecar
+  `resources/openapi.yaml` `paths:` keys so springdoc's runtime view
+  matches.
+  ([#70](https://github.com/jackhiggs/linkml-openapi/issues/70))
 
 ### Changed
 

--- a/src/linkml_openapi/spring/cli.py
+++ b/src/linkml_openapi/spring/cli.py
@@ -26,6 +26,19 @@ from linkml_openapi.spring.generator import SpringServerGenerator
     ),
 )
 @click.option(
+    "--path-style",
+    type=click.Choice(["snake_case", "kebab-case"]),
+    default=None,
+    help=(
+        "URL path-segment convention. Defaults to the schema-level "
+        "`openapi.path_style` annotation, or `snake_case` if neither is "
+        "set (byte-identical to today). `kebab-case` flips auto-derived "
+        "class- and slot-driven URL segments to hyphenated form. "
+        "Threads through to controller `@*Mapping` URLs and the sidecar "
+        "OpenAPI spec so springdoc's runtime view matches."
+    ),
+)
+@click.option(
     "--path-prefix",
     default=None,
     metavar="/PREFIX",
@@ -39,9 +52,17 @@ from linkml_openapi.spring.generator import SpringServerGenerator
     ),
 )
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, output: Path, package: str, path_prefix: str | None) -> None:
+def cli(
+    yamlfile,
+    output: Path,
+    package: str,
+    path_prefix: str | None,
+    path_style: str | None,
+) -> None:
     """Generate Spring server source files directly from a LinkML schema."""
-    gen = SpringServerGenerator(yamlfile, package=package, path_prefix=path_prefix)
+    gen = SpringServerGenerator(
+        yamlfile, package=package, path_prefix=path_prefix, path_style=path_style
+    )
     written = gen.emit(output)
     for path in written:
         click.echo(str(path))

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -86,6 +86,12 @@ class SpringServerGenerator:
 
     schema_path: str
     package: str = "io.example"
+    # URL path-segment convention. None falls back to the schema-level
+    # ``openapi.path_style`` annotation, then ``"snake_case"`` (today's
+    # default). ``"kebab-case"`` flips auto-derived class- and slot-
+    # driven URL segments to hyphenated form (``/data-services``,
+    # ``/contact-point``). Mirrors gen-openapi's ``path_style`` flag.
+    path_style: str | None = None
     # URL path prefix prepended to every emitted controller path. None
     # falls back to the schema-level ``openapi.path_prefix`` annotation,
     # then no prefix. Emitted as a class-level ``@RequestMapping`` on
@@ -222,6 +228,7 @@ class SpringServerGenerator:
         return OpenAPIGenerator(
             self.schema_path,
             path_prefix=self._effective_path_prefix or None,
+            path_style=self.path_style,
         ).serialize()
 
     def build(self) -> dict[str, str]:
@@ -1224,7 +1231,20 @@ public class %(class_name)s {
         return ["application/json"]
 
     def _resolve_path_style(self) -> str:
-        """Active schema-level path style; defaults to snake_case."""
+        """Pick the effective URL path-segment convention.
+
+        Resolution order: ``path_style`` kwarg → schema-level
+        ``openapi.path_style`` annotation → ``"snake_case"`` (today's
+        default). Mirrors :meth:`OpenAPIGenerator._resolve_path_style`.
+        """
+        if self.path_style is not None:
+            value = str(self.path_style).strip().lower()
+            if value not in ("snake_case", "kebab-case"):
+                raise ValueError(
+                    f"path_style {self.path_style!r} is not supported. "
+                    "Use `snake_case` or `kebab-case`."
+                )
+            return value
         sv_schema = self._sv.schema
         if sv_schema and sv_schema.annotations:
             for ann in sv_schema.annotations.values():

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -621,6 +621,68 @@ classes:
         src = files["io/example/acro/api/HubApi.java"]
         assert '"/hubs/{id}/xml-parser"' in src
 
+    def test_path_style_kwarg_overrides_schema_annotation(self, tmp_path):
+        """Per #70, the `path_style` kwarg wins over the schema-level
+        `openapi.path_style` annotation (matching gen-openapi)."""
+        fixture = tmp_path / "kw.yaml"
+        fixture.write_text("""
+id: https://example.org/kw
+name: kw
+default_range: string
+annotations:
+  openapi.path_style: snake_case
+classes:
+  DataService:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+""")
+        # Schema says snake_case; kwarg flips to kebab.
+        files = SpringServerGenerator(
+            str(fixture), package="io.example.kw", path_style="kebab-case"
+        ).build()
+        src = files["io/example/kw/api/DataServiceApi.java"]
+        assert '"/data-services"' in src
+        assert '"/data_services"' not in src
+
+    def test_path_style_kwarg_threads_into_sidecar(self, tmp_path):
+        """The sidecar `resources/openapi.yaml` adopts the same path-style
+        as the controllers — springdoc's runtime view matches."""
+        import yaml as _yaml
+
+        fixture = tmp_path / "side.yaml"
+        fixture.write_text("""
+id: https://example.org/side
+name: side
+default_range: string
+classes:
+  DataService:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+""")
+        gen = SpringServerGenerator(str(fixture), package="io.example.s", path_style="kebab-case")
+        spec = _yaml.safe_load(gen._render_openapi_spec())
+        assert "/data-services" in spec["paths"]
+        assert "/data_services" not in spec["paths"]
+
+    def test_invalid_path_style_kwarg_raises(self, tmp_path):
+        fixture = tmp_path / "bad.yaml"
+        fixture.write_text("""
+id: https://example.org/bad
+name: bad
+default_range: string
+classes:
+  Foo:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+""")
+        with pytest.raises(ValueError, match="not supported"):
+            SpringServerGenerator(
+                str(fixture), package="io.example.bad", path_style="camelCase"
+            )._resolve_path_style()
+
 
 class TestDeepChainedPaths:
     """Deep nested URL chains land on the leaf class's controller as


### PR DESCRIPTION
Closes #70.

## Summary

Mirrors gen-openapi's `--path-style` flag on `gen-spring-server`. Resolution order: CLI / `path_style=` kwarg → schema-level `openapi.path_style` annotation → `snake_case`. Threads through to controller `@*Mapping` URLs and the sidecar `resources/openapi.yaml` `paths:` keys so springdoc's runtime view matches the static spec.

The schema-level `openapi.path_style` and `openapi.path_split_camel` annotations were already honoured by the Spring emitter — this PR adds the kwarg/CLI override.

## Test plan

- [x] 403 / 403 tests pass (3 new: kwarg-overrides-annotation, sidecar parity, invalid value rejection)
- [x] `ruff check` + `ruff format --check` clean
- [x] Default behaviour byte-identical (no flag/annotation = today's snake_case output)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_