### PR TITLE
feat: concrete polymorphic root injection (#95); x-namespaces (#98); x-ranges-resolved (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--emit-namespaces` flag** (`emit_namespaces=` kwarg) — emits a
+  top-level `x-namespaces` map (CURIE prefix → expanded IRI) on the
+  spec, drawn from the LinkML schema's `prefixes:` block
+  ([#98](https://github.com/jackhiggs/linkml-openapi/issues/98)). RDF
+  runtimes build JSON-LD `@context` blocks / Turtle `@prefix` decls /
+  RDF-XML namespaces from a single source of truth without re-parsing
+  the LinkML schema. Default off; byte-identical when unset.
+- **`x-ranges-resolved` companion map** alongside
+  `x-rdf-properties-resolved` (also gated behind `--rdf-resolved-map`)
+  — slot name → list of concrete range class names, with `is_a` +
+  `slot_usage` narrowing already resolved
+  ([#99](https://github.com/jackhiggs/linkml-openapi/issues/99)). Lets
+  runtimes deserialise into typed objects without chasing
+  `oneOf`/`$ref`. `AcmeDataset.distribution` resolves to
+  `[AcmeDistribution]` (narrowed), `Dataset.distribution` to
+  `[Distribution, AcmeDistribution]` (wide).
+
+### Fixed
+
+- **Concrete polymorphic root now gets its discriminator field
+  injected** ([#95](https://github.com/jackhiggs/linkml-openapi/issues/95)).
+  When the root class is not `abstract: true` and has its own
+  `openapi.type_value`, the use-site `oneOf` + `discriminator
+  mapping` already included it — but the root's component schema was
+  missing the `resourceType` property declaration, making the spec
+  wire-inconsistent (a `{"resourceType": "Resource", ...}` payload
+  had no property to match). Now the injection pass includes the
+  root when it's concrete. Abstract roots still omit the property
+  (today's behaviour preserved).
+
 ### Fixed
 
 - **`slot_usage` narrowing on inherited slot now materialises on the

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ json_str = gen.serialize(format="json")
 | `path_style` | `str` | `None` (→ `snake_case`) | URL path-segment convention (`"snake_case"` or `"kebab-case"`) — overrides `openapi.path_style` |
 | `path_prefix` | `str` | `None` | URL path prefix prepended to every `paths:` key (e.g. `/api/v1`) — overrides `openapi.path_prefix` |
 | `codegen_friendly` | `bool` | `False` | Emit a spec optimised for downstream codegens (drops single-value `enum` on discriminator pins; replaces inline `oneOf` use sites with `$ref` to the polymorphic parent + parent-level `discriminator` block). |
-| `rdf_resolved_map` | `bool` | `False` | Emit a flattened `x-rdf-properties-resolved` map (slot name → expanded RDF IRI) on every component schema, with `allOf` inheritance resolved — for RDF runtimes that prefer not to chase `$ref` chains. Per-property `x-rdf-property` annotations are also emitted in this mode. |
+| `rdf_resolved_map` | `bool` | `False` | Emit flattened `x-rdf-properties-resolved` (slot → IRI) and `x-ranges-resolved` (slot → list of concrete range class names) maps on every component schema, with `allOf` inheritance resolved — for RDF runtimes that prefer not to chase `$ref` chains. Per-property `x-rdf-property` annotations are also emitted in this mode. |
+| `emit_namespaces` | `bool` | `False` | Emit a top-level `x-namespaces` map (CURIE prefix → expanded IRI) drawn from the schema's `prefixes:` block. Lets RDF runtimes build JSON-LD `@context` blocks / Turtle `@prefix` declarations from a single source of truth. |
 
 > **Why default to 3.0.3?** Several popular codegens — notably
 > `openapi-generator`'s Spring server library — still mishandle `allOf`-based

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -134,8 +134,26 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
         "runtimes (spring-rdf, etc.) look up any field's predicate "
         "directly on the subclass schema without chasing `$ref` chains. "
         "Per-property `x-rdf-property` annotations are emitted in both "
-        "modes (back-compat). Defaults to off — schemas regenerate "
-        "byte-identically when unset."
+        "modes (back-compat). Also emits an `x-ranges-resolved` map "
+        "(slot name → list of resolved range class names) so runtimes "
+        "can deserialise into typed objects without walking `allOf` / "
+        "`oneOf`. Defaults to off — schemas regenerate byte-identically "
+        "when unset."
+    ),
+)
+@click.option(
+    "--emit-namespaces",
+    "emit_namespaces",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit a top-level `x-namespaces` map on the spec (CURIE prefix "
+        "→ expanded IRI) drawn from the LinkML schema's `prefixes:` "
+        "block. Lets RDF runtimes build JSON-LD `@context` blocks / "
+        "Turtle `@prefix` declarations / RDF-XML namespaces from a "
+        "single source of truth without re-parsing the LinkML schema. "
+        "Defaults to off — schemas regenerate byte-identically when "
+        "unset."
     ),
 )
 @click.option(

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -236,6 +236,13 @@ class OpenAPIGenerator(Generator):
     # ``x-rdf-property`` annotations are emitted in both modes
     # (back-compat for runtimes that walk ``allOf``).
     rdf_resolved_map: bool = False
+    # Emit a top-level ``x-namespaces`` map (CURIE prefix → expanded
+    # IRI) on the spec, taken from the LinkML schema's ``prefixes:``
+    # block (#98). Lets RDF runtimes build JSON-LD ``@context`` blocks
+    # / Turtle prefixes from a single source of truth without
+    # re-parsing the LinkML schema. Default off — schemas regenerate
+    # byte-identically when unset.
+    emit_namespaces: bool = False
     # Names of registered post-processors to apply (in order) after the
     # canonical spec is built but before serialisation. See
     # ``linkml_openapi.post_processors`` for the registry. Each
@@ -318,6 +325,8 @@ class OpenAPIGenerator(Generator):
         self._strip_invalid_parameter_fields(raw)
         self._coerce_numeric_constraints(raw)
         self._inject_rdf_extensions(raw)
+        if self.emit_namespaces:
+            self._inject_namespaces(raw)
         if self.post_processors:
             from linkml_openapi.post_processors import apply as _apply_post
 
@@ -1219,6 +1228,15 @@ class OpenAPIGenerator(Generator):
                 resolved = self._resolve_rdf_properties_for_class(class_name)
                 if resolved:
                     schema["x-rdf-properties-resolved"] = resolved
+                # Companion `x-ranges-resolved` map (#99): slot name →
+                # list of resolved range class names (concrete
+                # descendants of the induced range, after inheritance
+                # + slot_usage narrowing). Lets runtimes know which
+                # concrete classes a property could deserialise to
+                # without walking allOf / oneOf themselves.
+                ranges = self._resolve_ranges_for_class(class_name)
+                if ranges:
+                    schema["x-ranges-resolved"] = ranges
 
     def _resolve_rdf_properties_for_class(self, class_name: str) -> dict[str, str]:
         """Build the flattened slot_name → RDF predicate IRI map for a class.
@@ -1237,6 +1255,58 @@ class OpenAPIGenerator(Generator):
                 # so PyYAML's safe-dumper can serialise the map.
                 resolved[str(slot.name)] = str(self.schemaview.expand_curie(slot.slot_uri))
         return resolved
+
+    def _resolve_ranges_for_class(self, class_name: str) -> dict[str, list[str]]:
+        """Build the flattened slot_name → [range class names] map (#99).
+
+        Walks each induced slot; for class-typed ranges, expands to the
+        list of concrete classes a payload property could deserialise
+        to (the range itself plus concrete descendants). Skips slots
+        whose range is a scalar / enum / built-in type.
+        """
+        cls = self.schemaview.get_class(class_name)
+        if cls is None:
+            return {}
+        ranges: dict[str, list[str]] = {}
+        for slot in self._induced_slots_iter(class_name):
+            if not slot.range:
+                continue
+            range_cls = self.schemaview.get_class(slot.range)
+            if range_cls is None:
+                continue
+            descendants = self._concrete_descendants_including_self(slot.range)
+            if descendants:
+                ranges[str(slot.name)] = [str(d) for d in descendants]
+        return ranges
+
+    def _inject_namespaces(self, raw: dict) -> None:
+        """Emit the LinkML schema's prefix map as a top-level
+        ``x-namespaces`` extension (#98).
+
+        Lets RDF runtimes (spring-rdf, JSON-LD adapters, Turtle
+        emitters) build their context / prefix declarations from a
+        single source of truth without re-parsing the LinkML schema.
+        Wire-format-agnostic — the runtime decides whether to render
+        as JSON-LD ``@context``, Turtle ``@prefix``, or RDF/XML
+        namespace declarations.
+
+        Schemas with no ``prefixes:`` block emit no ``x-namespaces``.
+        """
+        prefixes = getattr(self.schemaview.schema, "prefixes", None) or {}
+        ns: dict[str, str] = {}
+        for entry in prefixes.values() if hasattr(prefixes, "values") else prefixes:
+            # Each entry is a Prefix model (or dict); both have
+            # ``prefix_prefix`` + ``prefix_reference`` attrs / keys.
+            pfx = getattr(entry, "prefix_prefix", None) or (
+                entry.get("prefix_prefix") if isinstance(entry, dict) else None
+            )
+            ref = getattr(entry, "prefix_reference", None) or (
+                entry.get("prefix_reference") if isinstance(entry, dict) else None
+            )
+            if pfx and ref:
+                ns[str(pfx)] = str(ref)
+        if ns:
+            raw["x-namespaces"] = ns
 
     # --- Operation builders ------------------------------------------------
 
@@ -1840,8 +1910,20 @@ class OpenAPIGenerator(Generator):
 
             mapping: dict[str, str] = {}
             seen: dict[str, str] = {}
-            for sub_name in concrete:
+            # When the polymorphic root is itself concrete (not abstract /
+            # mixin and carries its own ``openapi.type_value``), include
+            # it in the injection so the wire payload satisfies the
+            # discriminator. The use-site (`_class_response_ref`) already
+            # includes the root in the ``oneOf`` + ``mapping`` for this
+            # case; without injection here the root's component schema
+            # has no ``resourceType`` property to dispatch against (#95).
+            inject_candidates = list(concrete)
+            if not cls.abstract and not cls.mixin and self._type_value(cls):
+                inject_candidates.insert(0, class_name)
+            for sub_name in inject_candidates:
                 tv = self._type_value(sv.get_class(sub_name))
+                if tv is None:
+                    continue
                 if tv in seen:
                     raise ValueError(
                         f"Duplicate openapi.type_value {tv!r} on classes "

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2369,8 +2369,7 @@ class TestRangeClassPathSegmentAndTargetTag:
         spec = self._spec()
         assert "/catalogs/{id}/datasets/{dataset_id}/distributions" in spec["paths"]
         assert (
-            "/catalogs/{id}/datasets/{dataset_id}/distributions/{distribution_id}"
-            in spec["paths"]
+            "/catalogs/{id}/datasets/{dataset_id}/distributions/{distribution_id}" in spec["paths"]
         )
         # Singular slot-name version is not emitted at any depth.
         assert not any("/distribution/" in p or p.endswith("/distribution") for p in spec["paths"])
@@ -2381,10 +2380,7 @@ class TestRangeClassPathSegmentAndTargetTag:
         up the range class's path; canonical chain rooted at
         AcmeCatalog."""
         spec = self._spec()
-        assert (
-            "/acme-catalogs/{id}/acme-datasets/{acme_dataset_id}/distributions"
-            in spec["paths"]
-        )
+        assert "/acme-catalogs/{id}/acme-datasets/{acme_dataset_id}/distributions" in spec["paths"]
         assert (
             "/acme-catalogs/{id}/acme-datasets/{acme_dataset_id}/distributions/{acme_distribution_id}"
             in spec["paths"]
@@ -2427,9 +2423,9 @@ class TestRangeClassPathSegmentAndTargetTag:
         """`AcmeDistribution.openapi.tag: AcmeDistributions` wins over
         AcmeCatalog / AcmeDataset tags on nested ops."""
         spec = self._spec()
-        op = spec["paths"][
-            "/acme-catalogs/{id}/acme-datasets/{acme_dataset_id}/distributions"
-        ]["get"]
+        op = spec["paths"]["/acme-catalogs/{id}/acme-datasets/{acme_dataset_id}/distributions"][
+            "get"
+        ]
         assert op["tags"] == ["AcmeDistributions"]
 
     def test_target_tag_wins_on_deep_chain(self):
@@ -2437,9 +2433,7 @@ class TestRangeClassPathSegmentAndTargetTag:
         chain. The leaf's explicit `openapi.tag` wins over the
         immediate URL parent (#68 default)."""
         spec = self._spec()
-        op = spec["paths"][
-            "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}"
-        ]["get"]
+        op = spec["paths"]["/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}"]["get"]
         assert op["tags"] == ["Distributions"]
 
     def test_flat_path_keeps_class_tag(self):
@@ -2462,10 +2456,7 @@ class TestCanonicalOnlyNestedSuppression:
         """Distribution has parent_path: Catalog.dataset/Dataset.distribution
         and nested_only: true. The full canonical chain item path emits."""
         spec = self._spec()
-        assert (
-            "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}"
-            in spec["paths"]
-        )
+        assert "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}" in spec["paths"]
 
     def test_non_canonical_intermediate_suppressed(self):
         """Without #88, intermediate single-hop `/datasets/{id}/distributions`
@@ -2478,10 +2469,7 @@ class TestCanonicalOnlyNestedSuppression:
         assert "/datasets/{id}/distributions/{distribution_id}" not in spec["paths"]
         assert "/acme-datasets/{id}/distributions" not in spec["paths"]
         # Canonical chains kept.
-        assert (
-            "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}"
-            in spec["paths"]
-        )
+        assert "/catalogs/{catalog_id}/datasets/{dataset_id}/distributions/{id}" in spec["paths"]
         assert (
             "/acme-catalogs/{acme_catalog_id}/acme-datasets/{acme_dataset_id}/distributions/{id}"
             in spec["paths"]
@@ -2642,6 +2630,132 @@ class TestSlotUsageNarrowingMaterialises:
         if local is not None:
             assert "title" not in local.get("properties", {})
             assert "mediaType" not in local.get("properties", {})
+
+
+class TestNonAbstractDiscriminatorRoot:
+    """Coverage for #95 — when the polymorphic root is concrete (not
+    abstract / mixin) and carries its own ``openapi.type_value``, the
+    root's component schema must also carry the discriminator field —
+    otherwise wire payloads for the root fail the discriminator
+    dispatch."""
+
+    _SCHEMA = """
+id: https://example.org/na
+name: na
+default_range: string
+classes:
+  Resource:
+    # NOT abstract — instantiable directly
+    annotations:
+      openapi.resource: "true"
+      openapi.discriminator: resourceType
+      openapi.type_value: Resource
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+  Dataset:
+    is_a: Resource
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: Dataset
+    attributes:
+      description: string
+"""
+
+    def test_concrete_root_has_resource_type_property(self):
+        spec = _generate_from_string(self._SCHEMA)
+        resource = spec["components"]["schemas"]["Resource"]
+        props = resource.get("properties") or {}
+        rt = props.get("resourceType")
+        assert rt is not None, (
+            "concrete polymorphic root must declare the discriminator "
+            "field; today's spec is wire-inconsistent without it"
+        )
+        assert rt == {"type": "string", "enum": ["Resource"], "default": "Resource"}
+
+    def test_subclass_still_pins_its_own_value(self):
+        spec = _generate_from_string(self._SCHEMA)
+        dataset = spec["components"]["schemas"]["Dataset"]
+        local = next((p for p in dataset.get("allOf", []) if "properties" in p), dataset)
+        props = local.get("properties", dataset.get("properties", {}))
+        rt = props["resourceType"]
+        assert rt == {"type": "string", "enum": ["Dataset"], "default": "Dataset"}
+
+    def test_abstract_root_still_omits_property(self):
+        """Sanity: when the root IS abstract, no property is injected
+        (the dcat3 fixture's behaviour stays unchanged)."""
+        schema = self._SCHEMA.replace(
+            "Resource:\n    # NOT abstract — instantiable directly\n    annotations:",
+            "Resource:\n    abstract: true\n    annotations:",
+        )
+        spec = _generate_from_string(schema)
+        resource = spec["components"]["schemas"]["Resource"]
+        props = resource.get("properties") or {}
+        assert "resourceType" not in props
+
+
+class TestEmitNamespaces:
+    """Coverage for #98 — top-level `x-namespaces` prefix map."""
+
+    @staticmethod
+    def _spec(emit_namespaces: bool = False) -> dict:
+        gen = OpenAPIGenerator(str(FIXTURES / "dcat3-acme.yaml"), emit_namespaces=emit_namespaces)
+        return yaml.safe_load(gen.serialize())
+
+    def test_default_off(self):
+        spec = self._spec(emit_namespaces=False)
+        assert "x-namespaces" not in spec
+
+    def test_emits_full_prefix_map(self):
+        spec = self._spec(emit_namespaces=True)
+        ns = spec.get("x-namespaces", {})
+        # dcat3-acme declares dcat, dct, acme — all should be present.
+        assert ns.get("dcat") == "http://www.w3.org/ns/dcat#"
+        assert ns.get("dct") == "http://purl.org/dc/terms/"
+        assert ns.get("acme") == "https://example.com/acme/"
+
+
+class TestRangesResolved:
+    """Coverage for #99 — `x-ranges-resolved` companion map alongside
+    `x-rdf-properties-resolved`."""
+
+    @staticmethod
+    def _spec(rdf_resolved_map: bool = False) -> dict:
+        gen = OpenAPIGenerator(str(FIXTURES / "dcat3-acme.yaml"), rdf_resolved_map=rdf_resolved_map)
+        return yaml.safe_load(gen.serialize())
+
+    def test_default_off(self):
+        """No `x-ranges-resolved` blocks appear without the flag."""
+        spec = self._spec(rdf_resolved_map=False)
+        for name, schema in spec["components"]["schemas"].items():
+            assert "x-ranges-resolved" not in schema, f"unexpected on {name}"
+
+    def test_wide_range_on_parent(self):
+        """`Dataset.distribution` ranges on Distribution which has one
+        concrete descendant (AcmeDistribution). The resolved map lists
+        both."""
+        spec = self._spec(rdf_resolved_map=True)
+        ds = spec["components"]["schemas"]["Dataset"]
+        rr = ds.get("x-ranges-resolved", {})
+        assert sorted(rr.get("distribution", [])) == ["AcmeDistribution", "Distribution"]
+
+    def test_narrowed_range_on_subclass(self):
+        """`AcmeDataset.slot_usage.distribution.range: AcmeDistribution`
+        narrows the inherited slot — the resolved map reflects the
+        narrowing (only AcmeDistribution)."""
+        spec = self._spec(rdf_resolved_map=True)
+        ad = spec["components"]["schemas"]["AcmeDataset"]
+        rr = ad.get("x-ranges-resolved", {})
+        assert rr.get("distribution") == ["AcmeDistribution"]
+
+    def test_scalar_ranges_omitted(self):
+        """Slots whose range is a scalar (string/int/uri) are not in
+        the map — only class-typed ranges."""
+        spec = self._spec(rdf_resolved_map=True)
+        ds = spec["components"]["schemas"]["Dataset"]
+        rr = ds.get("x-ranges-resolved", {})
+        assert "id" not in rr
+        assert "title" not in rr
 
 
 class TestRequestUpdateClass:


### PR DESCRIPTION
Closes #95, #98, #99.

## Summary

Three independent improvements, all additive (default-off / fix to a wire-inconsistent edge case):

### #95 — concrete polymorphic root injection

When the polymorphic root is **not** `abstract: true` and carries its own `openapi.type_value`, the use-site `oneOf` + `discriminator.mapping` already included it. But the root's component schema didn't declare the `resourceType` property — wire-inconsistent. Fix: include the root in the injection pass when it's concrete.

```yaml
# Before
Resource:                    # concrete polymorphic root
  properties:
    id: ...
    # resourceType property MISSING ❌

# After
Resource:
  properties:
    id: ...
    resourceType:            # ✓ injected
      type: string
      enum: [Resource]
      default: Resource
```

Abstract roots (e.g. dcat3's `Resource`) still omit — today's behaviour preserved.

### #98 — `--emit-namespaces`

New flag (`emit_namespaces=` kwarg). Emits a top-level `x-namespaces` map drawn from the LinkML schema's `prefixes:`.

```yaml
openapi: 3.0.3
x-namespaces:
  dcat: http://www.w3.org/ns/dcat#
  dct:  http://purl.org/dc/terms/
  acme: https://example.com/acme/
paths: ...
```

Lets RDF runtimes build JSON-LD `@context` / Turtle `@prefix` declarations from one source of truth.

### #99 — `x-ranges-resolved`

Companion to `x-rdf-properties-resolved` (same `--rdf-resolved-map` flag). Slot name → list of concrete range class names, with `is_a` + `slot_usage` narrowing resolved.

```yaml
Dataset:                                       # wide
  x-ranges-resolved:
    distribution: [Distribution, AcmeDistribution]

AcmeDataset:                                   # narrowed via slot_usage
  x-ranges-resolved:
    distribution: [AcmeDistribution]
```

## Test plan

- [x] 468 / 468 tests pass (9 new: 3 #95, 2 #98, 4 #99)
- [x] `ruff check` + `ruff format --check` clean
- [x] All three default off — `bookstore`/`petstore`/`minimal` byte-identical
- [x] dcat3 fixture's abstract Resource still omits `resourceType` (#95 abstract case preserved)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_