### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.15.0] — 2026-05-28
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.14.0"
+version = "0.15.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
## Summary

Release 0.15.0 — flip `Unreleased` → `0.15.0` in CHANGELOG.md, bump `pyproject.toml` and `__init__.py` to `0.15.0`.

Ships seven features / fixes from PR #111:

- **#104** — `openapi.error_responses` annotation + `--error-responses` CLI flag inject standard 4xx/5xx codes on every operation, with IANA reason phrases pointing at the active error class.
- **#105** — Pagination + list envelope + per-endpoint extra query params, via three composable class-level annotations (`openapi.list_envelope`, `openapi.pagination`, `openapi.list_query_params`).
- **#106** — `--codegen-friendly` no longer emits uncompilable Java when a subtype narrows an inherited slot's range; new opt-out annotation `openapi.codegen_inheritance: "false"` as escape hatch.
- **#107** — `discriminator.mapping` keys now follow `openapi.legacy_type_value` when the discriminator field matches the legacy_type_field (wire-matching dispatch).
- **#108** — `--codegen-friendly` strips the single-value `enum` on `openapi.legacy_type_field` properties (consistency with the primary discriminator).
- **#109** — Empty `PathItem` objects produced by `openapi.path_template` + collection-only `openapi.operations` are dropped instead of leaking invalid OpenAPI.
- **#110** — `openapi.expose: "false"` keeps a class as a referenceable schema but suppresses path emission on both emitters.

Every feature is default-off / annotation-gated. Schemas that don't opt in regenerate byte-identically.

## Test plan

- [x] `python -c "import linkml_openapi; print(linkml_openapi.__version__)"` → `0.15.0`
- [x] `pytest tests/` — 497 passed (no change since PR #111)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- [ ] CI green on this release PR
- [ ] After merge: tag `v0.15.0` triggers PyPI publish workflow

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_