### PR TITLE
feat: `openapi.request_class` / `openapi.update_class` (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-<<<<<<< HEAD
 - **`openapi.error_class_name`** schema-level annotation — renames the
   auto-emitted RFC 7807 `Problem` schema (and every `$ref` to it; and
   on the Spring side the auto-emitted Java DTO) without authoring a
@@ -35,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Validates: scalar range and `openapi.nested: "false"` combo both
   raise.
   ([#65](https://github.com/jackhiggs/linkml-openapi/issues/65))
+- **`openapi.request_class`** / **`openapi.update_class`** class-level
+  annotations — distinct schemas for POST/PUT request bodies vs GET
+  responses. POST uses ``request_class``; PUT prefers
+  ``update_class`` then falls back to ``request_class``; GET responses
+  are unchanged. Both emitters honour them; Spring renders the
+  ``@RequestBody`` parameter type as the override class. The named
+  classes must be declared in the schema; otherwise generation
+  fails.
+  ([#66](https://github.com/jackhiggs/linkml-openapi/issues/66))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,36 @@ classes:
       openapi.resource: "true"  # This class gets endpoints
 ```
 
+#### `openapi.request_class` / `openapi.update_class`
+
+Different schemas for POST/PUT bodies vs GET responses:
+
+```yaml
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: CatalogRequest      # POST + PUT body when no update_class
+      openapi.update_class: CatalogUpdateRequest # PUT body (overrides request_class for PUT)
+    attributes: { id: ..., title: string }
+
+  CatalogRequest:
+    attributes: { title: { required: true } }    # no `id` — server-assigned
+
+  CatalogUpdateRequest:
+    attributes: { title: string }                # patch-shaped
+```
+
+* POST `/catalogs` → body `$ref: CatalogRequest`; 201 response stays
+  `$ref: Catalog`.
+* PUT `/catalogs/{id}` → body `$ref: CatalogUpdateRequest` (else
+  `CatalogRequest`, else `Catalog`); 200 response stays `$ref: Catalog`.
+* GET responses are always the resource class — unchanged.
+* The named classes must be declared in the LinkML schema; otherwise
+  generation fails with a clear error.
+* Spring side: emits the matching `*Request` Java DTOs and uses them as
+  the `@RequestBody` parameter type on POST/PUT.
+
 #### `openapi.path`
 
 Sets a custom URL path segment for the resource's endpoints.

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1458,6 +1458,41 @@ class OpenAPIGenerator(Generator):
             return designates_slot.name
         return None
 
+    def _request_body_ref(
+        self, cls: ClassDefinition, class_name: str, op: str
+    ) -> Schema | Reference:
+        """Pick the schema referenced by a POST or PUT request body.
+
+        Resolution (#66):
+
+        * PUT (``op="update"``) → ``openapi.update_class`` if set, else
+          ``openapi.request_class`` if set, else the class's own response ref.
+        * POST (``op="create"``) → ``openapi.request_class`` if set, else
+          the class's own response ref.
+
+        The named class must exist in the schema; otherwise generation fails
+        with a clear error so authors don't ship specs with dangling
+        ``$ref``s. The Spring emitter generates a matching DTO and uses
+        it as the ``@RequestBody`` parameter type.
+        """
+        if op == "update":
+            override = self._class_annotation(
+                cls, "openapi.update_class"
+            ) or self._class_annotation(cls, "openapi.request_class")
+        elif op == "create":
+            override = self._class_annotation(cls, "openapi.request_class")
+        else:
+            override = None
+        if not override:
+            return self._class_response_ref(class_name)
+        target = override.strip()
+        if self.schemaview.get_class(target) is None:
+            raise ValueError(
+                f"Class {class_name!r} is annotated with a request-body class {target!r} "
+                "that is not defined in the schema. Add the class or drop the annotation."
+            )
+        return Reference(ref=f"#/components/schemas/{target}")
+
     def _class_response_ref(self, class_name: str) -> Schema | Reference:
         """Schema or ``$ref`` for the ``class_name`` payload in a path op.
 
@@ -1893,19 +1928,20 @@ class OpenAPIGenerator(Generator):
 
     def _make_create_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
-        ref = self._class_response_ref(class_name)
+        response_ref = self._class_response_ref(class_name)
+        request_ref = self._request_body_ref(cls, class_name, op="create")
         return Operation(
             summary=f"Create a {class_name}",
             operationId=f"create_{_to_snake_case(class_name)}",
             tags=[self._class_tag(class_name)],
             requestBody=RequestBody(
                 required=True,
-                content=self._content_for(ref, media_types),
+                content=self._content_for(request_ref, media_types),
             ),
             responses={
                 "201": Response(
                     description=f"{class_name} created",
-                    content=self._content_for(ref, media_types),
+                    content=self._content_for(response_ref, media_types),
                 ),
                 "422": self._error_response("Validation error"),
             },
@@ -1929,19 +1965,20 @@ class OpenAPIGenerator(Generator):
 
     def _make_update_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
         media_types = self._get_media_types(cls)
-        ref = self._class_response_ref(class_name)
+        response_ref = self._class_response_ref(class_name)
+        request_ref = self._request_body_ref(cls, class_name, op="update")
         return Operation(
             summary=f"Update a {class_name}",
             operationId=f"update_{_to_snake_case(class_name)}",
             tags=[self._class_tag(class_name)],
             requestBody=RequestBody(
                 required=True,
-                content=self._content_for(ref, media_types),
+                content=self._content_for(request_ref, media_types),
             ),
             responses={
                 "200": Response(
                     description=f"{class_name} updated",
-                    content=self._content_for(ref, media_types),
+                    content=self._content_for(response_ref, media_types),
                 ),
                 "404": self._error_response("Not found"),
                 "422": self._error_response("Validation error"),

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -606,6 +606,16 @@ public class %(class_name)s {
     ) -> list[dict]:
         """Standard CRUD on the resource itself."""
         cn = cls.name
+        # Distinct request-body classes for POST / PUT vs GET response (#66).
+        # Falls back to ``cn`` when the annotations are unset.
+        create_body_type = self._request_body_class(cls, op="create") or cn
+        update_body_type = self._request_body_class(cls, op="update") or cn
+        # Add Java imports for the synthesised request DTOs (the model
+        # classes themselves are emitted by ``build()`` for every class in
+        # the schema; they just need a controller-side import).
+        for body_type in (create_body_type, update_body_type):
+            if body_type != cn:
+                imports.add(f"{self.package}.model.{body_type}")
         base = f'"/{path_segment}"'
         item = f'"/{path_segment}/{{id}}"'
         list_return = f"List<{cn}>"
@@ -627,7 +637,11 @@ public class %(class_name)s {
                 "method_name": f"create{cn}",
                 "return_type": cn,
                 "params": [
-                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
+                    {
+                        "annotation": "@Valid @RequestBody",
+                        "java_type": create_body_type,
+                        "java_name": "body",
+                    },
                 ],
             },
             {
@@ -656,7 +670,11 @@ public class %(class_name)s {
                         "java_type": "String",
                         "java_name": "id",
                     },
-                    {"annotation": "@Valid @RequestBody", "java_type": cn, "java_name": "body"},
+                    {
+                        "annotation": "@Valid @RequestBody",
+                        "java_type": update_body_type,
+                        "java_name": "body",
+                    },
                 ],
             },
             {
@@ -1357,6 +1375,36 @@ public class %(class_name)s {
             if ann.tag == tag:
                 return str(ann.value)
         return None
+
+    def _request_body_class(self, cls: ClassDefinition, op: str) -> str | None:
+        """Distinct request-body Java type for POST/PUT (#66).
+
+        Resolution mirrors the OpenAPI side:
+        * ``op="create"`` → ``openapi.request_class`` if set, else None.
+        * ``op="update"`` → ``openapi.update_class`` if set, else
+          ``openapi.request_class`` if set, else None.
+
+        Returns the named class. Validates that the class exists in the
+        schema; otherwise raises so the codegen doesn't ship a controller
+        that imports a non-existent type.
+        """
+        if op == "update":
+            override = self._class_annotation(
+                cls, "openapi.update_class"
+            ) or self._class_annotation(cls, "openapi.request_class")
+        elif op == "create":
+            override = self._class_annotation(cls, "openapi.request_class")
+        else:
+            override = None
+        if not override:
+            return None
+        target = override.strip()
+        if self._sv.get_class(target) is None:
+            raise ValueError(
+                f"Class {cls.name!r} is annotated with a request-body class {target!r} "
+                "that is not defined in the schema. Add the class or drop the annotation."
+            )
+        return target
 
     def _resource_class_names(self) -> set[str]:
         out: set[str] = set()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2339,6 +2339,95 @@ classes:
         _generate_from_string_raises(schema, match="have no representation")
 
 
+class TestRequestUpdateClass:
+    """Coverage for issue #66 — distinct schemas for POST/PUT vs GET response."""
+
+    _SCHEMA = """
+id: https://example.org/r
+name: r
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: CatalogRequest
+      openapi.update_class: CatalogUpdateRequest
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+  CatalogRequest:
+    attributes:
+      title: { required: true }
+  CatalogUpdateRequest:
+    attributes:
+      title: string
+"""
+
+    def test_post_uses_request_class(self):
+        spec = _generate_from_string(self._SCHEMA)
+        post = spec["paths"]["/catalogs"]["post"]
+        assert post["requestBody"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/CatalogRequest"
+        }
+        assert post["responses"]["201"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/Catalog"
+        }
+
+    def test_put_uses_update_class(self):
+        spec = _generate_from_string(self._SCHEMA)
+        put = spec["paths"]["/catalogs/{id}"]["put"]
+        assert put["requestBody"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/CatalogUpdateRequest"
+        }
+        assert put["responses"]["200"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/Catalog"
+        }
+
+    def test_get_uses_resource_class(self):
+        spec = _generate_from_string(self._SCHEMA)
+        get_one = spec["paths"]["/catalogs/{id}"]["get"]
+        assert get_one["responses"]["200"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/Catalog"
+        }
+
+    def test_put_falls_back_to_request_class_when_no_update_class(self):
+        schema = """
+id: https://example.org/r2
+name: r2
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: CatalogRequest
+    attributes:
+      id: { identifier: true, required: true }
+  CatalogRequest:
+    attributes:
+      title: { required: true }
+"""
+        spec = _generate_from_string(schema)
+        put = spec["paths"]["/catalogs/{id}"]["put"]
+        assert put["requestBody"]["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/CatalogRequest"
+        }
+
+    def test_undefined_request_class_raises(self):
+        schema = """
+id: https://example.org/r-bad
+name: r_bad
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: NonExistent
+    attributes:
+      id: { identifier: true, required: true }
+"""
+        _generate_from_string_raises(schema, match="not defined in the schema")
+
+
 class TestProfiles:
     """Coverage for issue #17 — multi-view profile filtering."""
 

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -1274,3 +1274,67 @@ classes:
         api = files["io/example/sb/api/CatalogApi.java"]
         # Composition routing under /catalogs/{id}/datasets remains.
         assert '"/catalogs/{id}/datasets"' in api
+
+
+class TestRequestUpdateClass:
+    """Coverage for issue #66 — `openapi.request_class` /
+    `openapi.update_class` on the Spring side. Distinct Java types for
+    POST and PUT bodies vs the GET response type."""
+
+    _SCHEMA = """
+id: https://example.org/sr
+name: sr
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: CatalogRequest
+      openapi.update_class: CatalogUpdateRequest
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+  CatalogRequest:
+    attributes:
+      title: { required: true }
+  CatalogUpdateRequest:
+    attributes:
+      title: string
+"""
+
+    def test_request_dtos_emitted(self, tmp_path):
+        schema = tmp_path / "sr.yaml"
+        schema.write_text(self._SCHEMA)
+        files = SpringServerGenerator(str(schema), package="io.example.sr").build()
+        assert "io/example/sr/model/CatalogRequest.java" in files
+        assert "io/example/sr/model/CatalogUpdateRequest.java" in files
+
+    def test_post_uses_request_dto_in_signature(self, tmp_path):
+        schema = tmp_path / "sr.yaml"
+        schema.write_text(self._SCHEMA)
+        files = SpringServerGenerator(str(schema), package="io.example.sr").build()
+        api = files["io/example/sr/api/CatalogApi.java"]
+        # Imports both request DTOs.
+        assert "import io.example.sr.model.CatalogRequest;" in api
+        assert "import io.example.sr.model.CatalogUpdateRequest;" in api
+        # @Valid @RequestBody types switch per op; response stays Catalog.
+        assert "@Valid @RequestBody CatalogRequest body" in api
+        assert "@Valid @RequestBody CatalogUpdateRequest body" in api
+        assert "ResponseEntity<Catalog>" in api
+
+    def test_undefined_request_class_raises(self, tmp_path):
+        schema = tmp_path / "bad.yaml"
+        schema.write_text("""
+id: https://example.org/bad
+name: bad
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.request_class: NonExistent
+    attributes:
+      id: { identifier: true, required: true }
+""")
+        with pytest.raises(ValueError, match="not defined in the schema"):
+            SpringServerGenerator(str(schema), package="io.example.bad").build()


### PR DESCRIPTION
Closes #66.

## Summary

Distinct schemas for POST/PUT request bodies vs GET responses. Useful when POST input rejects server-assigned fields (`id`, `createdAt`, `etag`, …) while GET responses include them — and when PUT bodies are PATCH-shaped relative to the full resource.

```yaml
classes:
  Catalog:
    annotations:
      openapi.resource: "true"
      openapi.request_class: CatalogRequest      # POST + PUT body
      openapi.update_class: CatalogUpdateRequest # overrides request_class for PUT
    attributes: { id: ..., title: string }
```

Resolution:
- POST → `request_class` if set, else the resource class.
- PUT → `update_class` if set, else `request_class`, else the resource class.
- GET responses always the resource class — unchanged.

Both emitters honour it. Spring renders the `@RequestBody` parameter type as the override class and imports the matching DTO.

## Test plan

- [x] 408 / 408 tests pass (8 new: 5 OpenAPI side, 3 Spring side)
- [x] `ruff check` + `ruff format --check` clean
- [x] No drift on examples (no annotation = byte-identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_