### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.11.0] — 2026-05-05
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.10.0"
+version = "0.11.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
## Summary

Cuts 0.11.0.

### Highlights

**Added**
- `--codegen-friendly` flag on `gen-openapi` (#64) — `default`-only discriminator pins, `$ref`-to-parent at use sites, parent-level `discriminator` block.
- `openapi.body: "false"` slot annotation (#65) — composition for routing only.
- `openapi.request_class` / `openapi.update_class` (#66) — distinct schemas for POST/PUT bodies vs GET responses.
- `openapi.error_class_name` (#67) — rename the auto-emitted RFC 7807 schema without authoring a class.
- `gen-spring-server --path-style` (#70) — kebab-case parity with `gen-openapi`.

**Changed**
- Nested composition / reference / deep-chain operations now inherit the *immediate URL parent*'s `openapi.tag` instead of the leaf class's tag (#68). Wire change: Swagger UI groups nested ops with the parent's surface; sidecar OpenAPI spec inherits automatically.

### Test plan

- [x] 427 / 427 tests pass on `main` (4 docker-only e2e deselected; 1 skip)
- [x] `ruff check` + `ruff format --check` clean
- [x] `examples/{bookstore,minimal,petstore}/openapi.yaml` byte-identical (no annotation = unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_