### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.14.0] — 2026-05-15
 
 ### Added
 
@@ -39,8 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   had no property to match). Now the injection pass includes the
   root when it's concrete. Abstract roots still omit the property
   (today's behaviour preserved).
-
-### Fixed
 
 - **`slot_usage` narrowing on inherited slot now materialises on the
   child schema** ([#92](https://github.com/jackhiggs/linkml-openapi/issues/92)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.13.0"
+version = "0.14.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
Cuts 0.14.0.

## Highlights

### Fixed
- **Concrete polymorphic root now declares its discriminator field** ([#95](https://github.com/jackhiggs/linkml-openapi/issues/95)). Non-abstract polymorphic roots had the property missing despite being in the use-site discriminator mapping — wire-inconsistent. Abstract roots still omit (today's behaviour preserved).
- **`slot_usage` narrowing materialises on the child schema** ([#92](https://github.com/jackhiggs/linkml-openapi/issues/92)). `AcmeDataset.slot_usage.distribution.range: AcmeDistribution` now produces `distribution: $ref AcmeDistribution` in the child's `allOf` block instead of silently inheriting the parent's wider `oneOf`.

### Added
- **`--emit-namespaces`** ([#98](https://github.com/jackhiggs/linkml-openapi/issues/98)) — top-level `x-namespaces` map drawn from the schema's `prefixes:` block.
- **`x-ranges-resolved`** ([#99](https://github.com/jackhiggs/linkml-openapi/issues/99)) — companion to `x-rdf-properties-resolved` (under `--rdf-resolved-map`); slot → list of concrete range class names with inheritance + slot_usage narrowing resolved.

### Test plan
- [x] 468 / 468 tests pass on `main`
- [x] `ruff check` + `ruff format --check` clean
- [x] All additive new features default off — `bookstore` / `petstore` / `minimal` byte-identical
- [x] dcat3 fixture's abstract Resource still omits `resourceType` (the #95 fix is gated on `not abstract`)

## After merging

GitHub Release: https://github.com/jackhiggs/linkml-openapi/releases/new?tag=v0.14.0&target=main&title=v0.14.0

(Tag against `main` HEAD which now has the version bump, so the publish workflow ships to PyPI.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_