### PR TITLE
chore(release): 0.11.1 (re-cut with version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [0.11.1] — 2026-05-05
+
+### Docs
+
+- `examples/dcat3-demo/` adopts `--path-prefix /api/v1` in its Maven
+  invocation; controllers carry class-level
+  `@RequestMapping("/api/v1")`; sidecar OpenAPI spec is prefixed; every
+  curl example in the demo README updated to `/api/v1/...`. Closes the
+  last acceptance criterion of
+  [#61](https://github.com/jackhiggs/linkml-openapi/issues/61). No
+  behaviour change in the library itself.
+
 ## [0.11.0] — 2026-05-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.11.0"
+version = "0.11.1"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"


### PR DESCRIPTION
Re-cuts 0.11.1 with the version bump on `main` (the previous tag pointed at a commit still claiming 0.11.0, so the publish workflow failed against PyPI).

Docs-only patch on top of 0.11.0. `examples/dcat3-demo/` now serves under `/api/v1` end-to-end (closes the last acceptance criterion of #61). No library code changes — same wheel as 0.11.0 with a refreshed demo.

## After merging

1. Delete the stale tag/release: `https://github.com/jackhiggs/linkml-openapi/releases/tag/v0.11.1` → "Delete release", then delete the orphaned tag from https://github.com/jackhiggs/linkml-openapi/tags
2. Re-create the GitHub Release pointing at the new `main` HEAD: https://github.com/jackhiggs/linkml-openapi/releases/new?tag=v0.11.1&target=main&title=v0.11.1%20%E2%80%94%20dcat3-demo%20path%20prefix

The publish workflow will then build with the right version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_