### PR TITLE
fix: follow-on bugs batch (Spring/OpenAPI parity, profile typos, mixin narrowing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Spring controllers honour `openapi.list_envelope` /
+  `openapi.pagination` / `openapi.list_query_params`** (#4
+  follow-up). Previously only the sidecar OpenAPI spec carried
+  these — Spring controllers shipped `List<T>` + hardcoded
+  `limit/offset` regardless. Now the controllers return the
+  envelope class when set, emit the dialect's query params (`cursor`
+  / `pageSize`, etc.), and inject any extra typed `@RequestParam`
+  declarations declared via `openapi.list_query_params`. The live
+  springdoc view now matches the static sidecar wire-for-wire.
+
+### Fixed
+
+- **Mixin narrowing now triggers the `--codegen-friendly` fallback**
+  (#5). `_detect_narrowing_subclasses` only walked `is_a`; a class
+  that narrowed an inherited slot via a `mixins:` chain silently
+  fell through and re-introduced the #106 covariance crash under
+  `--codegen-friendly --flatten-inheritance`. The walk now visits
+  `is_a` AND every entry of `mixins:`.
+- **Spring `@JsonSubTypes` includes the concrete root regardless of
+  explicit `openapi.type_value`** (#6). Mirrors the OpenAPI
+  generator's `_type_value` fallback (uses `cls.name` when the
+  annotation isn't set), so a concrete polymorphic root's payload
+  can now Jackson-deserialise on the Spring side.
+- **Per-op error response baseline aligns with OpenAPI** (#7).
+  Spring previously emitted `{404, 422, 500}` on every op. The
+  OpenAPI generator emits per-op shapes (list: none; create: 422;
+  read/delete: 404; update/patch: 404+422; attach: 404+422; detach:
+  404). The Spring side now mirrors this. The 500 baseline is dropped
+  — schemas opt in via `openapi.error_responses` for server-error
+  contracts. `openapi.error_responses` codes still merge in
+  uniformly across all ops.
+- **`openapi.profile.<n>.include_classes` / `include_slots` /
+  `exclude_classes` / `exclude_slots` now detect typos** (#8).
+  Unknown class / slot names raise a `ValueError` naming the
+  misspelled tokens. Previously a typo silently included/excluded
+  the wrong set — worst case `include_classes: Cataog` excluded the
+  entire schema with no warning.
+- **`error_responses=[]` Spring kwarg now propagates to the sidecar**
+  (#9). The prior `[] or None` collapse silently fell back to the
+  schema annotation, so "skip everywhere" leaked the codes into the
+  sidecar spec. Spring and sidecar now agree on disable intent.
+- **Spring's `_get_slot_annotation_compat` walks JsonObj annotation
+  containers correctly.** Inherited `openapi.query_param`
+  annotations from a parent class's `slot_usage` were silently lost
+  on Spring (the walker treated the JsonObj as a single annotation
+  instead of iterating its keys). The fix mirrors the OpenAPI
+  generator's defensive iteration pattern. Surfaced by the parity
+  test once a separate regex fix let it see beyond the first
+  `@RequestParam`.
+- **Whitespace-only `openapi.pagination` value no longer crashes**
+  (L11). Both generators now treat `openapi.pagination: "  "` as
+  "unset" (legacy `limit`/`offset` baseline) instead of falling
+  through to an unknown-dialect error.
+
+### Internal
+
+- **Shared `_http` module** holds the IANA reason-phrase table; both
+  generators import from it so the table can't drift (#10).
+- **`_JAVA_RESERVED_WORDS`** extended to cover Java 9+/14+/17+
+  contextual keywords (`record`, `sealed`, `permits`, `var`,
+  `yield`, `module`, `requires`, `exports`, ...) so slot names that
+  collide with them get the `_` suffix on every supported LTS (L9).
+- **Misleading ordering comment** on `_path_item_has_operations`
+  cleaned up — the prior comment described an injection-then-filter
+  bug that doesn't exist (the injector skips op-less PathItems
+  anyway). Replaced with a comment stating the invariant the
+  ordering establishes (L10).
+- 11 new regression tests covering each fix above.
+
 ### Security
 
 - **Input validation for Java code emission.** A second code review

--- a/src/linkml_openapi/_http.py
+++ b/src/linkml_openapi/_http.py
@@ -1,0 +1,45 @@
+"""Shared HTTP-status reason phrases for the OpenAPI generator and
+the Spring emitter.
+
+Lives in its own module so a future edit to the table can't silently
+drift between the two emitters — both import the same constant.
+Sourced from IANA's HTTP Status Code Registry; only the 4xx and 5xx
+codes a schema author would plausibly declare via
+``openapi.error_responses`` are included. Codes outside the table
+fall back to ``f"HTTP {code}"`` at the call site.
+"""
+
+from __future__ import annotations
+
+HTTP_REASON_PHRASES: dict[int, str] = {
+    400: "Bad request",
+    401: "Unauthorized",
+    402: "Payment required",
+    403: "Forbidden",
+    404: "Not found",
+    405: "Method not allowed",
+    406: "Not acceptable",
+    408: "Request timeout",
+    409: "Conflict",
+    410: "Gone",
+    412: "Precondition failed",
+    413: "Payload too large",
+    415: "Unsupported media type",
+    422: "Validation error",
+    423: "Locked",
+    424: "Failed dependency",
+    428: "Precondition required",
+    429: "Too many requests",
+    451: "Unavailable for legal reasons",
+    500: "Server error",
+    501: "Not implemented",
+    502: "Bad gateway",
+    503: "Service unavailable",
+    504: "Gateway timeout",
+}
+
+
+def reason_for(code: int) -> str:
+    """Return the standard reason phrase for an HTTP status code, or
+    a generic fallback when the code isn't in the table."""
+    return HTTP_REASON_PHRASES.get(code, f"HTTP {code}")

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -43,6 +43,7 @@ from linkml_openapi._chains import (
 from linkml_openapi._chains import (
     parse_path_param_sources as _parse_path_param_sources_helper,
 )
+from linkml_openapi._http import reason_for
 from linkml_openapi._query_params import (
     QueryParamSpec,
     walk_query_params,
@@ -618,11 +619,11 @@ class OpenAPIGenerator(Generator):
         # ``openapi.operations`` lists only collection-level ops, or
         # when an auto-derived flat item path has no item-level ops
         # to attach (#109).
-        # Order matters: filter empty PathItems BEFORE injecting extra
-        # error responses. If we injected first, an otherwise-invalid
-        # operation-less PathItem could survive emission with only the
-        # synthetic 4xx/5xx responses attached, which is still
-        # structurally invalid (responses without a method holder).
+        # Filtering happens before extra-error injection — the
+        # injector skips op-less PathItems anyway, but keeping this
+        # invariant ordered makes the dataflow easier to reason about:
+        # after this line, every PathItem in ``paths`` has at least
+        # one HTTP method on it.
         paths = {url: item for url, item in paths.items() if self._path_item_has_operations(item)}
 
         # Merge schema-level / CLI ``openapi.error_responses`` codes
@@ -1444,35 +1445,8 @@ class OpenAPIGenerator(Generator):
             )
         return custom
 
-    # IANA standard reason phrases for the 4xx / 5xx codes we expect
-    # authors to declare via ``openapi.error_responses`` (#104). Any
-    # unrecognised code falls back to ``f"HTTP {code}"``.
-    _HTTP_REASON_PHRASES: ClassVar[dict[int, str]] = {
-        400: "Bad request",
-        401: "Unauthorized",
-        402: "Payment required",
-        403: "Forbidden",
-        404: "Not found",
-        405: "Method not allowed",
-        406: "Not acceptable",
-        408: "Request timeout",
-        409: "Conflict",
-        410: "Gone",
-        412: "Precondition failed",
-        413: "Payload too large",
-        415: "Unsupported media type",
-        422: "Validation error",
-        423: "Locked",
-        424: "Failed dependency",
-        428: "Precondition required",
-        429: "Too many requests",
-        451: "Unavailable for legal reasons",
-        500: "Server error",
-        501: "Not implemented",
-        502: "Bad gateway",
-        503: "Service unavailable",
-        504: "Gateway timeout",
-    }
+    # IANA standard reason phrases live in ``_http`` so the Spring
+    # emitter and the OpenAPI generator can't drift apart (#10).
 
     def _resolve_error_response_codes(self) -> list[int]:
         """Resolve the list of extra error codes from CLI/kwarg or
@@ -1515,7 +1489,7 @@ class OpenAPIGenerator(Generator):
 
     def _http_reason(self, code: int) -> str:
         """Standard reason phrase for an HTTP status code (#104)."""
-        return self._HTTP_REASON_PHRASES.get(code, f"HTTP {code}")
+        return reason_for(code)
 
     def _apply_extra_error_responses(self, paths: dict[str, PathItem]) -> None:
         """Merge ``openapi.error_responses`` codes into every operation
@@ -1599,6 +1573,25 @@ class OpenAPIGenerator(Generator):
                 f"{self.profile}.<key>` schema annotations."
             )
         p = profiles[self.profile]
+        sv = self.schemaview
+        # Validate that every name in ``include_*`` / ``exclude_*``
+        # actually exists in the schema. A typo (``Cataog`` for
+        # ``Catalog``) would otherwise silently exclude the entire
+        # schema (``include_classes``) or excluded-nothing
+        # (``exclude_classes``) — the spec compiles, the surface is
+        # wrong, and the wrong shape ships. Raise instead (#8).
+        all_class_names = set(sv.all_classes())
+        all_slot_names = {
+            s.name for class_name in all_class_names for s in self._induced_slots_iter(class_name)
+        }
+        self._validate_profile_names(
+            "exclude_classes", p.get("exclude_classes") or [], all_class_names
+        )
+        self._validate_profile_names(
+            "include_classes", p.get("include_classes") or [], all_class_names
+        )
+        self._validate_profile_names("exclude_slots", p.get("exclude_slots") or [], all_slot_names)
+        self._validate_profile_names("include_slots", p.get("include_slots") or [], all_slot_names)
         excluded_classes = set(p.get("exclude_classes", []))
         excluded_slots = set(p.get("exclude_slots", []))
         # ``include_classes`` / ``include_slots`` (when declared)
@@ -1607,7 +1600,6 @@ class OpenAPIGenerator(Generator):
         # a class can be both included and explicitly excluded; the
         # exclusion wins (matches the "drift on a slot annotation
         # surfaces loudly" philosophy: be conservative).
-        sv = self.schemaview
         include_classes = p.get("include_classes")
         if include_classes:
             include_set = set(include_classes)
@@ -1625,6 +1617,19 @@ class OpenAPIGenerator(Generator):
                         excluded_slots.add(slot.name)
         self._raise_on_drift(excluded_classes, excluded_slots)
         return excluded_classes, excluded_slots, p.get("description")
+
+    def _validate_profile_names(self, key: str, names: list[str], universe: set[str]) -> None:
+        """Raise on any profile-list name that doesn't exist in the
+        schema (#8). A typo would otherwise silently include / exclude
+        the wrong set."""
+        unknown = sorted(n for n in names if n not in universe)
+        if unknown:
+            kind = "class" if "classes" in key else "slot"
+            raise ValueError(
+                f"Profile {self.profile!r} `{key}` references unknown "
+                f"{kind} names: {unknown}. Fix the typo or remove the "
+                f"`openapi.profile.{self.profile}.{key}` annotation."
+            )
 
     def _raise_on_drift(self, excluded_classes: set[str], excluded_slots: set[str]) -> None:
         """Fail when an excluded slot is referenced by an annotation.
@@ -1696,19 +1701,36 @@ class OpenAPIGenerator(Generator):
         )
 
     def _detect_narrowing_subclasses(self) -> None:
-        """Walk every is_a relationship and record subclasses that
-        materially narrowed an inherited slot's range. Runs unconditionally
-        in ``__post_init__`` so the discriminator pass (#106) gets the
-        right answer regardless of whether the per-class emission later
-        takes the ``allOf`` branch or the ``flatten_inheritance`` branch
-        of ``_class_to_schema``.
+        """Walk every is_a / mixin relationship and record subclasses
+        that materially narrowed an inherited slot's range. Runs
+        unconditionally in ``__post_init__`` so the discriminator pass
+        (#106) gets the right answer regardless of whether the
+        per-class emission later takes the ``allOf`` branch or the
+        ``flatten_inheritance`` branch of ``_class_to_schema``.
+
+        Mixins are walked alongside ``is_a`` (a slot can be narrowed
+        from either) so a schema that uses LinkML's mixin mechanism to
+        share slots across resource classes still gets the
+        codegen-friendly fallback when a descendant narrows the
+        inherited slot.
         """
         sv = self.schemaview
         for class_name in sv.all_classes():
             cls = sv.get_class(class_name)
-            if cls is None or not cls.is_a:
+            if cls is None:
                 continue
-            parent_slots_by_name = {s.name: s for s in self._induced_slots_iter(cls.is_a)}
+            parents: list[str] = []
+            if cls.is_a:
+                parents.append(cls.is_a)
+            parents.extend(cls.mixins or [])
+            if not parents:
+                continue
+            parent_slots_by_name: dict[str, SlotDefinition] = {}
+            for parent in parents:
+                for s in self._induced_slots_iter(parent):
+                    # First-seen parent wins (matches LinkML's MRO);
+                    # we only need a "any parent had this slot" view.
+                    parent_slots_by_name.setdefault(s.name, s)
             for slot in self._induced_slots_iter(class_name):
                 parent_slot = parent_slots_by_name.get(slot.name)
                 if parent_slot is not None and self._slot_was_narrowed(slot, parent_slot):
@@ -3687,7 +3709,13 @@ class OpenAPIGenerator(Generator):
         no duplication of ``limit``/``offset`` against ``offset`` /
         ``limit`` from ``page-offset`` (#105 follow-up).
         """
-        if self._class_annotation(cls, "openapi.pagination"):
+        # Strip whitespace so ``openapi.pagination: "  "`` is treated
+        # the same as "unset" (legacy baseline). Without the strip a
+        # purely-whitespace value would skip the legacy params and
+        # then crash inside ``_pagination_params`` on the unknown
+        # dialect.
+        pagination_value = self._class_annotation(cls, "openapi.pagination")
+        if pagination_value and pagination_value.strip():
             pagination = self._pagination_params(cls)
         else:
             pagination = self._legacy_pagination_params()

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -28,9 +28,11 @@ Scope (MVP):
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import ClassVar
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
@@ -48,6 +50,7 @@ from linkml_openapi._chains import (
     parse_path_param_sources,
     render_chain_hops,
 )
+from linkml_openapi._http import HTTP_REASON_PHRASES
 from linkml_openapi._query_params import QueryParamSpec, walk_query_params
 from linkml_openapi.generator import _is_falsy, _to_snake_case
 
@@ -286,35 +289,8 @@ class SpringServerGenerator:
                     return value
         return None
 
-    # IANA reason phrases for extra ``openapi.error_responses`` codes.
-    # Kept in sync with ``OpenAPIGenerator._HTTP_REASON_PHRASES`` so
-    # the controller annotations and sidecar spec match wire-for-wire.
-    _HTTP_REASON_PHRASES = {
-        400: "Bad request",
-        401: "Unauthorized",
-        402: "Payment required",
-        403: "Forbidden",
-        404: "Not found",
-        405: "Method not allowed",
-        406: "Not acceptable",
-        408: "Request timeout",
-        409: "Conflict",
-        410: "Gone",
-        412: "Precondition failed",
-        413: "Payload too large",
-        415: "Unsupported media type",
-        422: "Validation error",
-        423: "Locked",
-        424: "Failed dependency",
-        428: "Precondition required",
-        429: "Too many requests",
-        451: "Unavailable for legal reasons",
-        500: "Server error",
-        501: "Not implemented",
-        502: "Bad gateway",
-        503: "Service unavailable",
-        504: "Gateway timeout",
-    }
+    # IANA reason phrases live in ``linkml_openapi._http`` so the
+    # controller annotations and sidecar spec can't drift (#10).
 
     def _resolve_error_response_codes(self) -> list[int]:
         """Resolve the extra HTTP codes to emit on every controller op.
@@ -463,14 +439,21 @@ class SpringServerGenerator:
         the live springdoc view diverges from the static spec."""
         from linkml_openapi.generator import OpenAPIGenerator
 
+        # Preserve the kwarg's tri-state semantics through to the
+        # sidecar (#9): an explicit empty list means "skip injection
+        # everywhere"; ``None`` means "let the sidecar resolve from
+        # the schema annotation." Without this, ``[] or None`` would
+        # collapse the disable intent and the sidecar would re-emit
+        # the annotation's codes.
+        if self.error_responses is not None:
+            sidecar_error_responses: list[int] | None = list(self._extra_error_codes)
+        else:
+            sidecar_error_responses = None
         return OpenAPIGenerator(
             self.schema_path,
             path_prefix=self._effective_path_prefix or None,
             path_style=self.path_style,
-            # Thread the same extra error codes (#104) so the sidecar
-            # spec advertises 400/401/etc. on the same operations the
-            # controllers do.
-            error_responses=self._extra_error_codes or None,
+            error_responses=sidecar_error_responses,
         ).serialize()
 
     def build(self) -> dict[str, str]:
@@ -854,7 +837,8 @@ public class %(class_name)s {
                     media_types,
                     self._error_class_name,
                     self._extra_error_codes,
-                    self._HTTP_REASON_PHRASES,
+                    HTTP_REASON_PHRASES,
+                    op_kind=_op_kind_from_method_name(op["method_name"]),
                 )
             )
         if self._effective_path_prefix:
@@ -942,7 +926,13 @@ public class %(class_name)s {
                 imports.add(f"{self.package}.model.{body_type}")
         base = f'"/{path_segment}"'
         item = f'"/{path_segment}/{{id}}"'
-        list_return = f"List<{cn}>"
+        # Envelope-aware return type for the list op (#105) — when
+        # ``openapi.list_envelope`` is set, the controller returns the
+        # envelope class (which embeds the array slot itself) instead
+        # of a bare ``List<T>``.
+        list_return = self._list_return_type(cls, f"List<{cn}>")
+        if list_return != f"List<{cn}>":
+            imports.add(f"{self.package}.model.{list_return}")
         produces = _produces_arg(media_types)
         consumes = produces
         return [
@@ -951,7 +941,7 @@ public class %(class_name)s {
                 "method_annotations": [f"@GetMapping(value = {base}, produces = {produces})"],
                 "method_name": f"list{cn}s",
                 "return_type": list_return,
-                "params": _list_query_params() + self._query_param_dicts(cls, imports),
+                "params": self._list_operation_param_dicts(cls, imports),
             },
             {
                 "javadoc": f"POST /{path_segment} — create a {cn}.",
@@ -1079,16 +1069,20 @@ public class %(class_name)s {
         target_id_var = _java_identifier(target.name) + "Id"
         produces = _produces_arg(media_types)
         consumes = produces
+        # Envelope / pagination / extras on the nested list op
+        # mirror the target class's top-level CRUD list shape (#4).
+        list_return = self._list_return_type(target, f"List<{tn}>")
+        if list_return != f"List<{tn}>":
+            imports.add(f"{self.package}.model.{list_return}")
         return [
             {
                 "javadoc": f"GET /{slot.name} — list embedded {tn}s under a {pn}.",
                 "method_annotations": [f"@GetMapping(value = {collection}, produces = {produces})"],
                 "method_name": f"list{pn}{sn}",
-                "return_type": f"List<{tn}>",
+                "return_type": list_return,
                 "params": [
                     _path_param("id"),
-                    *_list_query_params(),
-                    *self._query_param_dicts(target, imports),
+                    *self._list_operation_param_dicts(target, imports),
                 ],
             },
             {
@@ -1166,8 +1160,11 @@ public class %(class_name)s {
                 "return_type": "List<URI>",
                 "params": [
                     _path_param("id"),
-                    *_list_query_params(),
-                    *self._query_param_dicts(target, imports),
+                    # Pagination / filters / extras still come from the
+                    # target class — the reference list URL lists the
+                    # SAME resource type the composition list does, so
+                    # the query-param contract matches (#4).
+                    *self._list_operation_param_dicts(target, imports),
                 ],
             },
             {
@@ -1398,6 +1395,9 @@ public class %(class_name)s {
                     collection_params = [
                         p for p, n in zip(item_params, unique_placeholders) if n != tail_name
                     ]
+                    templated_list_return = self._list_return_type(cls, f"List<{cn}>")
+                    if templated_list_return != f"List<{cn}>":
+                        imports.add(f"{self.package}.model.{templated_list_return}")
                     ops.extend(
                         [
                             {
@@ -1407,11 +1407,10 @@ public class %(class_name)s {
                                     f" produces = {produces})"
                                 ],
                                 "method_name": f"list{cn}s{suffix}",
-                                "return_type": f"List<{cn}>",
+                                "return_type": templated_list_return,
                                 "params": [
                                     *collection_params,
-                                    *_list_query_params(),
-                                    *self._query_param_dicts(cls, imports),
+                                    *self._list_operation_param_dicts(cls, imports),
                                 ],
                             },
                             {
@@ -1462,6 +1461,160 @@ public class %(class_name)s {
             imports.add("java.util.List")
         return out
 
+    # --- #105: pagination / envelope / extras on Spring side ----------
+
+    # Dialect → list of (param name, Java type, description). Mirrors
+    # ``OpenAPIGenerator._PAGINATION_DIALECTS`` so the sidecar spec and
+    # the controller annotations advertise the same query-param shape.
+    _PAGINATION_DIALECTS: ClassVar[dict[str, list[tuple[str, str, str]]]] = {
+        "cursor": [
+            ("cursor", "String", "Opaque cursor returned by a previous page."),
+            ("pageSize", "Integer", "Maximum number of items per page."),
+        ],
+        "page-size": [
+            ("page", "Integer", "1-indexed page number."),
+            ("size", "Integer", "Page size."),
+        ],
+        "page-offset": [
+            ("offset", "Integer", "Zero-based offset into the result set."),
+            ("limit", "Integer", "Maximum number of items to return."),
+        ],
+        "none": [],
+    }
+
+    @staticmethod
+    def _request_param_dict(name: str, java_type: str) -> dict:
+        """Build one ``@RequestParam`` dict for the template."""
+        return {
+            "annotation": f'@RequestParam(name = "{name}", required = false)',
+            "java_type": java_type,
+            "java_name": name,
+        }
+
+    def _pagination_param_dicts(self, cls: ClassDefinition) -> list[dict]:
+        """``@RequestParam`` dicts for the class's pagination dialect
+        (#105). When ``openapi.pagination`` is unset, returns the
+        legacy ``limit`` / ``offset`` baseline so today's wire shape
+        is preserved. When it is set, the dialect's params *replace*
+        the baseline (no duplication)."""
+        dialect = self._class_annotation(cls, "openapi.pagination")
+        if not dialect or not dialect.strip():
+            return _list_query_params()
+        dialect = dialect.strip()
+        if dialect not in self._PAGINATION_DIALECTS:
+            raise ValueError(
+                f"openapi.pagination on {cls.name!r}: unknown dialect "
+                f"{dialect!r}; expected one of "
+                f"{sorted(self._PAGINATION_DIALECTS)}."
+            )
+        return [
+            self._request_param_dict(name, java_type)
+            for name, java_type, _ in self._PAGINATION_DIALECTS[dialect]
+        ]
+
+    def _extra_list_param_dicts(self, cls: ClassDefinition) -> list[dict]:
+        """``@RequestParam`` dicts from ``openapi.list_query_params``
+        (#105 JSON array). Decoded with the same length cap and
+        error paths the OpenAPI generator uses, so a malformed value
+        produces the same error on both sides."""
+        raw = self._class_annotation(cls, "openapi.list_query_params")
+        if not raw:
+            return []
+        if len(raw) > 65_536:
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: value is "
+                f"{len(raw)} bytes (cap is 65,536)."
+            )
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: value must be a "
+                f"JSON array of `{{name, type, description?}}` objects; got "
+                f"{raw!r} ({exc})."
+            ) from exc
+        except RecursionError as exc:
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: value is "
+                "too deeply nested to parse safely."
+            ) from exc
+        if not isinstance(decoded, list):
+            raise ValueError(
+                f"openapi.list_query_params on {cls.name!r}: expected a JSON "
+                f"array, got {type(decoded).__name__}."
+            )
+        java_type_for = {
+            "string": "String",
+            "integer": "Integer",
+            "number": "Double",
+            "boolean": "Boolean",
+            "array": "java.util.List<String>",
+        }
+        out: list[dict] = []
+        for idx, entry in enumerate(decoded):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry {idx} is not a JSON object."
+                )
+            name = entry.get("name")
+            otype = entry.get("type")
+            if not name or not otype:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry "
+                    f"{idx} must declare `name` and `type`."
+                )
+            if otype not in java_type_for:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: entry "
+                    f"{idx} type {otype!r} is not one of "
+                    f"{sorted(java_type_for)}."
+                )
+            out.append(self._request_param_dict(name, java_type_for[otype]))
+        return out
+
+    def _list_envelope_class(self, cls: ClassDefinition) -> str | None:
+        """The Java class name to use as the list-op return type when
+        ``openapi.list_envelope`` is set, or None for the default
+        ``List<T>`` shape. Validates that the envelope class exists
+        in the schema (matches the OpenAPI generator's behaviour)."""
+        envelope = self._class_annotation(cls, "openapi.list_envelope")
+        if not envelope:
+            return None
+        envelope = envelope.strip()
+        if self._sv.get_class(envelope) is None:
+            raise ValueError(
+                f"openapi.list_envelope on {cls.name!r} refers to undefined "
+                f"class {envelope!r}; add the class to the schema or remove "
+                "the annotation."
+            )
+        return envelope
+
+    def _list_operation_param_dicts(self, cls: ClassDefinition, imports: set[str]) -> list[dict]:
+        """Single composition point for every list-op site's
+        @RequestParam list (#4 follow-up). Combines pagination
+        (dialect or legacy baseline), slot-driven filter / sort
+        params, and ``openapi.list_query_params`` extras. Mirrors the
+        OpenAPI generator's ``_list_operation_params`` so the
+        controllers and the sidecar spec agree wire-for-wire."""
+        return (
+            self._pagination_param_dicts(cls)
+            + self._query_param_dicts(cls, imports)
+            + self._extra_list_param_dicts(cls)
+        )
+
+    def _list_return_type(self, cls: ClassDefinition, default: str) -> str:
+        """Return type for a list op. When ``openapi.list_envelope``
+        is set, returns the envelope class name (Spring still wraps
+        it in ``ResponseEntity<…>`` / ``Mono<…>`` per reactive
+        mode). Otherwise returns ``default`` (e.g. ``List<T>``)."""
+        envelope = self._list_envelope_class(cls)
+        if envelope is None:
+            return default
+        # Envelope DTO lives in the .model package and is emitted by
+        # the normal DTO walk; register an import so the controller
+        # file compiles.
+        return envelope
+
     def _schema_auto_query_params(self) -> bool:
         raw = None
         sv_schema = self._sv.schema
@@ -1479,26 +1632,45 @@ public class %(class_name)s {
     ) -> str | None:
         """Read a slot annotation, walking slot_usage on the class.
 
-        Mirrors the OpenAPI generator's _get_slot_annotation but uses the
-        Spring emitter's induced-slot cache."""
+        Mirrors the OpenAPI generator's _get_slot_annotation. The
+        ``annotations`` container on an induced slot is a
+        ``JsonObj`` (no ``.values()`` / ``.keys()``) so this walker
+        treats it the same way ``_get_slot_annotation`` does:
+        iterate the JsonObj (which yields keys), then subscript to
+        get each ``Annotation`` value. Without this, inherited
+        ``openapi.query_param`` annotations on parent classes
+        silently fall through and the Spring filter surface
+        diverges from the OpenAPI sidecar (caught by the parity
+        test).
+        """
+
+        def _iter_annotations(container):
+            """Yield each ``Annotation`` value in a LinkML annotations
+            container, handling both dict and JsonObj shapes."""
+            if container is None:
+                return
+            if isinstance(container, dict):
+                yield from container.values()
+                return
+            # JsonObj — iterates its keys; subscript yields the value.
+            for key in container:
+                if key.startswith("_"):
+                    continue
+                yield container[key]
+
         if cls.slot_usage:
             items = cls.slot_usage.values() if isinstance(cls.slot_usage, dict) else cls.slot_usage
             for su in items:
                 su_obj = su if not isinstance(su, str) else None
                 if su_obj and getattr(su_obj, "name", None) == slot_name:
-                    anns = getattr(su_obj, "annotations", None)
-                    if anns:
-                        for ann in anns.values() if isinstance(anns, dict) else [anns]:
-                            if hasattr(ann, "tag") and ann.tag == tag:
-                                return str(ann.value)
+                    for ann in _iter_annotations(getattr(su_obj, "annotations", None)):
+                        if hasattr(ann, "tag") and ann.tag == tag:
+                            return str(ann.value)
         induced = self._slot_for(cls, slot_name)
         if induced is not None:
-            anns = getattr(induced, "annotations", None)
-            if anns:
-                keys = anns.values() if isinstance(anns, dict) else [anns]
-                for ann in keys:
-                    if hasattr(ann, "tag") and ann.tag == tag:
-                        return str(ann.value)
+            for ann in _iter_annotations(getattr(induced, "annotations", None)):
+                if hasattr(ann, "tag") and ann.tag == tag:
+                    return str(ann.value)
         top_level = self._sv.get_slot(slot_name)
         if top_level and top_level.annotations:
             for ann in top_level.annotations.values():
@@ -1837,16 +2009,15 @@ public class %(class_name)s {
         if parent is not None and self._inherited_discriminator(parent):
             return None
         subtypes = []
-        # Include the root itself when it's concrete and pins its own
-        # type value (mirrors the OpenAPI generator's #95 fix): a
+        # Include the root itself when it's concrete and non-mixin
+        # (mirrors the OpenAPI generator's #95 fix): a
         # ``{"resourceType":"Resource", ...}`` payload otherwise has
         # no @JsonSubTypes mapping back to the root and Jackson
-        # refuses to deserialise it.
-        if (
-            not cls.abstract
-            and not cls.mixin
-            and (self._class_annotation(cls, "openapi.type_value") is not None)
-        ):
+        # refuses to deserialise it. Falls back to the class name as
+        # the tag when ``openapi.type_value`` isn't set — symmetric
+        # with the OpenAPI generator, which uses ``cls.name`` as the
+        # default discriminator value.
+        if not cls.abstract and not cls.mixin:
             subtypes.append({"class_name": cls.name, "tag": self._type_value(cls)})
         for name in self._sv.class_descendants(cls.name, reflexive=False):
             sub = self._sv.get_class(name)
@@ -1973,17 +2144,22 @@ def _validate_path_literal(value: str, annotation: str, owner: str = "") -> None
         )
 
 
-# Java reserved words (JLS §3.9, including contextual keywords and
-# the literal-like ``true`` / ``false`` / ``null``). Slot or class
-# names that resolve to one of these are suffixed with ``_`` so the
-# emitted Java still compiles.
+# Java reserved words (JLS §3.9, including contextual keywords from
+# Java 9+/14+/17+ and the literal-like ``true`` / ``false`` /
+# ``null``). Slot or class names that resolve to one of these are
+# suffixed with ``_`` so the emitted Java still compiles on any LTS.
+# ``record``, ``sealed``, ``permits``, ``var``, ``yield`` are
+# contextual keywords — they're not reserved in every position, but
+# making them safe in identifier slots avoids surprise breakage when
+# the slot's emitted Java moves between positions.
 _JAVA_RESERVED_WORDS = frozenset(
     """abstract assert boolean break byte case catch char class const continue
-       default do double else enum extends final finally float for goto if
-       implements import instanceof int interface long native new package
-       private protected public return short static strictfp super switch
-       synchronized this throw throws transient try void volatile while
-       true false null _""".split()
+       default do double else enum exports extends final finally float for goto
+       if implements import instanceof int interface long module native new
+       non-sealed open opens package permits private protected provides public
+       record requires return sealed short static strictfp super switch
+       synchronized this throw throws to transient transitive try uses var void
+       volatile while with yield true false null _""".split()
 )
 
 
@@ -2033,12 +2209,44 @@ def _list_query_params() -> list[dict]:
     ]
 
 
+def _op_kind_from_method_name(method_name: str) -> str:
+    """Derive the operation kind (used to pick the per-op error
+    baseline) from the Java method name's verb prefix. Method names
+    in this generator always start with ``list``, ``create``,
+    ``get``, ``update``, ``delete``, ``patch``, ``attach``, or
+    ``detach``; anything else falls back to ``other`` which gets the
+    legacy baseline."""
+    for verb in ("list", "create", "get", "update", "delete", "patch", "attach", "detach"):
+        if method_name.startswith(verb):
+            return verb
+    return "other"
+
+
+# Per-op baseline error codes — aligned with the OpenAPI generator's
+# per-op shape (`_make_*_operation` in `generator.py`) so the
+# controller annotations match the sidecar spec wire-for-wire.
+# ``other`` keeps the broad legacy baseline as a safety net for any
+# verb the generator grows in future.
+_OP_BASELINE_CODES: dict[str, tuple[int, ...]] = {
+    "list": (),
+    "create": (422,),
+    "get": (404,),
+    "update": (404, 422),
+    "patch": (404, 422),
+    "delete": (404,),
+    "attach": (404, 422),
+    "detach": (404,),
+    "other": (404, 422),
+}
+
+
 def _success_and_problem_responses(
     return_type: str,
     media_types: list[str],
     error_class: str = "Problem",
     extra_codes: list[int] | None = None,
     reason_phrases: dict[int, str] | None = None,
+    op_kind: str = "other",
 ) -> list[str]:
     """Success + RFC 7807 error responses for an operation.
 
@@ -2052,11 +2260,16 @@ def _success_and_problem_responses(
     ``extra_codes`` (#104) declares additional 4xx/5xx codes drawn
     from ``openapi.error_responses`` so the controller annotations
     match the sidecar spec.
+
+    ``op_kind`` picks the per-op error baseline; see
+    ``_OP_BASELINE_CODES``. Aligns the Spring controller annotations
+    with the OpenAPI generator's per-op shape so the sidecar and
+    controllers agree.
     """
     if return_type == "Void":
         return [
             '@ApiResponse(responseCode = "204", description = "No content")',
-            *_problem_responses(error_class, extra_codes, reason_phrases),
+            *_problem_responses(error_class, extra_codes, reason_phrases, op_kind),
         ]
     if return_type.startswith("List<"):
         inner = return_type[len("List<") : -1]
@@ -2079,27 +2292,28 @@ def _success_and_problem_responses(
         '@ApiResponse(responseCode = "200", description = "OK",'
         f" content = {{{', '.join(contents)}}})"
     )
-    return [success, *_problem_responses(error_class, extra_codes, reason_phrases)]
+    return [success, *_problem_responses(error_class, extra_codes, reason_phrases, op_kind)]
 
 
 def _problem_responses(
     error_class: str = "Problem",
     extra_codes: list[int] | None = None,
     reason_phrases: dict[int, str] | None = None,
+    op_kind: str = "other",
 ) -> list[str]:
-    """RFC 7807 error contract — same Problem-shaped DTO under
-    ``application/problem+json`` across every error response.
+    """RFC 7807 error contract — Problem-shaped DTO under
+    ``application/problem+json`` for the per-op error baseline plus
+    any extra codes the schema declared via ``openapi.error_responses``.
 
-    The 404 / 422 / 500 trio is always declared (today's contract).
-    ``extra_codes`` (#104) adds further codes from
-    ``openapi.error_responses``; duplicates with the baseline trio
-    are dropped silently so the wire shape matches the sidecar."""
-    baseline = {
-        404: "Not found",
-        422: "Validation error",
-        500: "Server error",
+    The baseline is selected by ``op_kind`` so a list op doesn't
+    declare a phantom 404, a create op doesn't declare a 404, etc.
+    Aligned with the OpenAPI generator's per-op error shape so the
+    sidecar spec and the controller annotations agree wire-for-wire.
+    """
+    baseline_codes = _OP_BASELINE_CODES.get(op_kind, _OP_BASELINE_CODES["other"])
+    codes: dict[int, str] = {
+        code: (reason_phrases or {}).get(code, f"HTTP {code}") for code in baseline_codes
     }
-    codes: dict[int, str] = dict(baseline)
     for code in extra_codes or ():
         if code in codes:
             continue

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -237,12 +237,20 @@ class TestApiSurface:
         assert '"text/turtle"' in src
         assert '"application/rdf+xml"' in src
 
-    def test_problem_responses_declared_on_every_op(self, files):
+    def test_problem_responses_match_openapi_per_op_shape(self, files):
+        """Per-op error baselines align with the OpenAPI generator
+        (#7 follow-up): list ops carry no baseline error; create has
+        422 only; read/delete have 404; update / patch carry both;
+        attach has both; detach has 404 only. ``openapi.error_responses``
+        adds further codes uniformly across ops."""
         src = files["io/example/dcat/api/CatalogApi.java"]
-        # Every op carries the Problem error contract for 404/422/500.
+        # The controller for Catalog should carry at least one 404 and
+        # one 422 (across its read / update ops) and reference the
+        # error DTO.
         assert src.count('responseCode = "404"') >= 1
         assert src.count('responseCode = "422"') >= 1
-        assert src.count('responseCode = "500"') >= 1
+        # 500 is no longer in the baseline — schemas opt in via
+        # ``openapi.error_responses`` for server-side error contracts.
         assert "Problem.class" in src
 
 
@@ -1000,18 +1008,50 @@ class TestParityWithOpenApiSide:
             if relpath.endswith("Api.java")
         }
 
-        # Collect spring {url: set_of_request_param_wire_names}
-        getmapping_re = re.compile(
-            r'@GetMapping\(value\s*=\s*"([^"]+)"[^)]*\)\s*\n'
-            r"[^\n]*\n\s*default ResponseEntity[^(]*\([^)]*\)",
-            re.DOTALL,
-        )
+        # Capture the URL and the FULL method body (up to the closing
+        # ``)`` of the method signature). The previous regex stopped
+        # at the first nested ``)`` inside any ``@RequestParam(...)``
+        # — fine when methods only had ``limit`` / ``offset``, but it
+        # silently undercount on rich filter params (the #4
+        # follow-up). Match instead by locating the method-signature
+        # opening paren and scanning forward for the matching close.
+        getmapping_url_re = re.compile(r'@GetMapping\(value\s*=\s*"([^"]+)"', re.DOTALL)
+
+        def _params_between_method_parens(source: str, start: int) -> str:
+            """Return the slice of ``source`` between the
+            method-signature's opening ``(`` and its matching ``)``,
+            handling nested ``(`` / ``)`` inside annotations."""
+            method_open = source.find("(", start)
+            depth = 0
+            i = method_open
+            while i < len(source):
+                if source[i] == "(":
+                    depth += 1
+                elif source[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        return source[method_open : i + 1]
+                i += 1
+            return ""
+
         spring_query_params: dict[str, set[str]] = {}
         for source in java_files.values():
-            for m in getmapping_re.finditer(source):
+            for m in getmapping_url_re.finditer(source):
                 url = m.group(1)
-                signature = m.group(0)
-                wire_names = set(request_param_re.findall(signature))
+                # Walk forward from the @GetMapping match to find the
+                # ``default ResponseEntity...`` method signature for
+                # that mapping.
+                default_idx = source.find("default ResponseEntity", m.end())
+                if default_idx == -1:
+                    continue
+                # Sanity check: the next `default ResponseEntity` must
+                # belong to THIS @GetMapping (i.e. no other
+                # @GetMapping in between).
+                next_get = source.find("@GetMapping", m.end())
+                if next_get != -1 and next_get < default_idx:
+                    continue
+                method_params = _params_between_method_parens(source, default_idx)
+                wire_names = set(request_param_re.findall(method_params))
                 if wire_names:
                     spring_query_params.setdefault(url, set()).update(wire_names)
 
@@ -1689,3 +1729,266 @@ classes:
         # The original wire name must be preserved on the @JsonProperty.
         assert '@JsonProperty("class")' in dto
         assert '@JsonProperty("default")' in dto
+
+
+class TestSpringPaginationAndEnvelope:
+    """Coverage for the #4 follow-up: Spring controllers now honour
+    ``openapi.pagination`` / ``openapi.list_envelope`` /
+    ``openapi.list_query_params`` alongside the sidecar, so the live
+    springdoc view matches the static spec wire-for-wire."""
+
+    SCHEMA = """\
+id: https://example.org/spring_page
+name: spring_page_test
+default_range: string
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+      openapi.pagination: cursor
+      openapi.list_envelope: PagedDatasets
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      title: { range: string }
+  PagedDatasets:
+    attributes:
+      items: { range: Dataset, multivalued: true }
+      nextCursor: { range: string }
+"""
+
+    @pytest.fixture
+    def files(self, tmp_path) -> dict:
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        return SpringServerGenerator(str(fixture), package="io.example.page").build()
+
+    def test_controller_uses_envelope_return_type(self, files):
+        api = files["io/example/page/api/DatasetApi.java"]
+        assert "ResponseEntity<PagedDatasets>" in api
+        assert "ResponseEntity<List<Dataset>>" not in api
+
+    def test_controller_emits_cursor_query_params(self, files):
+        api = files["io/example/page/api/DatasetApi.java"]
+        assert '@RequestParam(name = "cursor"' in api
+        assert '@RequestParam(name = "pageSize"' in api
+
+    def test_controller_drops_legacy_limit_offset_under_dialect(self, files):
+        api = files["io/example/page/api/DatasetApi.java"]
+        # Under a declared pagination dialect, the legacy ``limit``
+        # /``offset`` baseline must NOT also be emitted (would mean
+        # duplicate / contradictory paging contracts).
+        assert '@RequestParam(name = "limit"' not in api
+        assert '@RequestParam(name = "offset"' not in api
+
+
+class TestSpringExtraListQueryParams:
+    """`openapi.list_query_params` (JSON array) now produces matching
+    `@RequestParam` declarations on the Spring controller (#4)."""
+
+    SCHEMA = """\
+id: https://example.org/spring_extra
+name: spring_extra
+default_range: string
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+      openapi.list_query_params: |
+        [{"name": "filterBy", "type": "string"},
+         {"name": "archived", "type": "boolean"}]
+    attributes:
+      id: { identifier: true, range: string, required: true }
+"""
+
+    @pytest.fixture
+    def files(self, tmp_path) -> dict:
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        return SpringServerGenerator(str(fixture), package="io.example.extra").build()
+
+    def test_extra_string_param_emits_string_type(self, files):
+        api = files["io/example/extra/api/DatasetApi.java"]
+        assert '@RequestParam(name = "filterBy"' in api
+        assert "String filterBy" in api
+
+    def test_extra_boolean_param_emits_boolean_type(self, files):
+        api = files["io/example/extra/api/DatasetApi.java"]
+        assert '@RequestParam(name = "archived"' in api
+        assert "Boolean archived" in api
+
+
+class TestProfileIncludeTypoDetection:
+    """`openapi.profile.<n>.include_classes` / `include_slots` now
+    detect typos in the referenced names (#8) — silently nuking the
+    entire schema because of a misspelled class name was the worst
+    outcome of the prior "accepted but ignored" behaviour."""
+
+    def test_unknown_class_name_in_include_classes_raises(self, tmp_path):
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/profile_typo\n"
+            "name: profile_typo\n"
+            "default_range: string\n"
+            "annotations:\n"
+            "  openapi.profile.partner.include_classes: Cataog\n"
+            "classes:\n"
+            "  Catalog:\n"
+            '    annotations: { openapi.resource: "true" }\n'
+            "    attributes:\n"
+            "      id: { identifier: true, range: string, required: true }\n"
+        )
+        with pytest.raises(ValueError, match=r"unknown class names.*Cataog"):
+            OpenAPIGenerator(str(fixture), profile="partner").serialize()
+
+    def test_unknown_class_in_exclude_classes_also_raises(self, tmp_path):
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/profile_typo2\n"
+            "name: profile_typo2\n"
+            "default_range: string\n"
+            "annotations:\n"
+            "  openapi.profile.internal.exclude_classes: Misspelled\n"
+            "classes:\n"
+            "  Catalog:\n"
+            '    annotations: { openapi.resource: "true" }\n'
+            "    attributes:\n"
+            "      id: { identifier: true, range: string, required: true }\n"
+        )
+        with pytest.raises(ValueError, match=r"unknown class names.*Misspelled"):
+            OpenAPIGenerator(str(fixture), profile="internal").serialize()
+
+
+class TestErrorResponsesEmptyKwargDisablesSidecar:
+    """Coverage for #9 — Spring's ``error_responses=[]`` kwarg must
+    suppress injection in BOTH the controllers and the sidecar. The
+    prior ``[] or None`` collapse re-emitted the schema annotation's
+    codes in the sidecar."""
+
+    SCHEMA = """\
+id: https://example.org/err_disable
+name: err_disable
+default_range: string
+annotations:
+  openapi.error_responses: "400,500"
+classes:
+  Person:
+    annotations: { openapi.resource: "true", openapi.path: people }
+    attributes:
+      id: { identifier: true, range: string, required: true }
+"""
+
+    def test_explicit_empty_kwarg_skips_extras_in_sidecar(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        out = tmp_path / "out" / "java"
+        out.mkdir(parents=True)
+        SpringServerGenerator(str(fixture), package="io.example.disable", error_responses=[]).emit(
+            str(out)
+        )
+        spec_text = (tmp_path / "out" / "resources" / "openapi.yaml").read_text()
+        # The schema annotation declared 400 + 500 — but the explicit
+        # empty kwarg overrides it, so the sidecar must NOT carry
+        # either code.
+        assert "'400':" not in spec_text
+        assert "'500':" not in spec_text
+
+    def test_unset_kwarg_lets_sidecar_resolve_from_annotation(self, tmp_path):
+        # Sanity: when the kwarg is None, the sidecar still picks up
+        # the schema annotation's codes.
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        out = tmp_path / "out" / "java"
+        out.mkdir(parents=True)
+        SpringServerGenerator(str(fixture), package="io.example.disable2").emit(str(out))
+        spec_text = (tmp_path / "out" / "resources" / "openapi.yaml").read_text()
+        assert "'400':" in spec_text
+        assert "'500':" in spec_text
+
+
+class TestConcreteRootInJsonSubTypesWithoutExplicitTypeValue:
+    """Coverage for #6 — the Spring side now mirrors the OpenAPI
+    generator's fallback: a concrete polymorphic root with NO
+    explicit ``openapi.type_value`` still gets a ``@JsonSubTypes``
+    entry using its class name as the tag."""
+
+    SCHEMA = """\
+id: https://example.org/concrete_root_implicit
+name: concrete_root_implicit
+default_range: string
+classes:
+  Resource:
+    annotations:
+      openapi.resource: "true"
+      openapi.discriminator: resourceType
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      title: { range: string }
+  Dataset:
+    is_a: Resource
+    annotations: { openapi.resource: "true" }
+    attributes:
+      description: { range: string }
+"""
+
+    def test_root_appears_in_jsonsubtypes_even_without_type_value(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        files = SpringServerGenerator(str(fixture), package="io.example.implicit").build()
+        resource_dto = files["io/example/implicit/model/Resource.java"]
+        # Default tag falls back to class name (cls.name).
+        assert 'name = "Resource"' in resource_dto
+        assert "Resource.class" in resource_dto
+        assert 'name = "Dataset"' in resource_dto
+
+
+class TestMixinNarrowingDetected:
+    """Coverage for #5 — narrowing detection now walks mixins
+    alongside ``is_a``, so a class that narrows an inherited slot
+    via a mixin chain doesn't re-introduce the #106 covariance
+    crash under ``--codegen-friendly --flatten-inheritance``."""
+
+    def test_mixin_narrowing_triggers_codegen_fallback(self, tmp_path):
+        from linkml_openapi.generator import OpenAPIGenerator
+
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/mixin_narrow\n"
+            "name: mixin_narrow\n"
+            "default_range: string\n"
+            "classes:\n"
+            "  Distribution:\n"
+            "    attributes:\n"
+            "      id: { identifier: true, range: string, required: true }\n"
+            "  AcmeDistribution:\n"
+            "    is_a: Distribution\n"
+            "  HasDistributions:\n"
+            "    mixin: true\n"
+            "    annotations:\n"
+            "      openapi.discriminator: kind\n"
+            "    attributes:\n"
+            "      distribution:\n"
+            "        range: Distribution\n"
+            "        multivalued: true\n"
+            "  Dataset:\n"
+            "    mixins: [HasDistributions]\n"
+            '    annotations: { openapi.resource: "true" }\n'
+            "    attributes:\n"
+            "      id: { identifier: true, range: string, required: true }\n"
+            "  AcmeDataset:\n"
+            "    is_a: Dataset\n"
+            "    slot_usage:\n"
+            "      distribution:\n"
+            "        range: AcmeDistribution\n"
+        )
+        gen = OpenAPIGenerator(str(fixture))
+        gen.serialize()
+        # AcmeDataset narrowed via slot_usage on a slot inherited
+        # from the HasDistributions mixin chain. Detection must catch
+        # this and mark AcmeDataset.
+        assert "AcmeDataset" in gen._narrowing_subclasses


### PR DESCRIPTION
## Summary

PR B of the second code review batch — follow-on bugs surfaced after the security PR. Mix of correctness bugs and a single feature gap that closes the Spring↔OpenAPI parity story.

### Bugs

| # | Title | Fix |
|---|---|---|
| 5 | `_detect_narrowing_subclasses` ignored mixins | Walk `is_a` AND every `mixins:` entry |
| 6 | Spring `@JsonSubTypes` required explicit `openapi.type_value` on the root | Use `cls.name` fallback to mirror the OpenAPI side |
| 7 | Spring's error baseline diverged from OpenAPI's per-op shape | Per-op kind dispatch — list ops get nothing, create gets 422, read/delete get 404, etc. 500 dropped from baseline (schemas opt in via `openapi.error_responses`) |
| 8 | Profile `include_classes`/`include_slots`/`exclude_*` typo nuked the schema silently | Validate every name exists; raise with the misspelled tokens |
| 9 | `error_responses=[]` Spring kwarg silently fell back to the schema annotation in the sidecar | Track explicit-empty via `self.error_responses is not None` |
| 10 | `_HTTP_REASON_PHRASES` duplicated in two files | Extracted to `src/linkml_openapi/_http.py` |
| L9 | Java reserved-word list missing Java 9+/14+/17+ contextual keywords | Added `record`, `sealed`, `permits`, `var`, `yield`, `module`, etc. |
| L10 | Misleading ordering comment on `_path_item_has_operations` | Cleaned up |
| L11 | Whitespace-only `openapi.pagination` crashed on unknown dialect | Treat as "unset" |
| (parity) | `_get_slot_annotation_compat` treated JsonObj containers as a single annotation | Iterate JsonObj keys like the OpenAPI walker |

### Feature

**Spring controllers now honour `openapi.list_envelope` / `openapi.pagination` / `openapi.list_query_params` (#4).** Previously only the sidecar OpenAPI spec carried these — Spring controllers shipped `List<T>` + hardcoded `limit/offset` regardless of what the sidecar advertised. After this PR the controllers return the envelope class, emit the dialect's query params (`cursor`/`pageSize`, etc.), and inject any extra typed `@RequestParam` declarations. New `--error-responses` CLI flag on `gen-spring-server`. Live springdoc view now matches the static sidecar wire-for-wire.

### What's NOT in this PR

The API-surface / naming consistency findings (PR C) and the test-quality / perf cleanups (PR D) are still pending. They're additive / refactor-only and don't block this PR.

## Test plan

- [x] `pytest tests/` — **542 passed** (+11 new)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] Smoke: `bash examples/generate.sh` — no diff (examples already had `pagination=cursor` so the new behaviour produces no committed-output change)
- [ ] CI green

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_