### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.12.0] — 2026-05-11
 
 ### Added
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``reactive=`` kwarg → schema-level ``openapi.reactive`` annotation →
   off (today's blocking output). The OpenAPI sidecar spec is
   unchanged — reactive is purely a Spring codegen concern.
-  ([#80](https://github.com/jackhiggs/openapi/issues/80))
+  ([#80](https://github.com/jackhiggs/linkml-openapi/issues/80))
 
 ## [0.11.1] — 2026-05-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.11.1"
+version = "0.12.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"


### PR DESCRIPTION
Cuts 0.12.0.

## Highlights

- **`gen-spring-server --reactive`** — emits Spring WebFlux controllers (mirrors openapi-generator's `reactive: true`). Mono/Flux return types, Mono-wrapped `@RequestBody`, reactor imports. ([#80](https://github.com/jackhiggs/linkml-openapi/issues/80))

No behaviour change to existing output when the flag is absent; OpenAPI generator and sidecar spec are unchanged regardless.

## After merging

GitHub Release: https://github.com/jackhiggs/linkml-openapi/releases/new?tag=v0.12.0&target=main&title=v0.12.0%20%E2%80%94%20gen-spring-server%20--reactive

(Tag will be created against `main` HEAD which now has the version bump, so the publish workflow can build with the right version.)

## Test plan

- [x] 437 / 437 tests pass on `main`
- [x] `ruff check` + `ruff format --check` clean
- [x] No example drift; `bookstore`/`petstore`/`minimal` byte-identical

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_