### PR TITLE
feat(gen-openapi): `--codegen-friendly` mode (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   classes must be declared in the schema; otherwise generation
   fails.
   ([#66](https://github.com/jackhiggs/linkml-openapi/issues/66))
+- **`--codegen-friendly`** flag (and `codegen_friendly=` kwarg) on
+  `gen-openapi` — emits a spec optimised for downstream codegens
+  (openapi-generator, NSwag, etc.):
+  * Drops the single-value `enum` on every discriminator subclass
+    schema (keeps `default` only) so codegens don't materialise
+    single-value enum classes.
+  * Replaces inline `oneOf` at every use site (request body, response,
+    array `items`, slot range) with `$ref` to the polymorphic
+    parent — the parent's component schema gains its own
+    `discriminator` block + `mapping` so codegens still wire dispatch.
+  * The discriminator field name comes from each chain's
+    `openapi.discriminator` annotation (configurable per chain) — not
+    hardcoded.
+  * Default behaviour is unchanged (byte-identical when the flag is
+    absent).
+  ([#64](https://github.com/jackhiggs/linkml-openapi/issues/64))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ json_str = gen.serialize(format="json")
 | `error_schema` | `bool` | `True` | Synthesize an RFC 7807 `Problem` schema and reference it from non-2xx responses |
 | `path_style` | `str` | `None` (→ `snake_case`) | URL path-segment convention (`"snake_case"` or `"kebab-case"`) — overrides `openapi.path_style` |
 | `path_prefix` | `str` | `None` | URL path prefix prepended to every `paths:` key (e.g. `/api/v1`) — overrides `openapi.path_prefix` |
+| `codegen_friendly` | `bool` | `False` | Emit a spec optimised for downstream codegens (drops single-value `enum` on discriminator pins; replaces inline `oneOf` use sites with `$ref` to the polymorphic parent + parent-level `discriminator` block). |
 
 > **Why default to 3.0.3?** Several popular codegens — notably
 > `openapi-generator`'s Spring server library — still mishandle `allOf`-based

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -109,6 +109,20 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
     ),
 )
 @click.option(
+    "--codegen-friendly",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit a spec optimised for downstream codegens (openapi-generator, "
+        "NSwag, etc.). Drops the single-value `enum` on every discriminator "
+        "subclass schema (keeps `default` only) so codegens don't generate "
+        "single-value enum classes; replaces inline `oneOf` at use sites "
+        "with `$ref` to the polymorphic parent (the parent's component "
+        "schema gains its own `discriminator` block + `mapping` so dispatch "
+        "still works)."
+    ),
+)
+@click.option(
     "--post-process",
     "post_process",
     default=None,

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -216,6 +216,17 @@ class OpenAPIGenerator(Generator):
     # is intentionally left alone; if a deployment wants the prefix in
     # the server URL too, pass ``--server-url`` explicitly.
     path_prefix: str | None = None
+    # Codegen-friendly emission for downstream tools (#64). When True:
+    # * Discriminator pin on each subclass uses ``default`` only (drops
+    #   ``enum: [<self>]`` so codegens that materialise enums as Java
+    #   enums don't generate a single-value enum field).
+    # * Use-site polymorphic dispatch becomes ``$ref`` to the parent
+    #   class schema instead of inline ``oneOf: [...]``. The parent
+    #   component schema gains its own ``discriminator`` block (with
+    #   ``mapping``) so codegens still wire polymorphic dispatch.
+    # Default ``False`` keeps today's authoring-clarity output
+    # byte-identical.
+    codegen_friendly: bool = False
     # Names of registered post-processors to apply (in order) after the
     # canonical spec is built but before serialisation. See
     # ``linkml_openapi.post_processors`` for the registry. Each
@@ -1511,6 +1522,12 @@ class OpenAPIGenerator(Generator):
         descendants = self._concrete_descendants_including_self(class_name)
         if len(descendants) <= 1:
             return Reference(ref=f"#/components/schemas/{class_name}")
+        # Codegen-friendly mode: ``$ref`` to the parent class schema.
+        # The parent carries its own ``discriminator`` block (attached
+        # in ``_apply_discriminators``) so codegens dispatch correctly
+        # without inline ``oneOf`` at the use site (#64).
+        if self.codegen_friendly:
+            return Reference(ref=f"#/components/schemas/{class_name}")
         oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
         schema = Schema(oneOf=oneof)
         field = self._inherited_discriminator_field(class_name)
@@ -1754,6 +1771,18 @@ class OpenAPIGenerator(Generator):
             for tv, sub_name in seen.items():
                 self._inject_subclass_type_value(schemas, sub_name, field, tv)
 
+            # Codegen-friendly mode: attach the ``discriminator`` block
+            # (with ``mapping``) to the parent's component schema so a
+            # use-site ``$ref`` to the parent carries dispatch info for
+            # codegens. Default mode keeps the dispatch info inline at
+            # the use sites only (today's authoring-clarity output).
+            if self.codegen_friendly:
+                parent_schema = schemas.get(class_name)
+                if isinstance(parent_schema, Schema):
+                    parent_schema.discriminator = Discriminator(
+                        propertyName=field, mapping=dict(mapping)
+                    )
+
             # Optional back-compat field: `openapi.legacy_type_field` on
             # the polymorphic root names a per-class constant property
             # (e.g. `#type` carrying a Java FQN like
@@ -1827,11 +1856,21 @@ class OpenAPIGenerator(Generator):
             return
         local = self._writable_local_schema(schema)
         properties = dict(local.properties or {})
-        disc = Schema(
-            type=DataType.STRING,
-            enum=[type_value],
-            default=type_value,
-        )
+        # Codegen-friendly mode emits ``default`` only; openapi-generator
+        # then renders the discriminator as a plain ``String`` field with
+        # a constant default rather than a single-value enum (which it
+        # otherwise materialises as a Java enum class) (#64).
+        if self.codegen_friendly:
+            disc = Schema(
+                type=DataType.STRING,
+                default=type_value,
+            )
+        else:
+            disc = Schema(
+                type=DataType.STRING,
+                enum=[type_value],
+                default=type_value,
+            )
         properties[field] = disc
         local.properties = properties
         # The discriminator's RDF identity belongs to the *class*, not
@@ -2145,6 +2184,11 @@ class OpenAPIGenerator(Generator):
         if target_cls is not None and self._is_composition(slot):
             descendants = self._concrete_descendants_including_self(range_name)
             if len(descendants) > 1:
+                # Codegen-friendly: collapse to a ``$ref`` to the
+                # range — the parent's component schema carries the
+                # ``discriminator`` block (#64).
+                if self.codegen_friendly:
+                    return Reference(ref=f"#/components/schemas/{range_name}")
                 oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
                 schema = Schema(oneOf=oneof)
                 field = self._inherited_discriminator_field(range_name)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2428,6 +2428,75 @@ classes:
         _generate_from_string_raises(schema, match="not defined in the schema")
 
 
+class TestCodegenFriendly:
+    """Coverage for issue #64 — `--codegen-friendly` flag."""
+
+    _SCHEMA = """
+id: https://example.org/cgf
+name: cgf
+default_range: string
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.discriminator: resourceType
+    attributes:
+      id: { identifier: true, required: true }
+  Dataset:
+    is_a: Resource
+    annotations: { openapi.resource: "true" }
+  Catalog:
+    is_a: Dataset
+"""
+
+    def test_default_mode_emits_inline_oneof(self):
+        """Without --codegen-friendly, today's authoring-clarity output:
+        inline oneOf at use sites, enum + default on subclass pins."""
+        spec = _generate_from_string(self._SCHEMA)
+        post = spec["paths"]["/datasets"]["post"]
+        body = post["requestBody"]["content"]["application/json"]["schema"]
+        assert "oneOf" in body
+        ds = spec["components"]["schemas"]["Dataset"]
+        local = ds["allOf"][1] if "allOf" in ds else ds
+        disc = local["properties"]["resourceType"]
+        assert disc.get("enum") == ["Dataset"]
+        assert disc.get("default") == "Dataset"
+
+    def test_codegen_friendly_uses_default_only_on_subclass_pin(self):
+        spec = _generate_from_string(self._SCHEMA, codegen_friendly=True)
+        ds = spec["components"]["schemas"]["Dataset"]
+        local = ds["allOf"][1] if "allOf" in ds else ds
+        disc = local["properties"]["resourceType"]
+        assert "enum" not in disc, f"expected no enum, got {disc}"
+        assert disc["default"] == "Dataset"
+        assert disc["type"] == "string"
+
+    def test_codegen_friendly_use_site_is_ref_to_parent(self):
+        spec = _generate_from_string(self._SCHEMA, codegen_friendly=True)
+        post = spec["paths"]["/datasets"]["post"]
+        body = post["requestBody"]["content"]["application/json"]["schema"]
+        assert "oneOf" not in body
+        assert body == {"$ref": "#/components/schemas/Dataset"}
+        resp = post["responses"]["201"]["content"]["application/json"]["schema"]
+        assert resp == {"$ref": "#/components/schemas/Dataset"}
+
+    def test_codegen_friendly_parent_has_discriminator_block(self):
+        spec = _generate_from_string(self._SCHEMA, codegen_friendly=True)
+        resource = spec["components"]["schemas"]["Resource"]
+        disc = resource.get("discriminator")
+        assert disc is not None
+        assert disc["propertyName"] == "resourceType"
+        assert "Dataset" in disc["mapping"]
+        assert "Catalog" in disc["mapping"]
+
+    def test_codegen_friendly_array_items_also_use_ref(self):
+        spec = _generate_from_string(self._SCHEMA, codegen_friendly=True)
+        items = spec["paths"]["/datasets"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]["items"]
+        assert items == {"$ref": "#/components/schemas/Dataset"}
+
+
 class TestProfiles:
     """Coverage for issue #17 — multi-view profile filtering."""
 


### PR DESCRIPTION
Closes #64.

## Summary

`--codegen-friendly` flag (and `codegen_friendly=` kwarg) on `gen-openapi` — emits a spec optimised for downstream codegens (openapi-generator, NSwag, etc.). Three coupled changes:

1. **Subclass discriminator pin uses `default` only** — drops the single-value `enum` on every concrete subclass's discriminator property so codegens don't materialise it as a single-value enum class.
2. **`$ref`-to-parent at use sites** — replaces inline `oneOf: [...]` polymorphic dispatch on path responses, request bodies, list items, and slot ranges with a `$ref` to the polymorphic parent.
3. **Parent component schema gains its own `discriminator` block** — with `propertyName` (from the chain's `openapi.discriminator` annotation, not hardcoded) and `mapping` to every concrete descendant. This is what makes (2) work: codegens read the discriminator from the parent's schema and dispatch correctly.

Default behaviour (no flag) is byte-identical to today's authoring-clarity output.

## Discriminator field name

Per #64 discussion: the property name written on every subclass and the parent's `discriminator` block is the configured `openapi.discriminator` annotation per chain — never hardcoded as `resourceType`.

## Test plan

- [x] 405 / 405 tests pass (5 new — default-mode unchanged, default-only pin, ref-to-parent on POST body & 201 response, parent discriminator block, array items use ref too)
- [x] `ruff check` + `ruff format --check` clean
- [x] Examples byte-identical (`bookstore`, `petstore`, `minimal` all unchanged when flag is absent)
- [x] dcat3 fixture smoke-tested end-to-end with the flag

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_