### PR TITLE
fix: pin pydantic<2.13 to avoid pydantic_core 2.46.x (corporate AMS) — 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [0.12.1] — 2026-05-12
+
+### Fixed
+
+- **Pinned `pydantic<2.13`** so the transitive `pydantic_core` stays at
+  `2.41.x` rather than `2.46.x`. Some corporate licence-scanners
+  (JPMorgan AMS, etc.) don't yet recognise `pydantic_core 2.46.x` and
+  flag it as unknown during procurement. The library only uses
+  pydantic model construction and YAML/JSON serialisation — no
+  2.13-specific features — so the cap has no functional impact.
+
 ## [0.12.0] — 2026-05-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.12.0"
+version = "0.12.1"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -20,6 +20,11 @@ classifiers = [
 dependencies = [
     "linkml-runtime>=1.7.0",
     "openapi-pydantic>=0.5.0",
+    # Cap below pydantic 2.13 so transitive `pydantic_core` stays at
+    # 2.41.x (rather than 2.46.x which corporate licence-scanners flag
+    # as unrecognised). The generator only uses model construction and
+    # YAML/JSON serialisation — no 2.13-specific features.
+    "pydantic>=2.0,<2.13",
     "pyyaml>=6.0",
     "click>=8.0",
     "jinja2>=3.1",

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"


### PR DESCRIPTION
Cuts 0.12.1.

## Why

Corporate licence-scanners (JPMorgan AMS, etc.) don't yet recognise `pydantic_core 2.46.x` (current latest, pulled in by `pydantic 2.13.x`) and flag it as unknown during procurement.

## What

Add `pydantic>=2.0,<2.13` to runtime deps. With the cap in place, the resolver picks `pydantic 2.12.5` → `pydantic_core 2.41.5` — distinctly different from the AMS-flagged `2.46.4`.

The library only uses pydantic model construction and YAML/JSON serialisation — no 2.13-specific features — so the cap is functionally invisible. Verified locally: `pip install --dry-run` resolves cleanly with `openapi-pydantic>=0.5.0` against the new pin.

## After merging

GitHub Release: https://github.com/jackhiggs/linkml-openapi/releases/new?tag=v0.12.1&target=main&title=v0.12.1%20%E2%80%94%20pin%20pydantic%3C2.13

Body:
```markdown
Patch release.

- **Pinned `pydantic<2.13`** so the transitive `pydantic_core` stays at `2.41.x` rather than `2.46.x`. Some corporate licence-scanners don't yet recognise `pydantic_core 2.46.x` and flag it as unknown during procurement. The library only uses model construction and serialisation — no 2.13-specific features — so the cap has no functional impact.

**Full Changelog**: https://github.com/jackhiggs/linkml-openapi/compare/v0.12.0...v0.12.1
```

## Note

If `2.41.x` is also AMS-unknown, tighten the cap further (e.g. `<2.11` → `pydantic_core 2.33.x`, or `<2.10` → `2.27.x`). Today's pin is a one-step rollback.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_