### PR TITLE
feat: decouple slot name / URL segment / RDF predicate; target tag wins (#85, #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [Unreleased]
+
+### Changed (wire-affecting)
+
+- **Nested-composition URL segment now comes from the range class's
+  `openapi.path`** when set, not the slot name
+  ([#85](https://github.com/jackhiggs/linkml-openapi/issues/85)).
+  Resolution: slot-level `openapi.path_segment` →
+  **range class's `openapi.path`** (new) → slot name with active
+  path-style. Decouples slot name (singular, matching vocabulary like
+  `dcat:distribution`) from REST URL noun (plural, e.g.
+  `/distributions`). JSON body property key remains the slot name;
+  `x-rdf-property` from `slot_uri` is unchanged.
+  *Wire impact*: schemas with `openapi.path` declared on classes that
+  appear as composition targets see nested URLs change. The dcat3
+  fixture: `/catalogs/{id}/dataset/{ds}/distribution/{id}` →
+  `/catalogs/{id}/datasets/{ds}/distributions/{id}`.
+  `examples/{bookstore,minimal,petstore}/openapi.yaml` are unaffected
+  (no `openapi.path` on their classes).
+
+- **Target class's explicit `openapi.tag` wins over the parent-tag
+  default** for nested composition / reference / deep-chain
+  operations ([#86](https://github.com/jackhiggs/linkml-openapi/issues/86)).
+  Resolution: slot's `openapi.tag` (new) → target's explicit
+  `openapi.tag` → parent's tag (the
+  [#68](https://github.com/jackhiggs/linkml-openapi/issues/68)
+  default). Schemas without explicit `openapi.tag` on target classes
+  keep today's parent-tag grouping; schemas that *do* declare
+  `openapi.tag` on a target now have nested ops Swagger-UI-grouped
+  under the canonical class group.
+
+### Added
+
+- **`tests/fixtures/dcat3-acme.yaml`** — anonymised company-overlay
+  fixture exercising both wire changes. `AcmeDataset extends Dataset`
+  narrows `distribution` to `AcmeDistribution`; both `Distribution`
+  and `AcmeDistribution` declare `openapi.path: distributions` and
+  their own `openapi.tag`. Regression guard for
+  [#85](https://github.com/jackhiggs/linkml-openapi/issues/85) and
+  [#86](https://github.com/jackhiggs/linkml-openapi/issues/86).
+
 ## [0.12.1] — 2026-05-12
 
 ### Fixed

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -1087,16 +1087,31 @@ class OpenAPIGenerator(Generator):
     def _render_slot_segment(self, parent_cls: ClassDefinition | None, slot: SlotDefinition) -> str:
         """Render the URL segment for a slot used in a nested path.
 
-        Honours the slot's `openapi.path_segment` annotation (verbatim)
-        when set; otherwise applies the active path-style to the slot
-        name. The slot identifier in the OpenAPI body, operation IDs,
-        tags, and `x-rdf-property` extensions are untouched — only the
-        URL segment changes.
+        Resolution precedence (most specific first):
+
+        1. Slot-level ``openapi.path_segment`` (in ``slot_usage``) —
+           taken verbatim.
+        2. Range class's ``openapi.path`` (#85) — when the slot's range
+           is a class with that annotation, the class's URL noun drives
+           the segment so authors can keep slot names singular
+           (matching the underlying vocabulary, e.g. ``dcat:distribution``)
+           while serving plural REST URLs (``/distributions``).
+        3. Active path-style applied to the slot name (today's default).
+
+        The slot identifier in the OpenAPI body, operation IDs, tags,
+        and ``x-rdf-property`` extensions are untouched — only the URL
+        segment changes.
         """
         if parent_cls is not None:
             override = self._get_slot_annotation(parent_cls, slot.name, "openapi.path_segment")
             if override:
                 return override.strip()
+        if slot.range:
+            range_cls = self.schemaview.get_class(slot.range)
+            if range_cls is not None:
+                range_path = self._class_annotation(range_cls, "openapi.path")
+                if range_path:
+                    return range_path.strip().lstrip("/")
         return self._apply_path_style(slot.name)
 
     def _get_path_segment(self, cls: ClassDefinition) -> str:
@@ -2244,16 +2259,46 @@ class OpenAPIGenerator(Generator):
         """OpenAPI ``tags`` value to use for a class's operations.
 
         Defaults to the class name (current behaviour); the
-        ``openapi.tag`` class annotation overrides it. Composition- and
-        reference-derived nested operations call this with the *target*
-        class so all "Dataset" operations end up under one Swagger UI
-        group regardless of where in the URL hierarchy they emit.
+        ``openapi.tag`` class annotation overrides it.
         """
         cls = self.schemaview.get_class(class_name)
         override = self._class_annotation(cls, "openapi.tag") if cls else None
         if override:
             return override.strip()
         return class_name
+
+    def _nested_op_tag(
+        self,
+        parent_class_name: str,
+        target_class_name: str | None = None,
+        slot: SlotDefinition | None = None,
+    ) -> str:
+        """Resolve the OpenAPI tag for a nested-composition / reference /
+        deep-chain operation.
+
+        Resolution precedence (most specific first), per #86:
+
+        1. **Slot-level ``openapi.tag``** in ``slot_usage`` — schema
+           author opts a single relationship out of the class-level
+           defaults.
+        2. **Target class's explicit ``openapi.tag``** — when set, the
+           author has declared the canonical Swagger UI group for
+           ``T``-operations regardless of which URL reaches them.
+        3. **Parent class's tag** (#68 default) — keeps nested ops
+           grouped with the rest of the parent's surface when no
+           target-level signal is present.
+        """
+        if slot is not None:
+            parent_cls = self.schemaview.get_class(parent_class_name)
+            slot_tag = self._get_slot_annotation(parent_cls, slot.name, "openapi.tag")
+            if slot_tag:
+                return slot_tag.strip()
+        if target_class_name:
+            target_cls = self.schemaview.get_class(target_class_name)
+            target_tag = self._class_annotation(target_cls, "openapi.tag") if target_cls else None
+            if target_tag:
+                return target_tag.strip()
+        return self._class_tag(parent_class_name)
 
     def _resolve_item_path_vars(
         self,
@@ -2593,13 +2638,13 @@ class OpenAPIGenerator(Generator):
         chain_suffix = "_via_" + "_".join(_to_snake_case(p) for p, _ in chain)
         deep_paths = {deep_item_path: deep_item}
         self._suffix_operation_ids(deep_paths, chain_suffix)
-        # Re-tag deep-chain operations to the *immediate URL parent* (the
-        # last chain hop's class) so Swagger UI groups them with the rest
-        # of the parent's nested ops rather than under the leaf's tag
-        # (#68). The leaf's flat-path operations keep the leaf's tag.
+        # Re-tag deep-chain operations. Default groups them with the
+        # immediate URL parent (#68); an explicit `openapi.tag` on the
+        # leaf class wins over that (#86), so author-declared canonical
+        # groups for `T` survive being reached through a deep chain.
         if chain:
-            parent_tag = self._class_tag(chain[-1][0])
-            self._retag_path_operations(deep_paths, parent_tag)
+            tag = self._nested_op_tag(chain[-1][0], class_name)
+            self._retag_path_operations(deep_paths, tag)
         return deep_paths
 
     @staticmethod
@@ -2746,11 +2791,10 @@ class OpenAPIGenerator(Generator):
         media_types = self._get_media_types(target_cls)
         target_ref = self._class_response_ref(target_class_name)
         array_schema = Schema(type=DataType.ARRAY, items=target_ref)
-        # Nested composition operations group under the *parent* class's
-        # tag (Swagger UI groups by tag). All operations under
-        # /<parent>/{id}/... live with the rest of the parent's surface
-        # rather than scattering across the child's tag (#68).
-        op_tag = self._class_tag(parent_class_name)
+        # Nested composition op tag: slot's `openapi.tag` →
+        # target class's explicit `openapi.tag` → parent class's tag
+        # (#86 layers explicit target-side override on top of #68).
+        op_tag = self._nested_op_tag(parent_class_name, target_class_name, slot)
         slot_seg = slot.name
 
         collection = PathItem(parameters=list(parent_path_params))
@@ -2926,9 +2970,9 @@ class OpenAPIGenerator(Generator):
         link_ref = Reference(ref="#/components/schemas/ResourceLink")
         # Body accepts a single link or a batch — clients prefer batch.
         link_body_schema = Schema(oneOf=[link_ref, Schema(type=DataType.ARRAY, items=link_ref)])
-        # Reference attach/detach operations group under the *parent*
-        # class's tag for the same reason as composition (#68).
-        op_tag = self._class_tag(parent_class_name)
+        # Reference attach/detach op tag follows the same precedence as
+        # composition (#86 over #68).
+        op_tag = self._nested_op_tag(parent_class_name, target_class_name, slot)
         slot_seg = slot.name
 
         collection = PathItem(parameters=list(parent_path_params))

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -1395,7 +1395,11 @@ public class %(class_name)s {
 
         Priority:
         1. ``openapi.path_segment`` slot annotation — verbatim.
-        2. Slot name with active path-style applied.
+        2. Range class's ``openapi.path`` (#85) — when set, the class's
+           URL noun drives the segment so authors can keep slot names
+           singular (matching the underlying vocabulary, e.g.
+           ``dcat:distribution``) while serving plural REST URLs.
+        3. Slot name with active path-style applied.
         """
         if parent_cls is not None:
             explicit = self._get_slot_annotation_compat(
@@ -1403,6 +1407,12 @@ public class %(class_name)s {
             )
             if explicit:
                 return explicit.strip()
+        if slot.range:
+            range_cls = self._sv.get_class(slot.range)
+            if range_cls is not None:
+                range_path = self._class_annotation(range_cls, "openapi.path")
+                if range_path:
+                    return range_path.strip().lstrip("/")
         return self._apply_path_style(slot.name)
 
     def _induced_slots(self, class_name: str) -> list[SlotDefinition]:

--- a/tests/fixtures/dcat3-acme.yaml
+++ b/tests/fixtures/dcat3-acme.yaml
@@ -1,0 +1,69 @@
+id: https://example.org/dcat3-acme
+name: dcat3_acme
+default_range: string
+
+prefixes:
+  dcat: http://www.w3.org/ns/dcat#
+  dct:  http://purl.org/dc/terms/
+  acme: https://example.com/acme/
+
+classes:
+  # --- Stock DCAT-3 subset ---
+
+  Dataset:
+    class_uri: dcat:Dataset
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+      openapi.tag: Datasets
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+      distribution:
+        slot_uri: dcat:distribution
+        range: Distribution
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+
+  Distribution:
+    class_uri: dcat:Distribution
+    annotations:
+      openapi.resource: "true"
+      openapi.path: distributions
+      openapi.tag: Distributions
+      openapi.nested_only: "true"
+      openapi.parent_path: "Dataset.distribution"
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+      mediaType: uri
+
+  # --- Acme company overlay (fictional) ---
+
+  AcmeDataset:
+    is_a: Dataset
+    class_uri: acme:AcmeDataset
+    annotations:
+      openapi.resource: "true"
+      openapi.path: acme-datasets
+      openapi.tag: AcmeDatasets
+    slot_usage:
+      distribution:
+        range: AcmeDistribution   # narrowed from Distribution
+    attributes:
+      dataLineage: string
+      confidentialityClassification: string
+
+  AcmeDistribution:
+    is_a: Distribution
+    class_uri: acme:AcmeDistribution
+    annotations:
+      openapi.resource: "true"
+      openapi.path: distributions
+      openapi.tag: AcmeDistributions
+      openapi.nested_only: "true"
+      openapi.parent_path: "AcmeDataset.distribution"
+    attributes:
+      s3BucketUri: uri
+      kafkaTopic: string

--- a/tests/test_dcat3.py
+++ b/tests/test_dcat3.py
@@ -246,8 +246,8 @@ class TestComposition:
 
     def test_nested_distribution_collection_path_emitted(self, spec):
         """Composition produces nested CRUD paths under the parent."""
-        assert "/datasets/{id}/distribution" in spec["paths"]
-        assert "/datasets/{id}/distribution/{distribution_id}" in spec["paths"]
+        assert "/datasets/{id}/distributions" in spec["paths"]
+        assert "/datasets/{id}/distributions/{distribution_id}" in spec["paths"]
 
     @staticmethod
     def _ref_target(prop: dict) -> str | None:
@@ -511,7 +511,7 @@ class TestPolymorphicResponses:
             # Distribution is `nested_only`: the canonical URL is the deep
             # chained one under its parent Catalog → Dataset, not a flat
             # `/distributions/{id}`.
-            "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution/{id}",
+            "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}",
         ],
     )
     def test_non_polymorphic_class_endpoint_uses_plain_ref(self, spec, path):
@@ -542,7 +542,7 @@ class TestPathEmission:
             # Distribution carries `openapi.nested_only: "true"` — the
             # canonical URL is the deep chain under Catalog → Dataset, and
             # the flat `/distributions[/...]` surface is suppressed.
-            "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution/{id}",
+            "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}",
             "/catalog-records",
             "/catalog-records/{id}",
         ],

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1206,20 +1206,21 @@ class TestDeepNestedPaths:
     """Coverage for issue #32 — N-level parent chains and override layers."""
 
     def test_two_level_deep_item_path_emits(self):
-        """Dataset2 chain [(Catalog2, datasets)] → /catalogs2/{catalog2Id}/datasets/{dataset2Id}."""
+        """Dataset2 chain [(Catalog2, datasets)] →
+        /catalogs2/{catalog2Id}/datasets2/{dataset2Id}."""
         spec = _generate()
-        assert "/catalogs2/{catalog2Id}/datasets/{dataset2Id}" in spec["paths"]
+        assert "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}" in spec["paths"]
 
     def test_three_level_deep_item_path_emits(self):
         """Distribution2 chain [(Catalog2, datasets), (Dataset2, distributions)]."""
         spec = _generate()
-        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        path = "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}/distributions2/{dist2Id}"
         assert path in spec["paths"]
 
     def test_three_level_deep_item_has_full_crud(self):
         """Deep item path carries the leaf's CRUD (Distribution2 declares default ops)."""
         spec = _generate()
-        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        path = "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}/distributions2/{dist2Id}"
         item = spec["paths"][path]
         # Default operations include get / put / delete (no patch unless asked).
         assert "get" in item
@@ -1229,7 +1230,7 @@ class TestDeepNestedPaths:
     def test_three_level_deep_path_carries_all_ancestor_params(self):
         """Every ancestor's identifier shows up as a path parameter."""
         spec = _generate()
-        path = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}"
+        path = "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}/distributions2/{dist2Id}"
         params = spec["paths"][path].get("parameters", [])
         names = {p["name"] for p in params if p["in"] == "path"}
         assert {"catalog2Id", "dataset2Id", "dist2Id"} <= names
@@ -1240,7 +1241,7 @@ class TestDeepNestedPaths:
         # Catalog2's own item path uses the override.
         assert "/catalogs2/{catalog2Id}" in spec["paths"]
         # And the same name shows up wherever Catalog2 appears as an ancestor.
-        deep = "/catalogs2/{catalog2Id}/datasets/{dataset2Id}"
+        deep = "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}"
         assert deep in spec["paths"]
 
     def test_default_path_id_remains_snake_case(self):
@@ -1261,7 +1262,8 @@ class TestDeepNestedPaths:
         assert "/distributions2/{dist2Id}" not in spec["paths"]
         # …but the deep path is still there.
         assert (
-            "/catalogs2/{catalog2Id}/datasets/{dataset2Id}/distributions/{dist2Id}" in spec["paths"]
+            "/catalogs2/{catalog2Id}/datasets2/{dataset2Id}/distributions2/{dist2Id}"
+            in spec["paths"]
         )
 
     def test_leaf_schema_has_no_ancestor_id_fields(self):
@@ -1849,24 +1851,30 @@ class TestCompositionAndTagEnhancements:
 
     # --- Enhancement 5: openapi.tag --------------------------------------
 
-    def test_nested_composition_inherits_parent_tag(self):
-        """Per #68, single-hop nested composition endpoints inherit the
-        *parent* class's `openapi.tag` so Swagger UI groups them with the
-        rest of the parent's surface."""
+    def test_target_explicit_tag_wins_for_nested_composition(self):
+        """Per #86, when the target (range) class declares an explicit
+        `openapi.tag`, nested-composition ops on the parent inherit
+        *the target's* tag rather than the parent's. The author's
+        explicit tag on a class is the canonical group for that class's
+        operations regardless of which URL reaches them."""
         spec = _generate()
-        # /libraries/{id}/books — Library is the parent (openapi.tag: Library);
-        # the operation is tagged Library, NOT Book (the target's tag).
+        # /libraries/{id}/books — target BookEntry has openapi.tag: Book
+        # (explicit), so the op is tagged Book — not Library (the parent's
+        # tag); the #68 parent-default only kicks in when the target has
+        # no explicit annotation.
         list_book_op = spec["paths"]["/libraries/{libraryId}/books"]["get"]
-        assert list_book_op["tags"] == ["Library"]
+        assert list_book_op["tags"] == ["Book"]
 
-    def test_deep_chained_path_uses_immediate_url_parent_tag(self):
-        """Deep-chain item paths inherit the *immediate URL parent*'s tag —
-        the last chain hop's class — not the leaf class (#68)."""
+    def test_deep_chained_path_uses_target_tag_when_explicit(self):
+        """Per #86, deep-chain item paths use the leaf class's explicit
+        `openapi.tag` when set, overriding the #68 immediate-URL-parent
+        default."""
         spec = _generate()
-        # /libraries/{id}/books/{id}/chapters → immediate parent in the URL
-        # is BookEntry (openapi.tag: Book), not Library or Chapter.
+        # /libraries/{id}/books/{id}/chapters → leaf ChapterEntry has
+        # openapi.tag: Chapter (explicit), so the op is tagged Chapter —
+        # not Book (the immediate URL parent's tag).
         chapter_coll = spec["paths"]["/libraries/{libraryId}/books/{bookId}/chapters"]["get"]
-        assert chapter_coll["tags"] == ["Book"]
+        assert chapter_coll["tags"] == ["Chapter"]
 
     def test_openapi_tag_default_is_class_name(self):
         """Without the annotation, the tag is still the class name (backward compat)."""
@@ -2337,6 +2345,94 @@ classes:
       id: { identifier: true, required: true }
 """
         _generate_from_string_raises(schema, match="have no representation")
+
+
+class TestRangeClassPathSegmentAndTargetTag:
+    """Coverage for #85 (range class `openapi.path` drives nested URL
+    segment) and #86 (target class's explicit `openapi.tag` wins over
+    parent-tag default) — exercised against the `dcat3-acme.yaml`
+    fixture, an anonymised company-overlay extension of stock DCAT-3."""
+
+    @staticmethod
+    def _spec() -> dict:
+        gen = OpenAPIGenerator(str(FIXTURES / "dcat3-acme.yaml"))
+        return yaml.safe_load(gen.serialize())
+
+    # --- #85: URL segment from range class's openapi.path ---
+
+    def test_nested_segment_uses_range_class_openapi_path_stock_dcat(self):
+        """`Dataset.distribution` slot ranges on `Distribution` which has
+        `openapi.path: distributions`. The nested URL segment is the
+        class's plural noun, not the singular slot name."""
+        spec = self._spec()
+        assert "/datasets/{id}/distributions" in spec["paths"]
+        assert "/datasets/{id}/distributions/{distribution_id}" in spec["paths"]
+        # And the singular slot-name version does NOT leak through.
+        assert "/datasets/{id}/distribution" not in spec["paths"]
+
+    def test_nested_segment_uses_range_class_openapi_path_acme_overlay(self):
+        """`AcmeDataset.distribution` narrows the range to
+        `AcmeDistribution` (`openapi.path: distributions`). The URL
+        picks up the range class's path."""
+        spec = self._spec()
+        assert "/acme-datasets/{id}/distributions" in spec["paths"]
+        assert "/acme-datasets/{id}/distributions/{acme_distribution_id}" in spec["paths"]
+        assert "/acme-datasets/{id}/distribution" not in spec["paths"]
+
+    def test_jsonbody_property_key_is_still_slot_name_singular(self):
+        """The decoupling: URL is plural (from class), JSON property
+        key is singular (the slot name `distribution`). Both DCAT-3
+        semantic alignment and RESTful URL convention are honoured at
+        the same time."""
+        spec = self._spec()
+        dataset = spec["components"]["schemas"]["Dataset"]
+        # Walk the allOf to find the local properties block.
+        local = next((p for p in dataset.get("allOf", []) if "properties" in p), dataset)
+        props = local.get("properties", dataset.get("properties", {}))
+        assert "distribution" in props, f"expected singular 'distribution' key, got {list(props)}"
+
+    def test_rdf_property_extension_unchanged(self):
+        """`x-rdf-property` comes from `slot_uri`; the new URL-segment
+        rule must not touch it."""
+        spec = self._spec()
+        dataset = spec["components"]["schemas"]["Dataset"]
+        local = next((p for p in dataset.get("allOf", []) if "properties" in p), dataset)
+        props = local.get("properties", dataset.get("properties", {}))
+        prop = props["distribution"]
+        # `slot_uri: dcat:distribution` → x-rdf-property: full IRI
+        assert prop.get("x-rdf-property") == "http://www.w3.org/ns/dcat#distribution"
+
+    # --- #86: target class's explicit openapi.tag wins ---
+
+    def test_target_tag_wins_on_nested_composition(self):
+        """`Distribution` has `openapi.tag: Distributions` explicitly;
+        nested ops at `/datasets/{id}/distributions` inherit that tag
+        rather than the parent `Dataset.openapi.tag: Datasets`."""
+        spec = self._spec()
+        op = spec["paths"]["/datasets/{id}/distributions"]["get"]
+        assert op["tags"] == ["Distributions"]
+
+    def test_target_tag_wins_on_acme_overlay(self):
+        """`AcmeDistribution.openapi.tag: AcmeDistributions` wins over
+        `AcmeDataset.openapi.tag: AcmeDatasets` on nested ops."""
+        spec = self._spec()
+        op = spec["paths"]["/acme-datasets/{id}/distributions"]["get"]
+        assert op["tags"] == ["AcmeDistributions"]
+
+    def test_target_tag_wins_on_deep_chain(self):
+        """Distribution is `nested_only` and reachable via the deep chain
+        `Dataset.distribution`. The leaf's explicit `openapi.tag` wins
+        over the immediate URL parent (#68 default)."""
+        spec = self._spec()
+        # The deep-chained item path emitted under Dataset's chain.
+        op = spec["paths"]["/datasets/{dataset_id}/distributions/{id}"]["get"]
+        assert op["tags"] == ["Distributions"]
+
+    def test_flat_path_keeps_class_tag(self):
+        """Top-level CRUD on `/datasets` keeps `Datasets` (unchanged)."""
+        spec = self._spec()
+        op = spec["paths"]["/datasets"]["get"]
+        assert op["tags"] == ["Datasets"]
 
 
 class TestRequestUpdateClass:

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -200,12 +200,12 @@ class TestApiSurface:
 
     def test_inlined_composition_emits_nested_crud(self, files):
         """Dataset.distribution is inlined: true → nested CRUD on
-        /datasets/{id}/distribution + /datasets/{id}/distribution/{id}.
+        /datasets/{id}/distributions + /datasets/{id}/distributions/{id}.
         Methods reflect the embedded payload type (Distribution)."""
         src = files["io/example/dcat/api/DatasetApi.java"]
-        assert '@GetMapping(value = "/datasets/{id}/distribution"' in src
-        assert '@PostMapping(value = "/datasets/{id}/distribution"' in src
-        assert '@GetMapping(value = "/datasets/{id}/distribution/{DistributionId}"' in src
+        assert '@GetMapping(value = "/datasets/{id}/distributions"' in src
+        assert '@PostMapping(value = "/datasets/{id}/distributions"' in src
+        assert '@GetMapping(value = "/datasets/{id}/distributions/{DistributionId}"' in src
         assert "ResponseEntity<Distribution>" in src
         assert "List<Distribution>" in src
 
@@ -361,10 +361,10 @@ class TestQueryParams:
 
     def test_query_params_attached_to_composition_list(self, files):
         """Dataset.distribution is inlined: true → composition list at
-        /datasets/{id}/distribution. The list endpoint carries Distribution's
+        /datasets/{id}/distributions. The list endpoint carries Distribution's
         query params (auto-inferred from Distribution's scalar slots)."""
         src = files["io/example/dcat/api/DatasetApi.java"]
-        assert "/datasets/{id}/distribution" in src
+        assert "/datasets/{id}/distributions" in src
         list_method_start = src.find("listDatasetDistribution")
         list_method_end = src.find(") {", list_method_start)
         list_method_signature = src[list_method_start:list_method_end]
@@ -696,7 +696,7 @@ class TestDeepChainedPaths:
         leaf is {id}."""
         src = files["io/example/dcat/api/DistributionApi.java"]
         assert (
-            '@GetMapping(value = "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution/{id}"'
+            '@GetMapping(value = "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}"'
             in src
         )
 
@@ -708,9 +708,9 @@ class TestDeepChainedPaths:
 
     def test_dataset_chain_depth_one(self, files):
         """Dataset's parent chain is just [(Catalog, dataset)] — a single
-        hop. The deep URL is /catalogs/{catalog_id}/dataset/{id}."""
+        hop. The deep URL is /catalogs/{catalog_id}/datasets/{id}."""
         src = files["io/example/dcat/api/DatasetApi.java"]
-        assert '@GetMapping(value = "/catalogs/{catalog_id}/dataset/{id}"' in src
+        assert '@GetMapping(value = "/catalogs/{catalog_id}/datasets/{id}"' in src
         assert "getDatasetViaCatalog" in src
 
     def test_deep_path_params_in_order(self, files):
@@ -729,11 +729,11 @@ class TestDeepChainedPaths:
         """No collection-level GET/POST on the deep chained URL."""
         src = files["io/example/dcat/api/DistributionApi.java"]
         assert (
-            '@PostMapping(value = "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution",'
+            '@PostMapping(value = "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions",'
             not in src
         )
         assert (
-            '@GetMapping(value = "/catalogs/{catalog_id}/dataset/{dataset_id}/distribution",'
+            '@GetMapping(value = "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions",'
             not in src
         )
 


### PR DESCRIPTION
Closes #85 and #86.

## Summary

Two coupled wire changes addressing the downstream catalog reproduction:

**#85 — Nested-composition URL segment from range class's `openapi.path`**

Resolution order for the segment in `/<parent>/{id}/<seg>/...`:
1. Slot-level `openapi.path_segment` in `slot_usage` (existing)
2. **Range class's `openapi.path`** (new)
3. Slot name with active path-style applied (existing default)

Lets schema authors keep slot names singular (canonical vocabulary, e.g. `dcat:distribution`) while serving plural REST URLs (`/distributions`). JSON body property keys and `x-rdf-property` extensions are unchanged.

**#86 — Target class's explicit `openapi.tag` wins over parent-tag default**

Resolution order for the tag on a nested op from parent `P` to target `T`:
1. Slot-level `openapi.tag` in `slot_usage` (new)
2. **Target class's explicit `openapi.tag`** (new)
3. Parent class's tag (#68 default)

Schemas without explicit `openapi.tag` on target classes keep today's parent-tag grouping.

## Wire impact

- `examples/{bookstore,minimal,petstore}/openapi.yaml` — **byte-identical** (no `openapi.path` declared on composition-target classes).
- `tests/fixtures/dcat3.yaml` — deep paths change shape: `/catalogs/{cat}/dataset/{ds}/distribution/{id}` becomes `/catalogs/{cat}/datasets/{ds}/distributions/{id}`. This matches the schema author's declared `openapi.path: datasets` and `openapi.path: distributions`.

## Regression guard

New `tests/fixtures/dcat3-acme.yaml` — anonymised company-overlay fixture: `AcmeDataset extends Dataset` narrows the `distribution` slot to `AcmeDistribution`; both `Distribution` classes declare `openapi.path` and `openapi.tag`. 8 tests in `TestRangeClassPathSegmentAndTargetTag` pin the new contract.

## Test plan

- [x] 445 / 445 tests pass (8 new on the acme fixture; 11 existing deep-path / tag tests updated to the new contract; 426 unchanged)
- [x] `ruff check` + `ruff format --check` clean
- [x] No drift on `bookstore`/`petstore`/`minimal` examples
- [x] dcat3 fixture's new URL shape verified end-to-end
- [x] Spring controllers and Spring sidecar both honour the new precedence (Spring shares `_render_slot_segment_compat`; sidecar inherits from gen-openapi)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_