### PR TITLE
feat: standard errors (#104), pagination (#105), narrowing/legacy/expose (#106-#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [Unreleased]
+
+### Added
+
+- **Standard 4xx / 5xx error response declarations** on every emitted
+  operation, via a new schema-level annotation
+  `openapi.error_responses: "400,401,403,500,503"` (or the matching
+  `--error-responses` CLI flag /
+  `error_responses=[400, 401, 403, 500, 503]` kwarg)
+  ([#104](https://github.com/jackhiggs/linkml-openapi/issues/104)).
+  Each code is described with its standard reason phrase and
+  references the same body schema as today's `404` / `422`
+  (`Problem` by default, or the schema author's
+  `openapi.error_class`). The CLI / kwarg wins over the annotation;
+  an explicit empty list means "skip injection regardless." Existing
+  per-op responses for the same code are preserved. Default unset =
+  byte-identical to today.
+- **Pagination + list envelope + per-endpoint extra query params**
+  for list operations, declared via three composable class-level
+  annotations
+  ([#105](https://github.com/jackhiggs/linkml-openapi/issues/105)):
+  `openapi.list_envelope: <ClassName>` wraps the `200` body in a
+  `$ref` to the named class (the envelope owns the array slot);
+  `openapi.pagination: cursor | page-size | page-offset | none`
+  injects standard query params for the chosen dialect; and
+  `openapi.list_query_params: '<JSON array>'` injects extra typed
+  query params (e.g. filter / sort flags). Applies to top-level CRUD
+  lists, composition lists, reference lists, and templated deep-path
+  lists — one declared shape per resource class. Default unset =
+  byte-identical (bare array + today's auto-emitted `limit` /
+  `offset`).
+- **`openapi.expose: "false"`** class-level annotation
+  ([#110](https://github.com/jackhiggs/linkml-openapi/issues/110)) —
+  keeps the class addressable as a component schema (other resources
+  can `$ref` it) but suppresses its own path emission on both
+  `gen-openapi` and `gen-spring-server`. Use when the type is part
+  of the wire contract but CRUD ownership lives in a different
+  service.
+- **`openapi.codegen_inheritance: "false"`** root-class escape hatch
+  for `--codegen-friendly`
+  ([#106](https://github.com/jackhiggs/linkml-openapi/issues/106)).
+  Forces the use-site `oneOf` fallback even when no narrowing is
+  detected — useful when the schema author already knows the
+  inheritance-based dispatch won't work for a chosen codegen.
+
+### Fixed
+
+- **`--codegen-friendly` no longer emits uncompilable Java when a
+  subtype narrows an inherited slot's range**
+  ([#106](https://github.com/jackhiggs/linkml-openapi/issues/106)).
+  Before: with `slot_usage` narrowing on an inherited slot (#92
+  emits the narrowed shape on the child schema) the parent-level
+  discriminator-based dispatch collided with openapi-generator's
+  inheritance template, producing a covariant return-type compile
+  error (`List<AcmeDistribution> getDistribution()` overriding
+  `List<Distribution>`). After: the generator detects narrowing
+  during the build and falls back to use-site `oneOf` for the
+  affected polymorphic root only. Roots without narrowing keep
+  today's parent-`$ref` strategy (which already compiles fine).
+- **`discriminator.mapping` keys now match the wire when the
+  discriminator field is `openapi.legacy_type_field`**
+  ([#107](https://github.com/jackhiggs/linkml-openapi/issues/107)).
+  When `openapi.discriminator` and `openapi.legacy_type_field` name
+  the same field (e.g., `#type`), the mapping keys are each
+  subtype's `openapi.legacy_type_value` (the actual wire value)
+  instead of the simple class name — so dispatch resolves. When the
+  two annotations name different fields, today's simple-name mapping
+  is preserved.
+- **`--codegen-friendly` now strips the single-value `enum` on
+  `openapi.legacy_type_field` properties**
+  ([#108](https://github.com/jackhiggs/linkml-openapi/issues/108)) —
+  consistency with the primary discriminator's treatment. Codegens
+  no longer materialise a one-element enum class per subtype for the
+  legacy field. Without `--codegen-friendly`, today's
+  `enum: [<value>], default: <value>` shape is preserved.
+- **Empty `PathItem` objects no longer leak into the spec**
+  ([#109](https://github.com/jackhiggs/linkml-openapi/issues/109)).
+  When `openapi.path_template` produced a deep-item path but
+  `openapi.operations` listed only collection-level ops, the
+  deep-item entry was emitted with `parameters` only and no HTTP
+  methods — structurally invalid OpenAPI. The generator now drops
+  any PathItem that declares no operation and no `$ref`.
+
 ## [0.14.0] — 2026-05-15
 
 ### Added

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -204,9 +204,7 @@ def cli(
             try:
                 codes.append(int(token))
             except ValueError as exc:
-                raise click.BadParameter(
-                    f"--error-responses: {token!r} is not an integer"
-                ) from exc
+                raise click.BadParameter(f"--error-responses: {token!r} is not an integer") from exc
         kwargs["error_responses"] = codes
     gen = OpenAPIGenerator(yamlfile, resource_filter=resource_filter, **kwargs)
     spec = gen.serialize()

--- a/src/linkml_openapi/cli.py
+++ b/src/linkml_openapi/cli.py
@@ -57,6 +57,20 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
     ),
 )
 @click.option(
+    "--error-responses",
+    "error_responses",
+    default=None,
+    metavar="CODES",
+    help=(
+        "Comma-separated list of extra HTTP error status codes "
+        "(4xx/5xx) to declare on every operation. Overrides the "
+        "schema-level `openapi.error_responses` annotation. Each code "
+        "is described with its standard reason phrase and references "
+        "the active error class (Problem by default). Default is "
+        "unset — back-compat with today's output."
+    ),
+)
+@click.option(
     "--profile",
     default=None,
     metavar="NAME",
@@ -169,11 +183,31 @@ from linkml_openapi.generator import SUPPORTED_PATH_STYLES, OpenAPIGenerator
     ),
 )
 @click.version_option(__version__, "-V", "--version")
-def cli(yamlfile, resource_filter=(), emit_name_mappings=None, post_process=None, **kwargs):
+def cli(
+    yamlfile,
+    resource_filter=(),
+    emit_name_mappings=None,
+    post_process=None,
+    error_responses=None,
+    **kwargs,
+):
     """Generate an OpenAPI specification from a LinkML schema."""
     resource_filter = list(resource_filter) if resource_filter else None
     if post_process:
         kwargs["post_processors"] = [n.strip() for n in post_process.split(",") if n.strip()]
+    if error_responses is not None:
+        codes: list[int] = []
+        for token in error_responses.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                codes.append(int(token))
+            except ValueError as exc:
+                raise click.BadParameter(
+                    f"--error-responses: {token!r} is not an integer"
+                ) from exc
+        kwargs["error_responses"] = codes
     gen = OpenAPIGenerator(yamlfile, resource_filter=resource_filter, **kwargs)
     spec = gen.serialize()
     click.echo(spec)

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -596,10 +596,7 @@ class OpenAPIGenerator(Generator):
         # ``openapi.operations`` lists only collection-level ops, or
         # when an auto-derived flat item path has no item-level ops
         # to attach (#109).
-        paths = {
-            url: item for url, item in paths.items()
-            if self._path_item_has_operations(item)
-        }
+        paths = {url: item for url, item in paths.items() if self._path_item_has_operations(item)}
 
         # Merge schema-level / CLI ``openapi.error_responses`` codes
         # into every operation. Default-off (codes list is empty) so
@@ -1842,11 +1839,8 @@ class OpenAPIGenerator(Generator):
         cls = sv.get_class(class_name)
         if cls is not None:
             opt_out = (
-                (self._class_annotation(cls, "openapi.codegen_inheritance") or "")
-                .strip()
-                .lower()
-                == "false"
-            )
+                self._class_annotation(cls, "openapi.codegen_inheritance") or ""
+            ).strip().lower() == "false"
         if self.codegen_friendly and not has_narrowing and not opt_out:
             return Reference(ref=f"#/components/schemas/{class_name}")
         oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
@@ -2094,18 +2088,14 @@ class OpenAPIGenerator(Generator):
             # simple class name. Switch the mapping keys to follow the
             # wire so dispatch actually resolves (#107).
             root_legacy_field = self._class_annotation(cls, "openapi.legacy_type_field")
-            use_legacy_keys = (
-                root_legacy_field is not None and root_legacy_field.strip() == field
-            )
+            use_legacy_keys = root_legacy_field is not None and root_legacy_field.strip() == field
             for sub_name in inject_candidates:
                 sub_cls = sv.get_class(sub_name)
                 tv = self._type_value(sub_cls)
                 if tv is None:
                     continue
                 if use_legacy_keys:
-                    legacy_value = self._class_annotation(
-                        sub_cls, "openapi.legacy_type_value"
-                    )
+                    legacy_value = self._class_annotation(sub_cls, "openapi.legacy_type_value")
                     mapping_key = legacy_value.strip() if legacy_value else tv
                 else:
                     mapping_key = tv
@@ -2141,9 +2131,8 @@ class OpenAPIGenerator(Generator):
             descendants = self._concrete_descendants_including_self(class_name)
             has_narrowing = any(d in self._narrowing_subclasses for d in descendants)
             opt_out = (
-                (self._class_annotation(cls, "openapi.codegen_inheritance") or "").strip().lower()
-                == "false"
-            )
+                self._class_annotation(cls, "openapi.codegen_inheritance") or ""
+            ).strip().lower() == "false"
             if self.codegen_friendly and not has_narrowing and not opt_out:
                 parent_schema = schemas.get(class_name)
                 if isinstance(parent_schema, Schema):
@@ -2354,9 +2343,7 @@ class OpenAPIGenerator(Generator):
             items=self._class_response_ref(class_name),
         )
 
-    def _list_response_schema(
-        self, cls: ClassDefinition, class_name: str
-    ) -> Schema | Reference:
+    def _list_response_schema(self, cls: ClassDefinition, class_name: str) -> Schema | Reference:
         """Resolve the 200-response schema for a list op. When the
         class declares ``openapi.list_envelope: <ClassName>`` the
         response becomes a ``$ref`` to the envelope class (which must
@@ -2428,8 +2415,7 @@ class OpenAPIGenerator(Generator):
         for idx, entry in enumerate(decoded):
             if not isinstance(entry, dict):
                 raise ValueError(
-                    f"openapi.list_query_params on {cls.name!r}: entry "
-                    f"{idx} is not a JSON object."
+                    f"openapi.list_query_params on {cls.name!r}: entry {idx} is not a JSON object."
                 )
             name = entry.get("name")
             otype = entry.get("type")

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -243,6 +243,14 @@ class OpenAPIGenerator(Generator):
     # re-parsing the LinkML schema. Default off — schemas regenerate
     # byte-identically when unset.
     emit_namespaces: bool = False
+    # Extra HTTP status codes (4xx / 5xx) to declare on every emitted
+    # operation, drawn from ``openapi.error_responses`` schema annotation
+    # or the ``--error-responses`` CLI flag. None falls back to the
+    # schema annotation; an empty list means "skip injection" even when
+    # the schema declares one (CLI explicit override). Each code is
+    # described with its standard IANA reason phrase and references
+    # the same body schema as today's ``404`` / ``422`` (#104).
+    error_responses: list[int] | None = None
     # Names of registered post-processors to apply (in order) after the
     # canonical spec is built but before serialisation. See
     # ``linkml_openapi.post_processors`` for the registry. Each
@@ -272,6 +280,17 @@ class OpenAPIGenerator(Generator):
         # :meth:`emit_name_mappings` write a sibling file the user
         # passes to ``openapi-generator-cli``.
         self._codegen_name_mappings: dict[str, str] = {}
+        # Subclass names that materially narrowed an inherited slot's
+        # range via ``slot_usage`` (#92). Tracked per-build so the
+        # discriminator pass (#106) can detect when a polymorphic root
+        # has a narrowing descendant — emitting a schema-level
+        # discriminator on the root in that case produces uncompilable
+        # Java under openapi-generator's inheritance-based template
+        # (covariant return types). When ``--codegen-friendly`` is on
+        # and the root has any narrowing descendant, the schema-level
+        # discriminator block is skipped and dispatch falls back to
+        # use-site ``oneOf`` (which Jackson handles fine).
+        self._narrowing_subclasses: set[str] = set()
         # Multi-level composition recursion happens inside
         # `_add_composition_paths`; the stack tracks which composition
         # targets are currently being emitted so a cyclic
@@ -282,6 +301,11 @@ class OpenAPIGenerator(Generator):
         # None when error_schema is off. Cached per-build so each operation
         # builder doesn't re-resolve.
         self._error_class_name: str | None = self._resolve_error_class()
+        # Extra HTTP error codes to inject on every operation (#104).
+        # CLI / kwarg wins over the ``openapi.error_responses`` schema
+        # annotation; ``None`` means "use the schema annotation if any";
+        # an explicit empty list means "skip injection regardless".
+        self._extra_error_codes: list[int] = self._resolve_error_response_codes()
         # Resolve the active path-style: CLI / Python kwarg wins over the
         # schema-level annotation, which falls back to `"snake_case"`. We
         # validate once here so per-call-site renderers can just check the
@@ -563,6 +587,26 @@ class OpenAPIGenerator(Generator):
         if self._needs_resource_link and "ResourceLink" not in schemas:
             schemas["ResourceLink"] = self._build_resource_link_schema()
 
+        # Drop empty PathItems — those whose every operation slot
+        # (get/put/post/patch/delete) is ``None`` and which have no
+        # ``$ref``. They emit invalid OpenAPI (a path with only
+        # ``parameters:`` declared is structurally invalid; most
+        # validators reject it). Surfaces when
+        # ``openapi.path_template`` produces a deep-item path but
+        # ``openapi.operations`` lists only collection-level ops, or
+        # when an auto-derived flat item path has no item-level ops
+        # to attach (#109).
+        paths = {
+            url: item for url, item in paths.items()
+            if self._path_item_has_operations(item)
+        }
+
+        # Merge schema-level / CLI ``openapi.error_responses`` codes
+        # into every operation. Default-off (codes list is empty) so
+        # schemas without the annotation regenerate byte-identically
+        # (#104).
+        self._apply_extra_error_responses(paths)
+
         # Apply the path prefix to every emitted `paths:` key. Single
         # transformation point so composition / chain / templated /
         # synthetic-inverse paths all pick it up uniformly. Validates
@@ -658,6 +702,9 @@ class OpenAPIGenerator(Generator):
                 #   on the wire (#92).
                 parent_slot = parent_slots_by_name.get(slot.name)
                 is_narrowed = parent_slot is not None and self._slot_was_narrowed(slot, parent_slot)
+                if is_narrowed:
+                    # Track narrowing for the discriminator pass (#106).
+                    self._narrowing_subclasses.add(cls.name)
                 if slot.name not in parent_slots_by_name or is_narrowed:
                     local_properties[slot.name] = self._slot_to_schema(slot)
                     if slot.required:
@@ -843,8 +890,18 @@ class OpenAPIGenerator(Generator):
         sv = self.schemaview
         excluded = self._excluded_classes
 
+        def _exposed(name: str) -> bool:
+            # #110 — `openapi.expose: "false"` keeps the class as a
+            # referenceable component schema (other paths can `$ref`
+            # it) but suppresses path emission for that class itself.
+            cls = sv.get_class(name)
+            if cls is None:
+                return True
+            expose = self._class_annotation(cls, "openapi.expose")
+            return not (expose is not None and expose.strip().lower() == "false")
+
         if self.resource_filter:
-            result = [c for c in self.resource_filter if c not in excluded]
+            result = [c for c in self.resource_filter if c not in excluded and _exposed(c)]
         else:
             annotated = [
                 name
@@ -853,6 +910,7 @@ class OpenAPIGenerator(Generator):
                 and _is_truthy(
                     self._class_annotation(sv.get_class(name), "openapi.resource") or False
                 )
+                and _exposed(name)
             ]
             if annotated:
                 result = annotated
@@ -864,6 +922,7 @@ class OpenAPIGenerator(Generator):
                     and not sv.get_class(name).abstract
                     and not sv.get_class(name).mixin
                     and list(self._induced_slots_iter(name))
+                    and _exposed(name)
                 ]
         self._resource_classes_cache = result
         return result
@@ -1367,6 +1426,100 @@ class OpenAPIGenerator(Generator):
             )
         return custom
 
+    # IANA standard reason phrases for the 4xx / 5xx codes we expect
+    # authors to declare via ``openapi.error_responses`` (#104). Any
+    # unrecognised code falls back to ``f"HTTP {code}"``.
+    _HTTP_REASON_PHRASES: ClassVar[dict[int, str]] = {
+        400: "Bad request",
+        401: "Unauthorized",
+        402: "Payment required",
+        403: "Forbidden",
+        404: "Not found",
+        405: "Method not allowed",
+        406: "Not acceptable",
+        408: "Request timeout",
+        409: "Conflict",
+        410: "Gone",
+        412: "Precondition failed",
+        413: "Payload too large",
+        415: "Unsupported media type",
+        422: "Validation error",
+        423: "Locked",
+        424: "Failed dependency",
+        428: "Precondition required",
+        429: "Too many requests",
+        451: "Unavailable for legal reasons",
+        500: "Server error",
+        501: "Not implemented",
+        502: "Bad gateway",
+        503: "Service unavailable",
+        504: "Gateway timeout",
+    }
+
+    def _resolve_error_response_codes(self) -> list[int]:
+        """Resolve the list of extra error codes from CLI/kwarg or
+        schema annotation. CLI wins; an explicit empty list means
+        "skip injection regardless." Returns [] when nothing is set,
+        which keeps today's output byte-identical."""
+        if self.error_responses is not None:
+            codes = list(self.error_responses)
+        else:
+            raw = self._schema_annotation("openapi.error_responses")
+            if not raw:
+                return []
+            codes = []
+            for token in raw.split(","):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    codes.append(int(token))
+                except ValueError as exc:
+                    raise ValueError(
+                        f"openapi.error_responses contains non-integer token "
+                        f"{token!r}; expected comma-separated HTTP status codes."
+                    ) from exc
+        for code in codes:
+            if not (400 <= code <= 599):
+                raise ValueError(
+                    f"openapi.error_responses code {code} is outside the 4xx/5xx "
+                    "range; only client- and server-error codes are accepted."
+                )
+        # De-duplicate while preserving the declared order.
+        seen: set[int] = set()
+        unique: list[int] = []
+        for code in codes:
+            if code in seen:
+                continue
+            seen.add(code)
+            unique.append(code)
+        return unique
+
+    def _http_reason(self, code: int) -> str:
+        """Standard reason phrase for an HTTP status code (#104)."""
+        return self._HTTP_REASON_PHRASES.get(code, f"HTTP {code}")
+
+    def _apply_extra_error_responses(self, paths: dict[str, PathItem]) -> None:
+        """Merge ``openapi.error_responses`` codes into every operation
+        on every emitted PathItem (#104). Existing responses for the
+        same code are preserved (the schema author's per-op override
+        wins over the global list)."""
+        if not self._extra_error_codes:
+            return
+        methods = ("get", "put", "post", "patch", "delete", "options", "head", "trace")
+        for item in paths.values():
+            for method in methods:
+                op = getattr(item, method, None)
+                if op is None:
+                    continue
+                responses = dict(op.responses or {})
+                for code in self._extra_error_codes:
+                    key = str(code)
+                    if key in responses:
+                        continue
+                    responses[key] = self._error_response(self._http_reason(code))
+                op.responses = responses
+
     # --- Profiles --------------------------------------------------------
 
     _PROFILE_LIST_KEYS = ("exclude_classes", "exclude_slots", "include_classes", "include_slots")
@@ -1679,7 +1832,22 @@ class OpenAPIGenerator(Generator):
         # The parent carries its own ``discriminator`` block (attached
         # in ``_apply_discriminators``) so codegens dispatch correctly
         # without inline ``oneOf`` at the use site (#64).
-        if self.codegen_friendly:
+        # **But** when any descendant narrowed an inherited slot via
+        # ``slot_usage``, the parent-discriminator strategy collides
+        # with Java covariance (#106) — ``_apply_discriminators`` then
+        # skips the parent's discriminator block, and we must fall
+        # back to inline ``oneOf`` here too so dispatch still works.
+        has_narrowing = any(d in self._narrowing_subclasses for d in descendants)
+        opt_out = False
+        cls = sv.get_class(class_name)
+        if cls is not None:
+            opt_out = (
+                (self._class_annotation(cls, "openapi.codegen_inheritance") or "")
+                .strip()
+                .lower()
+                == "false"
+            )
+        if self.codegen_friendly and not has_narrowing and not opt_out:
             return Reference(ref=f"#/components/schemas/{class_name}")
         oneof = [Reference(ref=f"#/components/schemas/{n}") for n in descendants]
         schema = Schema(oneOf=oneof)
@@ -1920,28 +2088,63 @@ class OpenAPIGenerator(Generator):
             inject_candidates = list(concrete)
             if not cls.abstract and not cls.mixin and self._type_value(cls):
                 inject_candidates.insert(0, class_name)
+            # When the discriminator's propertyName matches the root's
+            # ``openapi.legacy_type_field``, the wire payload carries
+            # the legacy value (e.g. ``com.example.Dataset``) — not the
+            # simple class name. Switch the mapping keys to follow the
+            # wire so dispatch actually resolves (#107).
+            root_legacy_field = self._class_annotation(cls, "openapi.legacy_type_field")
+            use_legacy_keys = (
+                root_legacy_field is not None and root_legacy_field.strip() == field
+            )
             for sub_name in inject_candidates:
-                tv = self._type_value(sv.get_class(sub_name))
+                sub_cls = sv.get_class(sub_name)
+                tv = self._type_value(sub_cls)
                 if tv is None:
                     continue
-                if tv in seen:
+                if use_legacy_keys:
+                    legacy_value = self._class_annotation(
+                        sub_cls, "openapi.legacy_type_value"
+                    )
+                    mapping_key = legacy_value.strip() if legacy_value else tv
+                else:
+                    mapping_key = tv
+                if mapping_key in seen:
                     raise ValueError(
-                        f"Duplicate openapi.type_value {tv!r} on classes "
-                        f"{seen[tv]!r} and {sub_name!r}; values must be unique "
+                        f"Duplicate discriminator value {mapping_key!r} on classes "
+                        f"{seen[mapping_key]!r} and {sub_name!r}; values must be unique "
                         "across a discriminator group."
                     )
-                seen[tv] = sub_name
-                mapping[tv] = f"#/components/schemas/{sub_name}"
+                seen[mapping_key] = sub_name
+                mapping[mapping_key] = f"#/components/schemas/{sub_name}"
 
-            for tv, sub_name in seen.items():
-                self._inject_subclass_type_value(schemas, sub_name, field, tv)
+            # The injection still pins the wire field with the same
+            # value used as the mapping key — legacy value when the
+            # discriminator is the legacy field, type_value otherwise.
+            for key, sub_name in seen.items():
+                self._inject_subclass_type_value(schemas, sub_name, field, key)
 
             # Codegen-friendly mode: attach the ``discriminator`` block
             # (with ``mapping``) to the parent's component schema so a
             # use-site ``$ref`` to the parent carries dispatch info for
             # codegens. Default mode keeps the dispatch info inline at
             # the use sites only (today's authoring-clarity output).
-            if self.codegen_friendly:
+            # **Skip** when any descendant narrows an inherited slot
+            # via ``slot_usage`` (#106): openapi-generator's Java
+            # template then generates a covariant subtype field
+            # (``List<FusionDistribution>`` overriding
+            # ``List<Distribution>``) that doesn't compile. Falling
+            # back to use-site ``oneOf`` keeps Jackson dispatch working
+            # without the inheritance collision. Authors who want the
+            # discriminator regardless can drop ``slot_usage`` and
+            # rely on use-site oneOf only.
+            descendants = self._concrete_descendants_including_self(class_name)
+            has_narrowing = any(d in self._narrowing_subclasses for d in descendants)
+            opt_out = (
+                (self._class_annotation(cls, "openapi.codegen_inheritance") or "").strip().lower()
+                == "false"
+            )
+            if self.codegen_friendly and not has_narrowing and not opt_out:
                 parent_schema = schemas.get(class_name)
                 if isinstance(parent_schema, Schema):
                     parent_schema.discriminator = Discriminator(
@@ -2098,11 +2301,19 @@ class OpenAPIGenerator(Generator):
             return
         local = self._writable_local_schema(schema)
         properties = dict(local.properties or {})
-        properties[field] = Schema(
-            type=DataType.STRING,
-            enum=[value],
-            default=value,
-        )
+        # Codegen-friendly: drop the single-value ``enum`` so codegens
+        # don't synthesise a one-element enum per subtype. Matches the
+        # primary discriminator's behaviour (#64) — extending it to
+        # ``openapi.legacy_type_field`` was the missing consistency
+        # leg (#108).
+        if self.codegen_friendly:
+            properties[field] = Schema(type=DataType.STRING, default=value)
+        else:
+            properties[field] = Schema(
+                type=DataType.STRING,
+                enum=[value],
+                default=value,
+            )
         local.properties = properties
         required = list(local.required or [])
         if field not in required:
@@ -2111,21 +2322,158 @@ class OpenAPIGenerator(Generator):
         if codegen_name:
             self._codegen_name_mappings[field] = codegen_name
 
-    def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
-        media_types = self._get_media_types(cls)
-        array_schema = Schema(
+    # --- Pagination & list envelope (#105) ------------------------------
+
+    # Pagination dialects: schema-author tag → list of (param name,
+    # OpenAPI type, description). Both ``openapi.pagination`` and
+    # ``openapi.list_query_params`` are read off the target class; the
+    # same setting applies whether the list is top-level CRUD or a
+    # nested composition/reference op (one source of truth).
+    _PAGINATION_DIALECTS: ClassVar[dict[str, list[tuple[str, str, str]]]] = {
+        "cursor": [
+            ("cursor", "string", "Opaque cursor returned by a previous page."),
+            ("pageSize", "integer", "Maximum number of items per page."),
+        ],
+        "page-size": [
+            ("page", "integer", "1-indexed page number."),
+            ("size", "integer", "Page size."),
+        ],
+        "page-offset": [
+            ("offset", "integer", "Zero-based offset into the result set."),
+            ("limit", "integer", "Maximum number of items to return."),
+        ],
+        "none": [],
+    }
+
+    def _list_response_items_schema(self, class_name: str) -> Schema:
+        """The default 200 schema for a list op — an array whose
+        ``items`` is the resource's response ref. Extracted so the
+        envelope wrapper (#105) shares the same items shape."""
+        return Schema(
             type=DataType.ARRAY,
             items=self._class_response_ref(class_name),
         )
+
+    def _list_response_schema(
+        self, cls: ClassDefinition, class_name: str
+    ) -> Schema | Reference:
+        """Resolve the 200-response schema for a list op. When the
+        class declares ``openapi.list_envelope: <ClassName>`` the
+        response becomes a ``$ref`` to the envelope class (which must
+        exist in the schema); otherwise it's today's bare array
+        (#105). The envelope class is responsible for declaring the
+        array slot that points at the listed resource type."""
+        envelope = self._class_annotation(cls, "openapi.list_envelope")
+        if not envelope:
+            return self._list_response_items_schema(class_name)
+        envelope = envelope.strip()
+        if self.schemaview.get_class(envelope) is None:
+            raise ValueError(
+                f"openapi.list_envelope on {class_name!r} refers to undefined "
+                f"class {envelope!r}; add the class to the schema or remove "
+                "the annotation."
+            )
+        return Reference(ref=f"#/components/schemas/{envelope}")
+
+    def _pagination_params(self, cls: ClassDefinition) -> list[Parameter]:
+        """Build query Parameters for the dialect declared by
+        ``openapi.pagination``. Unknown dialects raise; ``none`` /
+        unset emits no parameters."""
+        dialect = self._class_annotation(cls, "openapi.pagination")
+        if not dialect:
+            return []
+        dialect = dialect.strip()
+        if dialect not in self._PAGINATION_DIALECTS:
+            raise ValueError(
+                f"openapi.pagination on {cls.name!r}: unknown dialect "
+                f"{dialect!r}; expected one of "
+                f"{sorted(self._PAGINATION_DIALECTS)}."
+            )
+        return [
+            Parameter(
+                name=name,
+                param_in=ParameterLocation.QUERY,
+                required=False,
+                description=description,
+                param_schema=Schema(type=DataType(otype)),
+            )
+            for name, otype, description in self._PAGINATION_DIALECTS[dialect]
+        ]
+
+    def _extra_list_query_params(self, cls: ClassDefinition) -> list[Parameter]:
+        """Decode ``openapi.list_query_params`` (JSON array string) into
+        Parameter objects. Each entry is ``{name, type, description?}``
+        plus optional ``required: true/false``. Unparseable JSON or
+        unknown OpenAPI scalar types raise (#105)."""
+        raw = self._class_annotation(cls, "openapi.list_query_params")
+        if not raw:
+            return []
+        import json
+
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: value must be a "
+                f"JSON array of `{{name, type, description?}}` objects; got "
+                f"{raw!r} ({exc})."
+            ) from exc
+        if not isinstance(decoded, list):
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: expected a JSON "
+                f"array, got {type(decoded).__name__}."
+            )
+        params: list[Parameter] = []
+        valid_types = {"string", "integer", "number", "boolean", "array"}
+        for idx, entry in enumerate(decoded):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry "
+                    f"{idx} is not a JSON object."
+                )
+            name = entry.get("name")
+            otype = entry.get("type")
+            if not name or not otype:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry "
+                    f"{idx} must declare `name` and `type`."
+                )
+            if otype not in valid_types:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry "
+                    f"{idx} type {otype!r} is not one of {sorted(valid_types)}."
+                )
+            params.append(
+                Parameter(
+                    name=str(name),
+                    param_in=ParameterLocation.QUERY,
+                    required=bool(entry.get("required", False)),
+                    description=entry.get("description"),
+                    param_schema=Schema(type=DataType(otype)),
+                )
+            )
+        return params
+
+    def _list_extras(self, cls: ClassDefinition) -> list[Parameter]:
+        """Combined pagination + extra-list-query-params builder, used
+        by every list-op emission site (top-level, composition, ref,
+        chain). Resolved off the target class so the same paging /
+        filtering shape applies wherever the resource is listed."""
+        return self._pagination_params(cls) + self._extra_list_query_params(cls)
+
+    def _make_list_operation(self, cls: ClassDefinition, class_name: str) -> Operation:
+        media_types = self._get_media_types(cls)
+        response_schema = self._list_response_schema(cls, class_name)
+        params = list(self._make_query_params(cls)) + self._list_extras(cls)
         return Operation(
             summary=f"List {_to_path_segment(class_name).replace('_', ' ')}",
             operationId=f"list_{_to_path_segment(class_name)}",
             tags=[self._class_tag(class_name)],
-            parameters=self._make_query_params(cls),
+            parameters=params,
             responses={
                 "200": Response(
                     description=f"List of {class_name} objects",
-                    content=self._content_for(array_schema, media_types),
+                    content=self._content_for(response_schema, media_types),
                 )
             },
         )
@@ -2844,6 +3192,18 @@ class OpenAPIGenerator(Generator):
                 if op is not None:
                     op.tags = [tag]
 
+    @staticmethod
+    def _path_item_has_operations(item: PathItem) -> bool:
+        """True when a PathItem declares at least one HTTP operation
+        or a ``$ref``. False for parameters-only PathItems, which are
+        structurally invalid OpenAPI (#109)."""
+        if getattr(item, "ref", None):
+            return True
+        for method in ("get", "put", "post", "patch", "delete", "options", "head", "trace"):
+            if getattr(item, method, None) is not None:
+                return True
+        return False
+
     _PATH_TEMPLATE_PLACEHOLDER_RE = PATH_TEMPLATE_PLACEHOLDER_RE
 
     @staticmethod
@@ -2991,7 +3351,11 @@ class OpenAPIGenerator(Generator):
         target_cls = self.schemaview.get_class(target_class_name)
         media_types = self._get_media_types(target_cls)
         target_ref = self._class_response_ref(target_class_name)
-        array_schema = Schema(type=DataType.ARRAY, items=target_ref)
+        # Honour ``openapi.list_envelope`` on the target (#105) — the
+        # nested list shares the envelope shape with the top-level
+        # list op so clients see a uniform paged structure.
+        list_response_schema = self._list_response_schema(target_cls, target_class_name)
+        list_extras = self._list_extras(target_cls)
         # Nested composition op tag: slot's `openapi.tag` →
         # target class's explicit `openapi.tag` → parent class's tag
         # (#86 layers explicit target-side override on top of #68).
@@ -3003,10 +3367,11 @@ class OpenAPIGenerator(Generator):
             summary=f"List {target_class_name} composed in {parent_class_name}.{slot.name}",
             operationId=f"list_{_to_snake_case(parent_class_name)}_{slot_seg}",
             tags=[op_tag],
+            parameters=list_extras or None,
             responses={
                 "200": Response(
                     description=f"{target_class_name} list",
-                    content=self._content_for(array_schema, media_types),
+                    content=self._content_for(list_response_schema, media_types),
                 ),
                 "404": self._error_response("Parent not found"),
             },
@@ -3165,8 +3530,9 @@ class OpenAPIGenerator(Generator):
 
         target_cls = self.schemaview.get_class(target_class_name)
         media_types = self._get_media_types(target_cls)
-        target_ref = self._class_response_ref(target_class_name)
-        array_schema = Schema(type=DataType.ARRAY, items=target_ref)
+        # Envelope-aware list response (#105).
+        list_response_schema = self._list_response_schema(target_cls, target_class_name)
+        list_extras = self._list_extras(target_cls)
 
         link_ref = Reference(ref="#/components/schemas/ResourceLink")
         # Body accepts a single link or a batch — clients prefer batch.
@@ -3181,10 +3547,11 @@ class OpenAPIGenerator(Generator):
             summary=f"List {target_class_name} attached to {parent_class_name}.{slot.name}",
             operationId=f"list_{_to_snake_case(parent_class_name)}_{slot_seg}",
             tags=[op_tag],
+            parameters=list_extras or None,
             responses={
                 "200": Response(
                     description=f"{target_class_name} list",
-                    content=self._content_for(array_schema, media_types),
+                    content=self._content_for(list_response_schema, media_types),
                 ),
                 "404": self._error_response("Parent not found"),
             },

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -1300,7 +1300,21 @@ public class %(class_name)s {
     # --- LinkML helpers ------------------------------------------------
 
     def _is_resource(self, cls: ClassDefinition) -> bool:
-        return self._class_annotation(cls, "openapi.resource") == "true"
+        """True when the class has paths emitted by ``gen-spring-server``.
+
+        Honours ``openapi.expose: "false"`` (#110) — when set, the class
+        stays as a Java DTO (so other resources can reference its
+        shape via ``$ref``) but no controller interface, no path
+        emission, no sidecar entries for it. Use when the schema
+        author wants the type addressable on the OpenAPI side but the
+        CRUD owner is a different service.
+        """
+        if self._class_annotation(cls, "openapi.resource") != "true":
+            return False
+        expose = self._class_annotation(cls, "openapi.expose")
+        if expose is not None and expose.strip().lower() == "false":
+            return False
+        return True
 
     def _media_types(self, cls: ClassDefinition) -> list[str]:
         """Per-class media type list. Walks the ``is_a`` chain, taking

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3597,7 +3597,7 @@ classes:
         # (#107 only widens the rule when both annotations agree).
         schema = self.SCHEMA.replace(
             'openapi.discriminator: "#type"',
-            'openapi.discriminator: kind',
+            "openapi.discriminator: kind",
         )
         spec = _generate_from_string(schema, codegen_friendly=True)
         kind = spec["components"]["schemas"]["Kind"]
@@ -3922,15 +3922,18 @@ classes:
         assert schema["items"] == {"$ref": "#/components/schemas/Dataset"}
 
     def test_envelope_wraps_200_in_ref(self):
-        schema_yaml = self.BASE.replace(
-            "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.list_envelope: PagedDatasets',
-        ) + """
+        schema_yaml = (
+            self.BASE.replace(
+                "openapi.path: datasets",
+                "openapi.path: datasets\n      openapi.list_envelope: PagedDatasets",
+            )
+            + """
   PagedDatasets:
     attributes:
       items: { range: Dataset, multivalued: true }
       nextCursor: string
 """
+        )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
         body = get["responses"]["200"]["content"]["application/json"]["schema"]
@@ -3939,7 +3942,7 @@ classes:
     def test_envelope_class_missing_raises(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.list_envelope: MissingClass',
+            "openapi.path: datasets\n      openapi.list_envelope: MissingClass",
         )
         _generate_from_string_raises(
             schema_yaml,
@@ -3949,7 +3952,7 @@ classes:
     def test_cursor_pagination_injects_cursor_and_page_size(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.pagination: cursor',
+            "openapi.path: datasets\n      openapi.pagination: cursor",
         )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
@@ -3960,7 +3963,7 @@ classes:
     def test_page_size_dialect_injects_page_and_size(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.pagination: page-size',
+            "openapi.path: datasets\n      openapi.pagination: page-size",
         )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
@@ -3971,7 +3974,7 @@ classes:
     def test_page_offset_dialect_injects_offset_and_limit(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.pagination: page-offset',
+            "openapi.path: datasets\n      openapi.pagination: page-offset",
         )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
@@ -3982,7 +3985,7 @@ classes:
     def test_unknown_dialect_raises(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.pagination: invalid',
+            "openapi.path: datasets\n      openapi.pagination: invalid",
         )
         _generate_from_string_raises(schema_yaml, match=r"unknown dialect")
 
@@ -3993,7 +3996,7 @@ classes:
         # dialect-specific names get added on top.
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            'openapi.path: datasets\n      openapi.pagination: none',
+            "openapi.path: datasets\n      openapi.pagination: none",
         )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
@@ -4010,7 +4013,7 @@ classes:
         )
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            f'openapi.path: datasets\n      openapi.list_query_params: \'{params_json}\'',
+            f"openapi.path: datasets\n      openapi.list_query_params: '{params_json}'",
         )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
@@ -4032,26 +4035,29 @@ classes:
         params_json = '[{"name": "bad", "type": "uuid"}]'
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
-            f'openapi.path: datasets\n      openapi.list_query_params: \'{params_json}\'',
+            f"openapi.path: datasets\n      openapi.list_query_params: '{params_json}'",
         )
         _generate_from_string_raises(schema_yaml, match=r"not one of")
 
     def test_all_three_compose(self):
         params_json = '[{"name": "filter", "type": "string"}]'
-        schema_yaml = self.BASE.replace(
-            "openapi.path: datasets",
-            (
-                "openapi.path: datasets\n"
-                "      openapi.list_envelope: PagedDatasets\n"
-                "      openapi.pagination: cursor\n"
-                f"      openapi.list_query_params: '{params_json}'"
-            ),
-        ) + """
+        schema_yaml = (
+            self.BASE.replace(
+                "openapi.path: datasets",
+                (
+                    "openapi.path: datasets\n"
+                    "      openapi.list_envelope: PagedDatasets\n"
+                    "      openapi.pagination: cursor\n"
+                    f"      openapi.list_query_params: '{params_json}'"
+                ),
+            )
+            + """
   PagedDatasets:
     attributes:
       items: { range: Dataset, multivalued: true }
       nextCursor: string
 """
+        )
         spec = _generate_from_string(schema_yaml)
         get = spec["paths"]["/datasets"]["get"]
         # Envelope: response is $ref.

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3460,3 +3460,652 @@ classes:
         refs = {r["$ref"] for r in prop["oneOf"]}
         assert refs == {"#/components/schemas/Dog", "#/components/schemas/Cat"}
         assert "discriminator" not in prop
+
+
+class TestCodegenFriendlyNarrowingFallback:
+    """Coverage for #106 — `--codegen-friendly` must fall back to
+    use-site ``oneOf`` when any concrete descendant of the polymorphic
+    root narrows an inherited slot's range via ``slot_usage``. The
+    schema-level discriminator + parent-`$ref` strategy collides with
+    Java covariance under openapi-generator otherwise.
+
+    Tested against ``dcat3-acme.yaml`` (AcmeDataset narrows
+    Dataset.distribution, AcmeCatalog narrows Catalog.dataset).
+    """
+
+    @staticmethod
+    def _spec(**kwargs) -> dict:
+        gen = OpenAPIGenerator(str(FIXTURES / "dcat3-acme.yaml"), **kwargs)
+        return yaml.safe_load(gen.serialize())
+
+    def test_narrowing_root_keeps_inline_oneof_under_codegen_friendly(self):
+        # Dataset → Distribution is narrowed by AcmeDataset, so the
+        # use-site reference must NOT be a bare $ref to Dataset. It
+        # stays as an inline oneOf even though codegen_friendly is on.
+        spec = self._spec(codegen_friendly=True)
+        get200 = spec["paths"]["/datasets"]["get"]["responses"]["200"]
+        items = get200["content"]["application/json"]["schema"]["items"]
+        assert "oneOf" in items, f"expected inline oneOf, got {items}"
+
+    def test_narrowing_root_skips_schema_level_discriminator(self):
+        # Dataset has narrowing descendants → no schema-level
+        # discriminator (to avoid the covariance collision). The use-site
+        # oneOf retains a discriminator block for Jackson dispatch.
+        spec = self._spec(codegen_friendly=True)
+        dataset = spec["components"]["schemas"]["Dataset"]
+        # Dataset is the polymorphic root for the narrowing — must not
+        # carry a discriminator block.
+        if "allOf" in dataset:
+            for branch in dataset["allOf"]:
+                assert "discriminator" not in branch
+        assert "discriminator" not in dataset
+
+    def test_opt_out_annotation_forces_inline_oneof(self):
+        schema = """
+id: https://example.org/codegen-opt-out
+name: cgf_opt_out
+default_range: string
+classes:
+  Item:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+      openapi.codegen_inheritance: "false"
+    attributes:
+      sku: { identifier: true, required: true }
+  Widget:
+    is_a: Item
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: WIDGET
+  Gadget:
+    is_a: Item
+    annotations:
+      openapi.type_value: GADGET
+"""
+        spec = _generate_from_string(schema, codegen_friendly=True)
+        item = spec["components"]["schemas"]["Item"]
+        # Opt-out flips the schema-level discriminator off.
+        assert "discriminator" not in item
+        # Use-site reference falls back to inline oneOf (or the
+        # property-level $ref to a non-discriminating parent — but the
+        # discriminator escape hatch implies inline oneOf is fine here).
+        post = spec["paths"]["/widgets"]["post"]
+        body = post["requestBody"]["content"]["application/json"]["schema"]
+        # Widget is a concrete subclass — body is a $ref to Widget (not
+        # the polymorphic root). The point is that Item carries no
+        # schema-level discriminator block.
+        assert body == {"$ref": "#/components/schemas/Widget"} or "oneOf" in body
+
+
+class TestDiscriminatorMappingUsesLegacyValues:
+    """Coverage for #107 — when ``openapi.discriminator`` and
+    ``openapi.legacy_type_field`` both name the SAME wire field, the
+    parent's ``discriminator.mapping`` keys must be the
+    ``openapi.legacy_type_value`` of each subtype (the actual wire
+    value), not the simple class names."""
+
+    SCHEMA = """
+id: https://example.org/legacy-disc
+name: legacy_disc
+default_range: string
+classes:
+  Kind:
+    abstract: true
+    annotations:
+      openapi.discriminator: "#type"
+      openapi.legacy_type_field: "#type"
+    attributes:
+      id: { identifier: true, required: true }
+  Individual:
+    is_a: Kind
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: Individual
+      openapi.legacy_type_value: "com.example.acme.vcard.Individual"
+  Organization:
+    is_a: Kind
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: Organization
+      openapi.legacy_type_value: "com.example.acme.vcard.Organization"
+"""
+
+    def test_mapping_keys_are_legacy_values_when_field_matches(self):
+        spec = _generate_from_string(self.SCHEMA, codegen_friendly=True)
+        kind = spec["components"]["schemas"]["Kind"]
+        disc = kind.get("discriminator")
+        assert disc is not None, "expected schema-level discriminator under codegen_friendly"
+        mapping = disc.get("mapping") or {}
+        assert "com.example.acme.vcard.Individual" in mapping
+        assert "com.example.acme.vcard.Organization" in mapping
+        # Simple names should NOT appear as mapping keys — discriminator
+        # routes on the wire #type, which only carries the legacy form.
+        assert "Individual" not in mapping
+        assert "Organization" not in mapping
+
+    def test_subclass_pin_uses_legacy_value(self):
+        spec = _generate_from_string(self.SCHEMA, codegen_friendly=True)
+        ind_local = spec["components"]["schemas"]["Individual"]["allOf"][1]
+        ht = ind_local["properties"]["#type"]
+        # Field value must match the mapping key.
+        assert ht["default"] == "com.example.acme.vcard.Individual"
+
+    def test_field_mismatch_keeps_simple_name_keys(self):
+        # When discriminator points to a different field from
+        # legacy_type_field, the mapping keys revert to simple names
+        # (#107 only widens the rule when both annotations agree).
+        schema = self.SCHEMA.replace(
+            'openapi.discriminator: "#type"',
+            'openapi.discriminator: kind',
+        )
+        spec = _generate_from_string(schema, codegen_friendly=True)
+        kind = spec["components"]["schemas"]["Kind"]
+        disc = kind.get("discriminator")
+        assert disc is not None
+        mapping = disc.get("mapping") or {}
+        assert "Individual" in mapping
+        assert "Organization" in mapping
+
+
+class TestCodegenFriendlyStripsLegacyFieldEnum:
+    """Coverage for #108 — under ``--codegen-friendly`` the single-
+    value ``enum`` on ``openapi.legacy_type_field`` properties is
+    dropped (keeping ``default:`` only), matching how the primary
+    discriminator is already handled (#64)."""
+
+    SCHEMA = """
+id: https://example.org/legacy-strip
+name: legacy_strip
+default_range: string
+classes:
+  Item:
+    abstract: true
+    annotations:
+      openapi.discriminator: kind
+      openapi.legacy_type_field: "#type"
+    attributes:
+      sku: { identifier: true, required: true }
+  Widget:
+    is_a: Item
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: WIDGET
+      openapi.legacy_type_value: "com.example.acme.Widget"
+"""
+
+    def test_codegen_friendly_drops_enum_on_legacy_field(self):
+        spec = _generate_from_string(self.SCHEMA, codegen_friendly=True)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        hash_type = widget_local["properties"]["#type"]
+        assert "enum" not in hash_type, f"expected no enum, got {hash_type}"
+        assert hash_type["default"] == "com.example.acme.Widget"
+        assert hash_type["type"] == "string"
+
+    def test_default_mode_keeps_enum_on_legacy_field(self):
+        spec = _generate_from_string(self.SCHEMA)
+        widget_local = spec["components"]["schemas"]["Widget"]["allOf"][1]
+        hash_type = widget_local["properties"]["#type"]
+        assert hash_type.get("enum") == ["com.example.acme.Widget"]
+        assert hash_type.get("default") == "com.example.acme.Widget"
+
+
+class TestEmptyPathItemDropped:
+    """Coverage for #109 — when ``openapi.path_template`` produces a
+    deep-item path but ``openapi.operations`` lists only collection-level
+    ops (no item-level ops), the deep-item ``PathItem`` was emitted
+    with ``parameters:`` only and no HTTP methods. That's structurally
+    invalid OpenAPI; the generator now drops such PathItems."""
+
+    SCHEMA = """
+id: https://example.org/empty-path
+name: empty_path
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+    attributes:
+      id: { identifier: true, required: true }
+  AttributeSpec:
+    annotations:
+      openapi.resource: "true"
+      openapi.path_template: "/catalogs/{cat}/attribute-specs/{id}"
+      openapi.path_param_sources: "cat:Catalog.id, id:AttributeSpec.id"
+      openapi.operations: "list,create"
+    attributes:
+      id: { identifier: true, required: true }
+      label: string
+"""
+
+    def test_deep_item_path_with_only_collection_ops_is_dropped(self):
+        spec = _generate_from_string(self.SCHEMA)
+        deep_item = "/catalogs/{cat}/attribute-specs/{id}"
+        assert deep_item not in spec["paths"], (
+            f"expected {deep_item} to be dropped (no operations); "
+            f"got {spec['paths'].get(deep_item)}"
+        )
+
+    def test_collection_path_with_list_create_still_emits(self):
+        spec = _generate_from_string(self.SCHEMA)
+        # The collection path must still emit with its ops.
+        collection = "/catalogs/{cat}/attribute-specs"
+        assert collection in spec["paths"]
+        item = spec["paths"][collection]
+        assert ("get" in item) or ("post" in item)
+
+    def test_path_with_only_parameters_block_never_emitted(self):
+        spec = _generate_from_string(self.SCHEMA)
+        for url, item in spec["paths"].items():
+            method_keys = {"get", "put", "post", "patch", "delete", "options", "head", "trace"}
+            has_method = any(k in item for k in method_keys)
+            has_ref = "$ref" in item
+            assert has_method or has_ref, (
+                f"{url} survived emission with no methods or $ref: {list(item)}"
+            )
+
+
+class TestOpenAPIExposeFalse:
+    """Coverage for #110 — ``openapi.expose: "false"`` on an
+    ``openapi.resource: "true"`` class keeps the class addressable as
+    a component schema (so other paths can ``$ref`` it) but suppresses
+    its own path emission. The Spring sidecar inherits the suppression
+    via :class:`OpenAPIGenerator`."""
+
+    SCHEMA = """
+id: https://example.org/expose
+name: expose
+default_range: string
+classes:
+  Person:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: persons
+    attributes:
+      id: { identifier: true, required: true }
+      role: { range: Role, inlined: true }
+  Role:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: roles
+      openapi.expose: "false"
+    attributes:
+      id: { identifier: true, required: true }
+      role_label: string
+"""
+
+    def test_expose_false_suppresses_paths(self):
+        spec = _generate_from_string(self.SCHEMA)
+        for url in spec["paths"]:
+            assert not url.startswith("/roles"), (
+                f"openapi.expose=false should drop /roles paths; got {url}"
+            )
+
+    def test_exposed_class_paths_still_emitted(self):
+        spec = _generate_from_string(self.SCHEMA)
+        assert "/persons" in spec["paths"]
+        assert "/persons/{id}" in spec["paths"]
+
+    def test_expose_false_class_schema_still_emitted(self):
+        # The component schema is needed for other resources to $ref.
+        spec = _generate_from_string(self.SCHEMA)
+        assert "Role" in spec["components"]["schemas"]
+
+    def test_expose_false_class_still_referenceable(self):
+        # Person.role still resolves to Role.
+        spec = _generate_from_string(self.SCHEMA)
+        person = spec["components"]["schemas"]["Person"]
+        role_prop = person["properties"]["role"]
+        # Either a $ref or a schema with a $ref under allOf — both fine
+        # as long as the link survives.
+        assert "Role" in yaml.safe_dump(role_prop)
+
+    def test_default_unset_preserves_today_behavior(self):
+        schema = self.SCHEMA.replace('      openapi.expose: "false"\n', "")
+        spec = _generate_from_string(schema)
+        assert "/roles" in spec["paths"]
+        assert "/roles/{id}" in spec["paths"]
+
+
+class TestExtraErrorResponses:
+    """Coverage for #104 — schema-level / CLI declaration of extra
+    HTTP error responses that should appear on every operation."""
+
+    BASE_SCHEMA = """
+id: https://example.org/errs
+name: errs
+default_range: string
+classes:
+  Person:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: persons
+    attributes:
+      id: { identifier: true, required: true }
+      full_name: string
+"""
+
+    def test_default_unset_keeps_today_behavior(self):
+        spec = _generate_from_string(self.BASE_SCHEMA)
+        get = spec["paths"]["/persons"]["get"]
+        # Today's wire shape — only the bodies the generator declares
+        # explicitly. No 400 / 500 etc.
+        assert "400" not in get["responses"]
+        assert "500" not in get["responses"]
+
+    def test_schema_annotation_injects_codes(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "400,401,500"',
+        )
+        spec = _generate_from_string(schema)
+        # The list endpoint gets 400 / 401 / 500 added (alongside its
+        # native 200).
+        get = spec["paths"]["/persons"]["get"]
+        for code in ("400", "401", "500"):
+            assert code in get["responses"], f"missing {code} on GET /persons"
+        # The item endpoint also picks up the extras — uniform across
+        # operations.
+        item_get = spec["paths"]["/persons/{id}"]["get"]
+        for code in ("400", "401", "500"):
+            assert code in item_get["responses"]
+
+    def test_response_uses_standard_reason_phrase(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "503"',
+        )
+        spec = _generate_from_string(schema)
+        get = spec["paths"]["/persons"]["get"]
+        assert get["responses"]["503"]["description"] == "Service unavailable"
+
+    def test_response_references_problem_schema(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "400"',
+        )
+        spec = _generate_from_string(schema)
+        get = spec["paths"]["/persons"]["get"]
+        body = get["responses"]["400"]["content"]["application/json"]["schema"]
+        assert body == {"$ref": "#/components/schemas/Problem"}
+
+    def test_existing_response_for_same_code_is_preserved(self):
+        # GET /persons/{id} already declares 404; the global injection
+        # must not overwrite the per-op description.
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "404"',
+        )
+        spec = _generate_from_string(schema)
+        item_get = spec["paths"]["/persons/{id}"]["get"]
+        # The existing 404 ("Not found") should still be there — not
+        # overwritten by the generic injected one.
+        assert item_get["responses"]["404"]["description"] == "Not found"
+
+    def test_kwarg_overrides_schema_annotation(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "400,401"',
+        )
+        spec = _generate_from_string(schema, error_responses=[500])
+        get = spec["paths"]["/persons"]["get"]
+        assert "500" in get["responses"]
+        # CLI override means the schema-annotation codes are NOT applied.
+        assert "400" not in get["responses"]
+
+    def test_empty_kwarg_disables_injection(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "400,500"',
+        )
+        spec = _generate_from_string(schema, error_responses=[])
+        get = spec["paths"]["/persons"]["get"]
+        assert "400" not in get["responses"]
+        assert "500" not in get["responses"]
+
+    def test_no_error_schema_omits_body(self):
+        schema = self.BASE_SCHEMA.replace(
+            "default_range: string",
+            'default_range: string\nannotations:\n  openapi.error_responses: "400"',
+        )
+        spec = _generate_from_string(schema, error_schema=False)
+        get = spec["paths"]["/persons"]["get"]
+        # Code still present, body omitted (matches --no-error-schema
+        # behaviour for the existing 404/422).
+        assert "400" in get["responses"]
+        assert "content" not in get["responses"]["400"]
+
+    def test_invalid_code_raises(self):
+        _generate_from_string_raises(
+            self.BASE_SCHEMA.replace(
+                "default_range: string",
+                'default_range: string\nannotations:\n  openapi.error_responses: "200,500"',
+            ),
+            match=r"outside the 4xx/5xx",
+        )
+
+    def test_non_integer_token_raises(self):
+        _generate_from_string_raises(
+            self.BASE_SCHEMA.replace(
+                "default_range: string",
+                'default_range: string\nannotations:\n  openapi.error_responses: "400,oops"',
+            ),
+            match=r"non-integer token",
+        )
+
+
+class TestPaginationAndListEnvelope:
+    """Coverage for #105 — list envelope + pagination dialects +
+    extra typed query params, declared per-resource-class via three
+    class-level annotations."""
+
+    BASE = """
+id: https://example.org/page
+name: page
+default_range: string
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+"""
+
+    def test_default_unset_keeps_bare_array(self):
+        spec = _generate_from_string(self.BASE)
+        get = spec["paths"]["/datasets"]["get"]
+        schema = get["responses"]["200"]["content"]["application/json"]["schema"]
+        assert schema["type"] == "array"
+        assert schema["items"] == {"$ref": "#/components/schemas/Dataset"}
+
+    def test_envelope_wraps_200_in_ref(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.list_envelope: PagedDatasets',
+        ) + """
+  PagedDatasets:
+    attributes:
+      items: { range: Dataset, multivalued: true }
+      nextCursor: string
+"""
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        body = get["responses"]["200"]["content"]["application/json"]["schema"]
+        assert body == {"$ref": "#/components/schemas/PagedDatasets"}
+
+    def test_envelope_class_missing_raises(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.list_envelope: MissingClass',
+        )
+        _generate_from_string_raises(
+            schema_yaml,
+            match=r"undefined class 'MissingClass'",
+        )
+
+    def test_cursor_pagination_injects_cursor_and_page_size(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.pagination: cursor',
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        names = {p["name"] for p in get["parameters"]}
+        assert "cursor" in names
+        assert "pageSize" in names
+
+    def test_page_size_dialect_injects_page_and_size(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.pagination: page-size',
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        names = {p["name"] for p in get["parameters"]}
+        assert "page" in names
+        assert "size" in names
+
+    def test_page_offset_dialect_injects_offset_and_limit(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.pagination: page-offset',
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        names = {p["name"] for p in get["parameters"]}
+        assert "offset" in names
+        assert "limit" in names
+
+    def test_unknown_dialect_raises(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.pagination: invalid',
+        )
+        _generate_from_string_raises(schema_yaml, match=r"unknown dialect")
+
+    def test_none_dialect_injects_nothing(self):
+        # ``none`` is an explicit opt-out — the generator still emits
+        # its today-default ``limit`` / ``offset`` query params
+        # (legacy auto-paging baseline that pre-dates #105), but no
+        # dialect-specific names get added on top.
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.pagination: none',
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        names = {p["name"] for p in (get.get("parameters") or [])}
+        assert "cursor" not in names
+        assert "pageSize" not in names
+        assert "page" not in names
+
+    def test_extra_list_query_params_inject(self):
+        # JSON-encoded array because LinkML annotations are scalar strings.
+        params_json = (
+            '[{"name": "filterBy", "type": "string", "description": "Filter"}, '
+            '{"name": "archived", "type": "boolean"}]'
+        )
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            f'openapi.path: datasets\n      openapi.list_query_params: \'{params_json}\'',
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        params = {p["name"]: p for p in get["parameters"]}
+        assert "filterBy" in params
+        assert params["filterBy"]["schema"]["type"] == "string"
+        assert params["filterBy"].get("description") == "Filter"
+        assert "archived" in params
+        assert params["archived"]["schema"]["type"] == "boolean"
+
+    def test_invalid_extra_param_json_raises(self):
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            'openapi.path: datasets\n      openapi.list_query_params: "not json"',
+        )
+        _generate_from_string_raises(schema_yaml, match=r"JSON array")
+
+    def test_invalid_extra_param_type_raises(self):
+        params_json = '[{"name": "bad", "type": "uuid"}]'
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            f'openapi.path: datasets\n      openapi.list_query_params: \'{params_json}\'',
+        )
+        _generate_from_string_raises(schema_yaml, match=r"not one of")
+
+    def test_all_three_compose(self):
+        params_json = '[{"name": "filter", "type": "string"}]'
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            (
+                "openapi.path: datasets\n"
+                "      openapi.list_envelope: PagedDatasets\n"
+                "      openapi.pagination: cursor\n"
+                f"      openapi.list_query_params: '{params_json}'"
+            ),
+        ) + """
+  PagedDatasets:
+    attributes:
+      items: { range: Dataset, multivalued: true }
+      nextCursor: string
+"""
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        # Envelope: response is $ref.
+        body = get["responses"]["200"]["content"]["application/json"]["schema"]
+        assert body == {"$ref": "#/components/schemas/PagedDatasets"}
+        # Pagination + filter both present as query params.
+        names = {p["name"] for p in get["parameters"]}
+        assert {"cursor", "pageSize", "filter"} <= names
+
+    def test_envelope_propagates_to_nested_composition_list(self):
+        # AcmeCatalog → dataset is a composition list; the target
+        # (Dataset / AcmeDataset) declares the envelope, so the
+        # nested list inherits it (one declared shape per resource).
+        schema_yaml = """
+id: https://example.org/nest-env
+name: nest_env
+default_range: string
+classes:
+  Catalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+    attributes:
+      id: { identifier: true, required: true }
+      dataset:
+        range: Dataset
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+      openapi.list_envelope: PagedDatasets
+      openapi.pagination: cursor
+    attributes:
+      id: { identifier: true, required: true }
+      title: string
+  PagedDatasets:
+    attributes:
+      items: { range: Dataset, multivalued: true }
+      nextCursor: string
+"""
+        spec = _generate_from_string(schema_yaml)
+        # Find any path under /catalogs/{id}/ that lists datasets.
+        nested = None
+        for url in spec["paths"]:
+            if url.startswith("/catalogs/{id}/") and "dataset" in url:
+                if "get" in spec["paths"][url]:
+                    nested = spec["paths"][url]
+                    break
+        assert nested is not None, f"no nested dataset list found in {list(spec['paths'])}"
+        body = nested["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+        assert body == {"$ref": "#/components/schemas/PagedDatasets"}
+        # And cursor pagination params are present.
+        names = {p["name"] for p in (nested["get"].get("parameters") or [])}
+        assert {"cursor", "pageSize"} <= names


### PR DESCRIPTION
## Summary

Seven additive features / fixes from the downstream prioritised list, each gated behind a class- or schema-level annotation or default-off flag so byte-identical for schemas that don't opt in.

- **#104** — `openapi.error_responses: "400,401,500"` schema annotation / `--error-responses` CLI flag inject standard 4xx/5xx codes on every emitted operation, with IANA reason phrases referencing the active error class (Problem by default). Existing per-op responses for the same code are preserved.
- **#105** — Three composable class-level annotations for list endpoints: `openapi.list_envelope: <Class>` wraps the 200 body in `$ref` to the named class; `openapi.pagination: cursor|page-size|page-offset` injects standard query params for the chosen dialect; `openapi.list_query_params: '<JSON>'` injects extra typed query params. Applies to top-level CRUD, composition, reference, and templated deep-path lists.
- **#106** — `--codegen-friendly` detects `slot_usage` range narrowing on descendants and falls back to use-site `oneOf` for the affected polymorphic root only, avoiding the Java covariance compile error under openapi-generator's inheritance template. New opt-out annotation `openapi.codegen_inheritance: "false"` for cases the auto-detector misses.
- **#107** — `discriminator.mapping` keys now use each subtype's `openapi.legacy_type_value` when the discriminator field and legacy_type_field both name the same wire field. Wire-matching dispatch for codegen-friendly + legacy-wire-compat schemas.
- **#108** — `--codegen-friendly` now drops the single-value `enum` on `openapi.legacy_type_field` properties (keeps `default:` only), matching the primary discriminator's treatment.
- **#109** — Empty `PathItem` objects (operation-less, parameters-only) produced by `openapi.path_template` + collection-only `openapi.operations` are now dropped instead of leaking invalid OpenAPI into the spec.
- **#110** — `openapi.expose: "false"` on an `openapi.resource: "true"` class keeps the type addressable as a component schema but suppresses path emission on both `gen-openapi` and `gen-spring-server`.

Default unset = byte-identical to today's output for every feature. 39 new test methods, 497 tests pass.

Closes #104, #105, #106, #107, #108, #109, #110.

## Test plan

- [x] `pytest tests/` — 497 passed (+39 new across 7 new test classes)
- [x] `ruff check src/ tests/` — clean
- [x] Smoke-test CLI on `tests/fixtures/dcat3-acme.yaml` with `--error-responses 400,401,500` — error responses inject correctly across all ops
- [x] Verify byte-identical default output: existing test suite passes unchanged (no regression rewrites)
- [ ] CI green on PR

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_