### PR TITLE
refactor: shared utilities, Spring CLI symmetry, README rewrite for v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (refactor / docs / CLI symmetry)
+
+- **`gen-spring-server` CLI gains four new sidecar-affecting flags**
+  to mirror `gen-openapi` (#14): `--profile`, `--emit-namespaces`,
+  `--rdf-resolved-map`, `--post-process`. They thread through to the
+  `OpenAPIGenerator` invocation that writes the sidecar OpenAPI
+  spec to `resources/openapi.yaml`. The Java controller emission
+  is unchanged — these flags only affect the sidecar.
+- **`src/linkml_openapi/_utils.py`** holds the shared
+  helpers (`pluralize`, `to_snake_case`, `is_truthy` / `is_falsy`,
+  `parse_csv`, `to_path_segment`, `is_irregular_plural_hint`) that
+  both generators need (#13). The Spring emitter imports directly
+  from `_utils` instead of reaching into `linkml_openapi.generator`
+  for private names. Existing `_pluralize` / `_to_snake_case` /
+  etc. names in `generator.py` are preserved as thin shims so
+  any external caller that touched them keeps working — they just
+  delegate to `_utils`.
+- **README documents the v0.15.0 features**: `openapi.expose`,
+  `openapi.pagination` (`cursor` / `page-size` / `page-offset` /
+  `none`), `openapi.list_envelope`, `openapi.list_query_params`,
+  `openapi.error_responses`, `openapi.codegen_inheritance`. The
+  annotation summary table now lists 22 additional annotations
+  (`openapi.discriminator`, the `legacy_type_*` cluster,
+  `request_class` / `update_class`, the profile keys, and the
+  v0.15.0 additions). The CLI section now describes
+  `gen-spring-server` alongside `gen-openapi`.
+- **Dataclass field-default conventions documented** on both
+  `OpenAPIGenerator` and `SpringServerGenerator` class docstrings
+  (#15). Tri-state semantics (`None` = "read schema annotation";
+  explicit value = "override") spelled out for `error_responses`,
+  `path_style`, `path_prefix`, `resource_filter`, `profile`,
+  `reactive`. Empty-collection defaults (`post_processors`,
+  `sidecar_post_processors`) clarified as non-tri-state.
+
 ### Added
 
 - **Spring controllers honour `openapi.list_envelope` /

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ pip install linkml-openapi
 
 ### CLI
 
+Two entry points:
+
+- **`gen-openapi`** emits an OpenAPI 3.0/3.1 spec.
+- **`gen-spring-server`** emits a Spring Boot Java source tree (controller interfaces + DTOs) plus a sidecar OpenAPI spec at `resources/openapi.yaml`.
+
 ```bash
 # Generate OpenAPI YAML from a LinkML schema
 gen-openapi schema.yaml > openapi.yaml
@@ -38,7 +43,19 @@ gen-openapi schema.yaml --api-title "My API" --api-version 2.0.0 --server-url ht
 
 # Only generate endpoints for specific classes
 gen-openapi schema.yaml --classes Person --classes Address
+
+# Inject standard 4xx/5xx error responses on every operation
+gen-openapi schema.yaml --error-responses 400,401,403,500,503 > openapi.yaml
+
+# Emit a Spring Boot server tree under ./build/spring-src
+gen-spring-server schema.yaml --output ./build/spring-src --package com.example.api
+
+# Spring + reactive (WebFlux) + URL prefix
+gen-spring-server schema.yaml --output ./build/spring-src \
+    --package com.example.api --reactive --path-prefix /api/v1
 ```
+
+The Spring CLI mirrors `gen-openapi`'s flags where they affect the sidecar OpenAPI spec (`--error-responses`, `--profile`, `--emit-namespaces`, `--rdf-resolved-map`, `--post-process`); reactive / path-style / path-prefix also apply to the controller emission.
 
 ### Python
 
@@ -281,6 +298,28 @@ The OpenAPI generator output is not affected.
 Reactive apps depend on `spring-boot-starter-webflux` instead of
 `spring-boot-starter-web` (the starters are mutually exclusive).
 
+#### `openapi.error_responses` — standard 4xx/5xx codes on every op
+
+Inject a shared list of error responses on every emitted operation,
+each described with its standard IANA reason phrase and referencing
+the active error class (`Problem` by default, or the user-defined
+class set via `openapi.error_class`):
+
+```yaml
+annotations:
+  openapi.error_responses: "400,401,403,500,503"
+```
+
+Override per-build with `--error-responses 400,401,403,500,503` on
+either CLI or `error_responses=[400, 401, 403, 500, 503]` in the
+Python API. An explicit empty list `[]` disables injection even when
+the schema annotation declares one.
+
+The Spring side mirrors the OpenAPI side per-op: list endpoints
+declare no baseline error, create gets `422`, read/delete get `404`,
+update/patch get `404+422`, and any `openapi.error_responses` codes
+merge in uniformly across all ops.
+
 ### Class-level annotations
 
 Annotations are placed in the `annotations` block of a class definition.
@@ -358,6 +397,120 @@ Sets a custom URL path segment for the resource's endpoints.
     annotations:
       openapi.resource: "true"
       openapi.path: people     # GET /people, GET /people/{id}
+```
+
+#### `openapi.expose`
+
+Suppress path emission for an `openapi.resource: "true"` class
+while keeping it as a referenceable component schema. Useful when
+the class is part of the wire contract (other resources `$ref` it)
+but CRUD ownership lives in a different service:
+
+```yaml
+classes:
+  Person:
+    annotations: { openapi.resource: "true" }
+    attributes:
+      role: { range: Role, inlined: true }
+  Role:
+    annotations:
+      openapi.resource: "true"
+      openapi.expose: "false"   # Role schema emitted, /roles paths suppressed
+    attributes:
+      id: { identifier: true, required: true }
+      label: string
+```
+
+Both `gen-openapi` and `gen-spring-server` honour the annotation —
+the Spring side skips the controller interface and the sidecar OpenAPI spec.
+
+#### `openapi.pagination` / `openapi.list_envelope` / `openapi.list_query_params`
+
+Three composable per-class annotations for list endpoints.
+
+**`openapi.pagination`** picks a query-param dialect:
+
+| Value | Injected query params |
+|-------|-----------------------|
+| `cursor` | `cursor` (string), `pageSize` (integer) |
+| `page-size` | `page` (integer), `size` (integer) |
+| `page-offset` | `offset` (integer), `limit` (integer) |
+| `none` | (no pagination params at all) |
+| unset | Legacy `limit`/`offset` baseline (today's behaviour) |
+
+```yaml
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.pagination: cursor
+```
+
+When a dialect is declared, the legacy `limit`/`offset` are NOT
+also emitted (no duplication).
+
+**`openapi.list_envelope`** wraps the 200 response in a `$ref` to a
+declared envelope class instead of returning a bare array:
+
+```yaml
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.list_envelope: PagedDatasets
+  PagedDatasets:
+    attributes:
+      items: { range: Dataset, multivalued: true }
+      nextCursor: string
+      hasMore: boolean
+```
+
+The envelope class owns the array slot pointing at the listed
+resource; the generator just routes the list-op response at it.
+
+**`openapi.list_query_params`** injects extra typed query
+parameters on top of slot-driven filters:
+
+```yaml
+classes:
+  Dataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.list_query_params: |
+        [{"name": "filterBy", "type": "string", "description": "Filter expression"},
+         {"name": "includeArchived", "type": "boolean"}]
+```
+
+Value is a JSON array of `{name, type, description?, required?}`
+objects. Types: `string` / `integer` / `number` / `boolean` /
+`array`.
+
+The Spring side honours all three — controllers return the
+envelope class, accept the dialect's query params, and add the
+extra `@RequestParam` declarations.
+
+#### `openapi.codegen_inheritance` — escape hatch for `--codegen-friendly`
+
+When `--codegen-friendly` is on, the generator normally emits a
+schema-level discriminator on the polymorphic root and replaces
+use-site `oneOf` with a `$ref` to the parent (the parent owns the
+`mapping` for codegen dispatch). This collides with
+openapi-generator's Java inheritance template when a subclass
+narrows an inherited slot via `slot_usage`: the generated subclass
+emits a covariant override that doesn't compile.
+
+The generator detects narrowing automatically and falls back to
+inline use-site `oneOf` for the affected root. Pass
+`openapi.codegen_inheritance: "false"` on the root to force the
+fallback for any root, regardless of auto-detection:
+
+```yaml
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.discriminator: resourceType
+      openapi.codegen_inheritance: "false"   # use-site oneOf only
 ```
 
 #### `openapi.operations`
@@ -1147,6 +1300,27 @@ endpoints regardless of any of these annotations.
 | `openapi.path_variable` | slot (via `slot_usage`) | `"true"` | Identifier slot |
 | `openapi.path_segment` | slot (via `slot_usage`) | URL segment string | Slot name with active path-style applied |
 | `openapi.query_param` | slot (via `slot_usage`) | `"true"` / token list / `"false"` | Auto-inferred from slot type |
+| `openapi.discriminator` | class | property name string | None (no polymorphic dispatch) |
+| `openapi.type_value` | class | string | Falls back to class name |
+| `openapi.legacy_type_field` | class | wire JSON property name | None — no legacy synthesis |
+| `openapi.legacy_type_value` | class | wire value string | (required when ancestor sets `legacy_type_field`) |
+| `openapi.legacy_type_codegen_name` | class | Java-side field name | Wire field name passed through unchanged |
+| `openapi.request_class` / `openapi.update_class` | class | LinkML class name | Resource class itself |
+| `openapi.body` | slot (via `slot_usage`) | `"false"` | Slot lands on parent body |
+| `openapi.nested` | slot (via `slot_usage`) | `"false"` | Nested endpoint emits |
+| `openapi.expose` | class | `"false"` | Path emission enabled |
+| `openapi.error_class` | schema | LinkML class name | Synthesised RFC 7807 Problem |
+| `openapi.error_responses` | schema | comma-separated 4xx/5xx codes | None — only per-op baseline emitted |
+| `openapi.pagination` | class | `cursor` / `page-size` / `page-offset` / `none` | Legacy `limit`/`offset` baseline |
+| `openapi.list_envelope` | class | LinkML class name | Bare array response |
+| `openapi.list_query_params` | class | JSON array of `{name, type, description?}` | None |
+| `openapi.codegen_inheritance` | class | `"false"` | `--codegen-friendly` uses parent-$ref strategy |
+| `openapi.reactive` | schema | `"true"` / `"false"` | Off — blocking Spring MVC |
+| `openapi.profile.<name>.exclude_classes` | schema | comma-separated class names | None |
+| `openapi.profile.<name>.include_classes` | schema | comma-separated class names | None (all included) |
+| `openapi.profile.<name>.exclude_slots` | schema | comma-separated slot names | None |
+| `openapi.profile.<name>.include_slots` | schema | comma-separated slot names | None (all included) |
+| `openapi.profile.<name>.description` | schema | description string | None |
 | `openapi.format` | slot | format string | derived from slot range |
 
 ## Type Mapping

--- a/src/linkml_openapi/_utils.py
+++ b/src/linkml_openapi/_utils.py
@@ -1,0 +1,125 @@
+"""Shared utilities for the OpenAPI generator and the Spring emitter.
+
+Lives in its own module so the Spring side can import without
+reaching into ``linkml_openapi.generator`` for private names —
+mirrors the pattern established by ``_chains.py`` / ``_query_params.py``
+/ ``_http.py``.
+
+Membership rule for this module: a helper belongs here when it has
+no dependency on the LinkML SchemaView, is needed by both emitters,
+and is small enough that copy-paste would be tempting otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Class-name suffixes that are already plural (or unchanged in plural form)
+# and should be returned as-is from `pluralize`.
+_INVARIANT_PLURAL_SUFFIXES = ("series", "species", "genus")
+
+# Class-name suffixes that become irregular in plural form. We don't try
+# to inflect these — we just emit a heads-up so the user can set
+# `openapi.path` explicitly. Listed lower-case for case-insensitive match.
+_IRREGULAR_HINT_SUFFIXES = (
+    "child",
+    "datum",
+    "criterion",
+    "phenomenon",
+    "analysis",
+    "thesis",
+    "axis",
+    "crisis",
+)
+
+
+def pluralize(name: str) -> str:
+    """Pluralize an English noun for URL paths.
+
+    Handles the common regular-pluralization patterns (`-s/-x/-z/-ch/-sh`,
+    consonant-`y`, default `+s`) and the most common already-plural Latin
+    forms used in domain modeling (`series`, `species`, `genus`). For
+    irregular nouns (`child`, `person`, `index`, …) the function falls
+    back to `+s` and the caller is expected to set `openapi.path`
+    explicitly when correctness matters.
+    """
+    if not name:
+        return name
+
+    lower = name.lower()
+    for inv in _INVARIANT_PLURAL_SUFFIXES:
+        if lower.endswith(inv):
+            return name
+
+    if name.endswith(("ch", "sh")):
+        return name + "es"
+    if name.endswith(("s", "x", "z")):
+        return name + "es"
+    if name.endswith("y") and name[-2:] not in ("ay", "ey", "oy", "uy"):
+        return name[:-1] + "ies"
+    return name + "s"
+
+
+def is_irregular_plural_hint(name: str) -> bool:
+    """True when `name` looks like it would be misled by ``pluralize``'s
+    default rules. Used by the OpenAPI generator to surface a warning
+    at generation time so the user can set ``openapi.path`` explicitly.
+    """
+    if not name:
+        return False
+    lower = name.lower()
+    return any(lower.endswith(suf) for suf in _IRREGULAR_HINT_SUFFIXES)
+
+
+def to_snake_case(name: str) -> str:
+    """Convert CamelCase to snake_case."""
+    s = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", name)
+    return s.lower()
+
+
+def to_path_segment(name: str) -> str:
+    """Convert class name to URL path segment: CamelCase → snake_case → plural."""
+    return pluralize(to_snake_case(name))
+
+
+def is_truthy(value: object | None) -> bool:
+    """Check if an annotation value represents a boolean true.
+
+    ``None`` (annotation absent) is not truthy. Use this for opt-in
+    annotations (``openapi.resource: "true"``, etc.) so the parsing
+    rule is identical across both generators.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() == "true"
+
+
+def is_falsy(value: object | None) -> bool:
+    """Check if an annotation value represents a boolean false.
+
+    ``None`` (annotation absent) is NOT falsy — distinguish "the
+    author explicitly opted out" from "the author didn't say anything."
+    Use this for opt-out annotations (``openapi.expose: "false"``,
+    ``openapi.codegen_inheritance: "false"``, etc.) so the falsy
+    parsing rule is identical across both generators.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return not value
+    return str(value).strip().lower() == "false"
+
+
+def parse_csv(value: str | None, *, lowercase: bool = False) -> list[str]:
+    """Split a comma-separated annotation value, trimming whitespace
+    and empties. ``lowercase=True`` normalises every token (used for
+    case-insensitive comparisons of HTTP methods, operation kinds,
+    etc.)."""
+    if not value:
+        return []
+    out = [t.strip() for t in str(value).split(",")]
+    if lowercase:
+        out = [t.lower() for t in out]
+    return [t for t in out if t]

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -48,6 +48,15 @@ from linkml_openapi._query_params import (
     QueryParamSpec,
     walk_query_params,
 )
+from linkml_openapi._utils import (
+    is_falsy,
+    is_irregular_plural_hint,
+    is_truthy,
+    parse_csv,
+    pluralize,
+    to_path_segment,
+    to_snake_case,
+)
 
 # LinkML range → OpenAPI DataType mapping
 RANGE_TYPE_MAP: dict[str, dict[str, Any]] = {
@@ -67,102 +76,36 @@ RANGE_TYPE_MAP: dict[str, dict[str, Any]] = {
 
 
 # Class-name suffixes that are already plural (or unchanged in plural form)
-# and should be returned as-is from `_pluralize`.
-_INVARIANT_PLURAL_SUFFIXES = ("series", "species", "genus")
-
-# Class-name suffixes that become irregular in plural form. We don't try
-# to inflect these — we just emit a heads-up so the user can set
-# `openapi.path` explicitly. Listed lower-case for case-insensitive match.
-_IRREGULAR_HINT_SUFFIXES = (
-    "child",
-    "datum",
-    "criterion",
-    "phenomenon",
-    "analysis",
-    "thesis",
-    "axis",
-    "crisis",
-)
+# and the irregular-plural hint list live in ``_utils`` so both emitters
+# share one source of truth (see _utils.pluralize / is_irregular_plural_hint).
 
 
 def _pluralize(name: str) -> str:
-    """Pluralize an English noun for URL paths.
-
-    Handles the common regular-pluralization patterns (`-s/-x/-z/-ch/-sh`,
-    consonant-`y`, default `+s`) and the most common already-plural Latin
-    forms used in domain modeling (`series`, `species`, `genus`). For
-    irregular nouns (`child`, `person`, `index`, …) the function falls
-    back to `+s` and the caller is expected to set `openapi.path`
-    explicitly when correctness matters; `_warn_on_irregular_plural`
-    surfaces a warning at generation time.
-    """
-    if not name:
-        return name
-
-    lower = name.lower()
-    for inv in _INVARIANT_PLURAL_SUFFIXES:
-        if lower.endswith(inv):
-            return name
-
-    if name.endswith(("ch", "sh")):
-        return name + "es"
-    if name.endswith(("s", "x", "z")):
-        return name + "es"
-    if name.endswith("y") and name[-2:] not in ("ay", "ey", "oy", "uy"):
-        return name[:-1] + "ies"
-    return name + "s"
+    return pluralize(name)
 
 
 def _is_irregular_plural_hint(name: str) -> bool:
-    """True when `name` looks like it would be misled by the default rules."""
-    if not name:
-        return False
-    lower = name.lower()
-    return any(lower.endswith(suf) for suf in _IRREGULAR_HINT_SUFFIXES)
+    return is_irregular_plural_hint(name)
 
 
 def _to_snake_case(name: str) -> str:
-    """Convert CamelCase to snake_case."""
-    s = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", name)
-    return s.lower()
+    return to_snake_case(name)
 
 
 def _is_truthy(value: object) -> bool:
-    """Check if an annotation value represents a boolean true."""
-    if isinstance(value, bool):
-        return value
-    return str(value).lower() == "true"
+    return is_truthy(value)
 
 
 def _is_falsy(value: object | None) -> bool:
-    """Check if an annotation value represents a boolean false.
-
-    ``None`` (annotation absent) is NOT falsy — distinguish "the
-    author explicitly opted out" from "the author didn't say anything."
-    Use this for opt-out annotations (``openapi.expose: "false"``,
-    ``openapi.codegen_inheritance: "false"``, etc.) so the falsy
-    parsing rule is identical across the file.
-    """
-    if value is None:
-        return False
-    if isinstance(value, bool):
-        return not value
-    return str(value).strip().lower() == "false"
+    return is_falsy(value)
 
 
 def _to_path_segment(name: str) -> str:
-    """Convert class name to URL path segment: CamelCase → snake_case → plural."""
-    return _pluralize(_to_snake_case(name))
+    return to_path_segment(name)
 
 
 def _parse_csv(value: str | None, *, lowercase: bool = False) -> list[str]:
-    """Split a comma-separated annotation value, trimming whitespace and empties."""
-    if not value:
-        return []
-    out = [t.strip() for t in str(value).split(",")]
-    if lowercase:
-        out = [t.lower() for t in out]
-    return [t for t in out if t]
+    return parse_csv(value, lowercase=lowercase)
 
 
 # URL path-segment styles. Module-level so the CLI can import the
@@ -186,7 +129,39 @@ ITEM_OPERATIONS: frozenset[str] = frozenset({OP_READ, OP_UPDATE, OP_PATCH, OP_DE
 
 @dataclass
 class OpenAPIGenerator(Generator):
-    """Generate an OpenAPI 3.1 specification from a LinkML schema."""
+    """Generate an OpenAPI 3.1 specification from a LinkML schema.
+
+    **Field default-value conventions:**
+
+    *Tri-state* fields (``None`` / explicit value) distinguish "the
+    caller didn't touch this knob" from "the caller explicitly
+    overrode this value." A ``None`` default means "fall back to the
+    matching ``openapi.*`` schema annotation, or the documented
+    fallback if no annotation exists." An explicit value (including
+    an empty list / string) means "use exactly this; do not consult
+    the schema annotation." Tri-state fields documented as such:
+
+    - ``error_responses``: ``None`` reads ``openapi.error_responses``;
+      ``[]`` explicitly disables injection; non-empty list overrides
+      the annotation.
+    - ``path_style``: ``None`` reads ``openapi.path_style`` (default
+      ``"snake_case"``); explicit value wins.
+    - ``path_prefix``: ``None`` reads ``openapi.path_prefix`` (default
+      no prefix); explicit value wins.
+    - ``resource_filter``: ``None`` defaults to "all
+      ``openapi.resource: true`` classes"; explicit list narrows.
+    - ``profile``: ``None`` activates no profile; an explicit name
+      activates the matching ``openapi.profile.<name>`` block.
+
+    *Bool* fields (``True`` / ``False`` defaults) are not tri-state —
+    the schema annotation (when one exists) is read independently
+    and the ``True``/``False`` field acts as a CLI / kwarg override
+    only when explicitly set. Documented per-field where relevant.
+
+    *Empty-collection* defaults (``post_processors: list[str] = []``)
+    mean "no entries" — they are not tri-state. An empty list and a
+    missing schema annotation produce identical behaviour.
+    """
 
     # ClassVar overrides
     generatorname: ClassVar[str] = os.path.basename(__file__)

--- a/src/linkml_openapi/spring/cli.py
+++ b/src/linkml_openapi/spring/cli.py
@@ -83,6 +83,61 @@ from linkml_openapi.spring.generator import SpringServerGenerator
         "springdoc's runtime view matches."
     ),
 )
+@click.option(
+    "--profile",
+    default=None,
+    metavar="NAME",
+    help=(
+        "Active profile name for the sidecar OpenAPI spec. The "
+        "profile must be declared via `openapi.profile.<NAME>.<key>` "
+        "schema annotations; classes / slots listed in `exclude_*` / "
+        "`include_*` are filtered out of the sidecar. Mirrors "
+        "`gen-openapi --profile`. NOTE: profile filtering applies "
+        "only to the sidecar spec — the Spring controllers are "
+        "always emitted from the full schema. Use this when the "
+        "Spring service hosts the full API surface but the sidecar "
+        "needs a narrower partner/external view."
+    ),
+)
+@click.option(
+    "--emit-namespaces",
+    "emit_namespaces",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit a top-level `x-namespaces` map on the sidecar OpenAPI "
+        "spec (CURIE prefix → expanded IRI) drawn from the LinkML "
+        "schema's `prefixes:` block. Lets RDF runtimes build "
+        "JSON-LD `@context` blocks / Turtle `@prefix` declarations "
+        "from a single source of truth. Mirrors `gen-openapi "
+        "--emit-namespaces`. Defaults to off."
+    ),
+)
+@click.option(
+    "--rdf-resolved-map",
+    "rdf_resolved_map",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit `x-rdf-properties-resolved` + `x-ranges-resolved` on "
+        "every component schema in the sidecar — slot name → "
+        "expanded RDF predicate IRI / resolved range class names, "
+        "with inheritance via `allOf` already resolved. Mirrors "
+        "`gen-openapi --rdf-resolved-map`. Defaults to off."
+    ),
+)
+@click.option(
+    "--post-process",
+    "post_process",
+    default=None,
+    metavar="NAME[,NAME...]",
+    help=(
+        "Comma-separated list of registered post-processors to apply "
+        "to the sidecar OpenAPI spec. Mirrors `gen-openapi "
+        "--post-process`. See linkml_openapi.post_processors for the "
+        "registry."
+    ),
+)
 @click.version_option(__version__, "-V", "--version")
 def cli(
     yamlfile,
@@ -92,6 +147,10 @@ def cli(
     path_style: str | None,
     reactive: bool | None,
     error_responses: str | None,
+    profile: str | None,
+    emit_namespaces: bool,
+    rdf_resolved_map: bool,
+    post_process: str | None,
 ) -> None:
     """Generate Spring server source files directly from a LinkML schema."""
     parsed_codes: list[int] | None = None
@@ -105,6 +164,9 @@ def cli(
                 parsed_codes.append(int(token))
             except ValueError as exc:
                 raise click.BadParameter(f"--error-responses: {token!r} is not an integer") from exc
+    post_processors: list[str] = []
+    if post_process:
+        post_processors = [n.strip() for n in post_process.split(",") if n.strip()]
     gen = SpringServerGenerator(
         yamlfile,
         package=package,
@@ -112,6 +174,10 @@ def cli(
         path_style=path_style,
         reactive=reactive,
         error_responses=parsed_codes,
+        sidecar_profile=profile,
+        sidecar_emit_namespaces=emit_namespaces,
+        sidecar_rdf_resolved_map=rdf_resolved_map,
+        sidecar_post_processors=post_processors,
     )
     written = gen.emit(output)
     for path in written:

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -52,7 +52,8 @@ from linkml_openapi._chains import (
 )
 from linkml_openapi._http import HTTP_REASON_PHRASES
 from linkml_openapi._query_params import QueryParamSpec, walk_query_params
-from linkml_openapi.generator import _is_falsy, _to_snake_case
+from linkml_openapi._utils import is_falsy as _is_falsy
+from linkml_openapi._utils import to_snake_case as _to_snake_case
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
@@ -85,6 +86,14 @@ class SpringServerGenerator:
     Use :meth:`emit` to write the source tree to disk, or
     :meth:`build` to get the in-memory rendering as
     ``{relative_path: source_text}`` for testing.
+
+    **Field default-value conventions:** mirror the OpenAPI
+    generator's. Tri-state fields (``None`` = "read schema
+    annotation"; explicit value = "override") include
+    ``error_responses``, ``path_style``, ``path_prefix``,
+    ``reactive``. ``sidecar_*`` fields pass through to the
+    sidecar OpenAPI generator unchanged; they do NOT affect the
+    Java controller source.
     """
 
     schema_path: str
@@ -119,6 +128,17 @@ class SpringServerGenerator:
     # None falls back to the schema-level ``openapi.error_responses``
     # annotation; an empty list explicitly disables injection.
     error_responses: list[int] | None = None
+    # Sidecar-only knobs (#14 follow-up): pass through to the
+    # ``OpenAPIGenerator`` invocation in ``_render_openapi_spec`` so a
+    # user moving from ``gen-openapi`` to ``gen-spring-server`` doesn't
+    # lose access to profiles, RDF resolved maps, namespaces, or
+    # post-processors. These do NOT affect the Spring controller
+    # source — only the sidecar OpenAPI spec written to
+    # ``resources/openapi.yaml``.
+    sidecar_profile: str | None = None
+    sidecar_emit_namespaces: bool = False
+    sidecar_rdf_resolved_map: bool = False
+    sidecar_post_processors: list[str] = field(default_factory=list)
 
     _sv: SchemaView = field(init=False)
     _env: Environment = field(init=False)
@@ -454,6 +474,10 @@ class SpringServerGenerator:
             path_prefix=self._effective_path_prefix or None,
             path_style=self.path_style,
             error_responses=sidecar_error_responses,
+            profile=self.sidecar_profile,
+            emit_namespaces=self.sidecar_emit_namespaces,
+            rdf_resolved_map=self.sidecar_rdf_resolved_map,
+            post_processors=list(self.sidecar_post_processors),
         ).serialize()
 
     def build(self) -> dict[str, str]:

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -1992,3 +1992,56 @@ class TestMixinNarrowingDetected:
         # from the HasDistributions mixin chain. Detection must catch
         # this and mark AcmeDataset.
         assert "AcmeDataset" in gen._narrowing_subclasses
+
+
+class TestSpringSidecarFlagPassthrough:
+    """``gen-spring-server`` now exposes the same sidecar-affecting
+    flags as ``gen-openapi`` (#14): ``--profile``,
+    ``--emit-namespaces``, ``--rdf-resolved-map``, ``--post-process``.
+    They thread through to the OpenAPIGenerator that builds the
+    sidecar spec written under ``resources/openapi.yaml``."""
+
+    SCHEMA = """\
+id: https://example.org/spring_passthrough
+name: spring_passthrough
+prefixes:
+  acme: https://example.com/acme/
+default_range: string
+classes:
+  Dataset:
+    annotations: { openapi.resource: "true", openapi.path: datasets }
+    class_uri: acme:Dataset
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      title: { range: string }
+"""
+
+    def test_emit_namespaces_reaches_sidecar(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        out = tmp_path / "out" / "java"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        SpringServerGenerator(
+            str(fixture),
+            package="io.example.pass",
+            sidecar_emit_namespaces=True,
+        ).emit(str(out))
+        spec_text = (tmp_path / "out" / "resources" / "openapi.yaml").read_text()
+        assert "x-namespaces:" in spec_text
+        assert "acme: https://example.com/acme/" in spec_text
+
+    def test_rdf_resolved_map_reaches_sidecar(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(self.SCHEMA)
+        out = tmp_path / "out" / "java"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        SpringServerGenerator(
+            str(fixture),
+            package="io.example.pass2",
+            sidecar_rdf_resolved_map=True,
+        ).emit(str(out))
+        spec_text = (tmp_path / "out" / "resources" / "openapi.yaml").read_text()
+        # Resolved-map mode emits the flattened map alongside
+        # per-property `x-rdf-property` extensions; either marker
+        # indicates the flag reached the sidecar.
+        assert "x-rdf-class" in spec_text  # class_uri on Dataset gets surfaced


### PR DESCRIPTION
## Summary

PR C of the second code-review batch — additive consistency cleanups. No wire-shape changes. Targets #13, #14, #15, #16 from the API-surface review. Breaking changes (#11 vocabulary cleanup, #12 list_query_params YAML-list) deferred to a separate PR.

### #13 — Shared `_utils.py`

`_pluralize`, `_to_snake_case`, `_is_truthy`, `_is_falsy`, `_parse_csv`, `_to_path_segment`, `_is_irregular_plural_hint` moved out of `generator.py` into a new `_utils.py` module. The Spring emitter now imports directly from `_utils` instead of reaching into `linkml_openapi.generator` for private (underscore-prefixed) names — mirrors the established `_chains.py` / `_query_params.py` / `_http.py` pattern. The old names in `generator.py` are preserved as thin shims so any external caller that touched them keeps working.

### #14 — Spring CLI symmetry

`gen-spring-server` gains four new flags that mirror `gen-openapi`:

| Flag | Effect |
|---|---|
| `--profile NAME` | Sidecar OpenAPI spec uses the named profile's `include_*` / `exclude_*` lists |
| `--emit-namespaces` | Sidecar emits `x-namespaces` map from the schema's `prefixes:` block |
| `--rdf-resolved-map` | Sidecar emits flattened `x-rdf-properties-resolved` / `x-ranges-resolved` |
| `--post-process NAME[,...]` | Run registered post-processors on the sidecar spec |

All four affect only the sidecar — the Spring controller emission is unchanged.

### #15 — Documented tri-state semantics

`OpenAPIGenerator` and `SpringServerGenerator` class docstrings now spell out the field-default conventions:

- **Tri-state** (`None` = "read schema annotation"; explicit value = "override"): `error_responses`, `path_style`, `path_prefix`, `resource_filter`, `profile`, `reactive`.
- **Bool defaults** are not tri-state — annotation read happens independently of the kwarg.
- **Empty-collection defaults** (`post_processors`, `sidecar_post_processors`) are not tri-state — `[]` and "no annotation" produce identical behaviour.

### #16 — README rewrite for v0.15.0

Documents every new annotation: `openapi.expose`, `openapi.pagination` (with the dialect table), `openapi.list_envelope`, `openapi.list_query_params`, `openapi.error_responses`, `openapi.codegen_inheritance`. Annotation summary table gains 22 new rows covering the v0.15.0 additions plus pre-existing gaps (`openapi.discriminator`, the `legacy_type_*` cluster, `request_class` / `update_class`, profile keys). CLI section now describes `gen-spring-server` alongside `gen-openapi`.

### Deferred to a separate breaking PR

- **#11**: Annotation vocabulary cleanup (feature-prefixed dotted keys like `openapi.error.class`, `openapi.list.envelope`). Breaking — needs a deprecation cycle.
- **#12**: `openapi.list_query_params` should accept a YAML list directly (no JSON-string). Also breaking on the wire (though we could ship a back-compat path for the JSON string).

## Test plan

- [x] `pytest tests/` — **544 passed** (+2 new sidecar-flag-passthrough tests)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [ ] CI green

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_