### PR TITLE
feat: `openapi.body: "false"` — composition for routing only (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+<<<<<<< HEAD
 - **`openapi.error_class_name`** schema-level annotation — renames the
   auto-emitted RFC 7807 `Problem` schema (and every `$ref` to it; and
   on the Spring side the auto-emitted Java DTO) without authoring a
@@ -25,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `resources/openapi.yaml` `paths:` keys so springdoc's runtime view
   matches.
   ([#70](https://github.com/jackhiggs/linkml-openapi/issues/70))
+- **`openapi.body: "false"`** slot annotation — suppresses a
+  class-ranged slot from the parent's component-schema `properties`
+  while keeping the nested endpoint. Use it for "composition for
+  routing only" — the related collection is discoverable via the URL
+  but clients fetch it on demand instead of receiving it embedded.
+  Both emitters honour it (Spring drops the DTO field too).
+  Validates: scalar range and `openapi.nested: "false"` combo both
+  raise.
+  ([#65](https://github.com/jackhiggs/linkml-openapi/issues/65))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -821,6 +821,30 @@ get_distribution_via_catalog_dataset
 
 Slot annotations are placed via `slot_usage` on the class (not on the top-level slot definition). This is because the same slot may serve different roles in different classes.
 
+#### `openapi.body`
+
+Set to `"false"` to suppress a class-ranged slot from the parent's
+component-schema `properties` while keeping the nested endpoint:
+
+```yaml
+classes:
+  Catalog:
+    slot_usage:
+      datasets:
+        annotations:
+          openapi.body: "false"   # /catalogs/{id}/datasets stays; Catalog.datasets disappears
+```
+
+Use it for "composition for routing only" — the related collection is
+discoverable via the URL but clients fetch it on demand instead of
+receiving it embedded in the parent payload.
+
+* Validates: error if the slot's range is a scalar (no nested endpoint
+  to preserve), or if combined with `openapi.nested: "false"` (slot
+  would have no representation at all).
+* Both emitters honour it. Spring drops the field from the DTO; the
+  controller's nested endpoint is still emitted.
+
 #### `openapi.format`
 
 Override the OpenAPI `format` string for a slot's emitted schema. Useful

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -618,6 +618,8 @@ class OpenAPIGenerator(Generator):
                 if self._is_slot_excluded(slot):
                     continue
                 self._record_rdf_slot_uri(cls.name, slot)
+                if self._is_slot_body_excluded(cls, slot):
+                    continue
                 if slot.name not in parent_slot_names:
                     local_properties[slot.name] = self._slot_to_schema(slot)
                     if slot.required:
@@ -649,6 +651,8 @@ class OpenAPIGenerator(Generator):
             if self._is_slot_excluded(slot):
                 continue
             self._record_rdf_slot_uri(cls.name, slot)
+            if self._is_slot_body_excluded(cls, slot):
+                continue
             properties[slot.name] = self._slot_to_schema(slot)
             if slot.required:
                 required.append(slot.name)
@@ -1335,6 +1339,35 @@ class OpenAPIGenerator(Generator):
         if slot.range and slot.range in self._excluded_classes:
             return True
         return False
+
+    def _is_slot_body_excluded(self, cls: ClassDefinition, slot: SlotDefinition) -> bool:
+        """True when the slot is excluded from the parent class's body schema.
+
+        Honours ``openapi.body: "false"`` (#65) — slot generates the
+        nested endpoint but is dropped from the parent's component
+        ``properties``. Validates that the slot's range is a class
+        (composition for routing only makes no sense for scalars), and
+        that it is not also marked ``openapi.nested: "false"`` (the
+        slot would have no representation at all).
+        """
+        body_ann = self._get_slot_annotation(cls, slot.name, "openapi.body")
+        if body_ann is None or body_ann.strip().lower() != "false":
+            return False
+        if not slot.range or self.schemaview.get_class(slot.range) is None:
+            raise ValueError(
+                f'Slot {cls.name}.{slot.name!r} is annotated `openapi.body: "false"` '
+                f"but its range {slot.range!r} is not a class. The annotation only "
+                "makes sense on class-ranged slots — there's no nested endpoint to "
+                "preserve otherwise."
+            )
+        nested_ann = self._get_slot_annotation(cls, slot.name, "openapi.nested")
+        if nested_ann is not None and nested_ann.strip().lower() == "false":
+            raise ValueError(
+                f'Slot {cls.name}.{slot.name!r} is annotated both `openapi.body: "false"` '
+                'and `openapi.nested: "false"`. The slot would have no representation '
+                "at all — drop one annotation."
+            )
+        return True
 
     @staticmethod
     def _build_problem_schema(name: str = "Problem") -> Schema:

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -365,6 +365,12 @@ public class %(class_name)s {
             slot = self._slot_for(cls, slot_name)
             if slot is None:
                 continue
+            # Honour `openapi.body: "false"` (#65) — slot generates the
+            # nested controller endpoint but is dropped from the DTO so
+            # the parent's JSON body doesn't carry the child collection.
+            body_ann = self._get_slot_annotation_compat(cls, slot_name, "openapi.body")
+            if body_ann is not None and str(body_ann).strip().lower() == "false":
+                continue
             prop = self._slot_to_property(slot, imports)
             if prop is not None:
                 properties.append(prop)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2265,6 +2265,80 @@ classes:
         assert spec["servers"] == [{"url": "https://api.example.com"}]
 
 
+class TestBodyFalse:
+    """Coverage for issue #65 — `openapi.body: "false"` slot annotation."""
+
+    _SCHEMA = """
+id: https://example.org/b
+name: b
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      datasets:
+        range: Dataset
+        multivalued: true
+        inlined_as_list: true
+        annotations:
+          openapi.body: "false"
+  Dataset:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+
+    def test_slot_dropped_from_parent_body(self):
+        spec = _generate_from_string(self._SCHEMA)
+        catalog = spec["components"]["schemas"]["Catalog"]
+        assert "datasets" not in catalog.get("properties", {})
+
+    def test_nested_endpoint_still_emitted(self):
+        spec = _generate_from_string(self._SCHEMA)
+        assert "/catalogs/{id}/datasets" in spec["paths"]
+
+    def test_scalar_ranged_slot_raises(self):
+        schema = """
+id: https://example.org/scalar-bad
+name: scalar_bad
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      title:
+        annotations:
+          openapi.body: "false"
+"""
+        _generate_from_string_raises(schema, match="not a class")
+
+    def test_combined_with_nested_false_raises(self):
+        schema = """
+id: https://example.org/combo-bad
+name: combo_bad
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      datasets:
+        range: Dataset
+        multivalued: true
+        inlined_as_list: true
+        annotations:
+          openapi.body: "false"
+          openapi.nested: "false"
+  Dataset:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        _generate_from_string_raises(schema, match="have no representation")
+
+
 class TestProfiles:
     """Coverage for issue #17 — multi-view profile filtering."""
 

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -1229,3 +1229,48 @@ classes:
         """Module fixture has no error_class_name annotation → Problem stays."""
         assert "io/example/dcat/model/Problem.java" in files
         assert "public class Problem" in files["io/example/dcat/model/Problem.java"]
+
+
+class TestBodyFalse:
+    """Coverage for issue #65 — `openapi.body: "false"` slot annotation
+    on the Spring side. The slot generates a nested controller endpoint
+    but is dropped from the Java DTO so the parent payload doesn't carry
+    the child collection."""
+
+    _SCHEMA = """
+id: https://example.org/sb
+name: sb
+default_range: string
+classes:
+  Catalog:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+      datasets:
+        range: Dataset
+        multivalued: true
+        inlined_as_list: true
+        annotations:
+          openapi.body: "false"
+  Dataset:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      id: { identifier: true, required: true }
+"""
+
+    def test_field_dropped_from_dto(self, tmp_path):
+        schema_path = tmp_path / "sb.yaml"
+        schema_path.write_text(self._SCHEMA)
+        files = SpringServerGenerator(str(schema_path), package="io.example.sb").build()
+        catalog_dto = files["io/example/sb/model/Catalog.java"]
+        # Catalog.datasets is excluded → no `private List<Dataset> datasets` field.
+        assert "private java.util.List<Dataset> datasets" not in catalog_dto
+        assert "private List<Dataset> datasets" not in catalog_dto
+
+    def test_nested_endpoint_still_emitted(self, tmp_path):
+        schema_path = tmp_path / "sb.yaml"
+        schema_path.write_text(self._SCHEMA)
+        files = SpringServerGenerator(str(schema_path), package="io.example.sb").build()
+        api = files["io/example/sb/api/CatalogApi.java"]
+        # Composition routing under /catalogs/{id}/datasets remains.
+        assert '"/catalogs/{id}/datasets"' in api


### PR DESCRIPTION
Closes #65.

## Summary

`openapi.body: "false"` on a class-ranged slot suppresses the slot from the parent's component-schema `properties` while keeping the auto-derived nested endpoint. Use it for "composition for routing only" — the related collection is discoverable via `/<parent>/{id}/<slot>` but clients fetch it on demand instead of receiving it embedded in the parent payload.

- OpenAPI generator: drops the slot from the parent's `properties`. Nested endpoint emission is unchanged.
- Spring emitter: additionally drops the matching DTO field.
- Validation: error if range is scalar (no nested endpoint to preserve), error if combined with `openapi.nested: "false"` (slot would have no representation at all).

## Test plan

- [x] 406 / 406 tests pass (6 new: 4 OpenAPI side, 2 Spring side)
- [x] `ruff check` + `ruff format --check` clean
- [x] No drift on examples (no annotation = byte-identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_