### PR TITLE
docs(dcat3-demo): adopt /api/v1 path prefix (#61)

### DIFF
--- a/examples/dcat3-demo/README.md
+++ b/examples/dcat3-demo/README.md
@@ -32,12 +32,22 @@ JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home \
 ```
 
 Maven runs `gen-spring-server` against `tests/fixtures/dcat3.yaml`
-during the `generate-sources` phase, compiles, and boots Spring Boot
-on port 8080. To use a different port:
+during the `generate-sources` phase (with `--path-prefix /api/v1`),
+compiles, and boots Spring Boot on port 8080. To use a different
+port:
 
 ```bash
 mvn spring-boot:run -Dspring-boot.run.arguments=--server.port=8089
 ```
+
+> **Path prefix.** The demo serves every endpoint under `/api/v1`
+> (`/api/v1/catalogs/{id}`, `/api/v1/datasets`, …). The Maven build
+> passes `--path-prefix /api/v1` to `gen-spring-server`, which emits
+> a class-level `@RequestMapping("/api/v1")` on every controller
+> interface and prefixes every `paths:` key in the sidecar
+> `resources/openapi.yaml` so springdoc's runtime view matches.
+> Drop the `--path-prefix` argument from `pom.xml` to serve at the
+> root again.
 
 ## URLs
 
@@ -46,6 +56,9 @@ mvn spring-boot:run -Dspring-boot.run.arguments=--server.port=8089
 | `http://localhost:8080/swagger-ui/index.html` | Interactive Swagger UI |
 | `http://localhost:8080/redoc.html` | ReDoc rendering |
 | `http://localhost:8080/v3/api-docs` | Live OpenAPI 3.1 spec (springdoc) |
+
+(Swagger UI / ReDoc / `/v3/api-docs` are springdoc's own paths and
+are not affected by the resource path prefix.)
 
 ## Content negotiation
 
@@ -56,16 +69,16 @@ The demo seeds an in-memory store with a `Catalog`, two `Dataset`s
 
 ```bash
 # JSON (default)
-curl -s http://localhost:8080/catalogs/city-data
+curl -s http://localhost:8080/api/v1/catalogs/city-data
 
 # Turtle
-curl -s -H 'Accept: text/turtle' http://localhost:8080/catalogs/city-data
+curl -s -H 'Accept: text/turtle' http://localhost:8080/api/v1/catalogs/city-data
 
 # JSON-LD
-curl -s -H 'Accept: application/ld+json' http://localhost:8080/catalogs/city-data
+curl -s -H 'Accept: application/ld+json' http://localhost:8080/api/v1/catalogs/city-data
 
 # RDF/XML
-curl -s -H 'Accept: application/rdf+xml' http://localhost:8080/catalogs/city-data
+curl -s -H 'Accept: application/rdf+xml' http://localhost:8080/api/v1/catalogs/city-data
 ```
 
 Sample Turtle output:
@@ -91,20 +104,21 @@ through to the RDF output.
 
 ## URL surface
 
-After the kebab-case transform and inherited-slot suppression, the
-demo exposes ~54 paths:
+After the kebab-case transform, inherited-slot suppression, and
+`/api/v1` path prefix, the demo exposes ~54 paths:
 
 - **Top-level CRUD** on every resource class:
-  `/catalogs`, `/datasets`, `/dataset-series`, `/data-services`,
-  `/agents`, `/catalog-records`
+  `/api/v1/catalogs`, `/api/v1/datasets`, `/api/v1/dataset-series`,
+  `/api/v1/data-services`, `/api/v1/agents`, `/api/v1/catalog-records`
 - **Single-level nested**:
-  `/datasets/{id}/distribution`, `/catalogs/{id}/dataset`,
-  `/data-services/{id}/serves-dataset`,
-  `/<resource>/{id}/contact-point|contributor|creator`
+  `/api/v1/datasets/{id}/distribution`,
+  `/api/v1/catalogs/{id}/dataset`,
+  `/api/v1/data-services/{id}/serves-dataset`,
+  `/api/v1/<resource>/{id}/contact-point|contributor|creator`
 - **Deep-chained item paths**:
-  `/catalogs/{cat}/dataset/{ds}/in-series/{id}`,
-  `/catalogs/{cat}/dataset/{ds}/distribution/{id}` (Distribution is
-  `nested_only` — no flat `/distributions` URL)
+  `/api/v1/catalogs/{cat}/dataset/{ds}/in-series/{id}`,
+  `/api/v1/catalogs/{cat}/dataset/{ds}/distribution/{id}` (Distribution
+  is `nested_only` — no flat `/api/v1/distributions` URL)
 - **Slot-driven query parameters** on every list endpoint:
   `?title=`, `?issued__gte=`, `?issued__lte=`, `?modified__gte=`,
   `?sort=` array, plus `?limit=` and `?offset=` for pagination
@@ -112,7 +126,7 @@ demo exposes ~54 paths:
 ## Try the deep chain
 
 ```bash
-curl -s "http://localhost:8080/catalogs/city-data/dataset/transit-2024/distribution/transit-2024-gtfs"
+curl -s "http://localhost:8080/api/v1/catalogs/city-data/dataset/transit-2024/distribution/transit-2024-gtfs"
 ```
 
 Returns the seeded `Distribution` with `title`, `mediaType`, `byteSize`,

--- a/examples/dcat3-demo/pom.xml
+++ b/examples/dcat3-demo/pom.xml
@@ -99,6 +99,15 @@
                                 <argument>${project.build.directory}/generated-sources/openapi/java</argument>
                                 <argument>--package</argument>
                                 <argument>io.example.dcat</argument>
+                                <!--
+                                  Demo runs under /api/v1 to exercise the
+                                  path-prefix feature (#61). Class-level
+                                  @RequestMapping("/api/v1") on every
+                                  controller; sidecar OpenAPI spec
+                                  prefixes every paths: key.
+                                -->
+                                <argument>--path-prefix</argument>
+                                <argument>/api/v1</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/examples/dcat3-demo/src/main/java/io/example/dcat/StubControllers.java
+++ b/examples/dcat3-demo/src/main/java/io/example/dcat/StubControllers.java
@@ -327,7 +327,7 @@ public class StubControllers {
 
     /**
      * Distribution is `nested_only` — its only canonical URLs are the
-     * deep chain `/catalogs/{cat}/dataset/{ds}/distribution/{id}`.
+     * deep chain `/api/v1/catalogs/{cat}/dataset/{ds}/distribution/{id}`.
      * Wires through to the same in-memory store as the parent paths.
      */
     @RestController

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "linkml-openapi"
-version = "0.8.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes the last acceptance criterion of #61.

## Summary

Wires the path-prefix feature (shipped in 0.10.0) into the dcat3-demo so it serves every resource endpoint under `/api/v1`.

- **`pom.xml`**: passes `--path-prefix /api/v1` to `gen-spring-server` during `generate-sources`. Generated controller interfaces get class-level `@RequestMapping("/api/v1")`; sidecar `resources/openapi.yaml` keys are prefixed.
- **`README.md`**: every curl example updated to `/api/v1/...`; short note explains how to drop the flag.
- **`StubControllers.java`**: doc-comment URL updated; no code changes (Spring composes the class-level `@RequestMapping` with the interface's method-level mappings).

The test fixture `tests/fixtures/dcat3.yaml` is intentionally **not** modified — keeping the path prefix in the demo's Maven invocation rather than the schema annotation means existing test assertions stay byte-identical.

## Test plan

- [x] 427 / 427 tests pass on this branch
- [x] `ruff check` + `ruff format --check` clean
- [x] `mvn -B compile` green
- [x] `mvn -B spring-boot:run` boots cleanly; verified end-to-end:
  - `GET /api/v1/catalogs/city-data` → 200 JSON, Turtle, JSON-LD all work
  - Deep chain `GET /api/v1/catalogs/city-data/dataset/transit-2024/distribution/transit-2024-gtfs` → 200
  - Non-prefixed `GET /catalogs/city-data` → 404 (prefix is enforced)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_