### PR TITLE
feat(#12): openapi.list_query_params accepts YAML list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,40 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Internal (test suite)
+### Added
 
-- **Test suite ~70% faster.** `_generate()` in `test_generator.py`
-  now caches the no-kwarg result (the ~50 tests that called
-  `_generate()` against `person.yaml` each paid ~0.8s of
-  schema-walk + serialise; now the cost is paid once per process).
-  Full suite runtime dropped from ~95s → ~27s.
-- **`tests/conftest.py`** holds the module-scoped `person_spec` /
-  `person_spec_json` fixtures and a `schema_to_file` factory for
-  tests that need ad-hoc YAML on disk (replaces inline
-  `tempfile.NamedTemporaryFile(delete=False)` blocks with a
-  `tmp_path`-based path that pytest cleans up automatically).
-- **`tests/test_helpers.py`** covers `_generate_from_string` and
-  `_generate_from_string_raises` — the helpers ~100 tests rely on
-  for ad-hoc schemas. A silent regression there would mask failures
-  across the entire suite; the new tests pin the helpers' contract.
-- **Local `import tempfile` / `import pytest` hoisted** out of
-  `_generate_from_string` and `_generate_from_string_raises` to the
-  module-level imports (code-smell flagged in the review).
-- **Pagination dialect tests parametrised** — the three
-  cursor/page-size/page-offset tests in
-  `TestPaginationAndListEnvelope` collapsed into one
-  `pytest.mark.parametrize` test (failures now name the failing
-  dialect).
-- **Shape-not-bug assertions tightened**:
-  - `test_expose_false_class_still_referenceable` now walks the
-    property tree and asserts on the resolved `$ref` target instead
-    of `"Role" in yaml.safe_dump(...)` (substring match that passed
-    for any text containing "Role").
-  - `test_ambiguous_chain_resolved_by_parent_path` gained both
-    positive ("Folder branch wins") and negative ("no `_via_bookmark`
-    operation IDs emitted") assertions; the prior version had a
-    comment-only `del bookmark_deep` that passed when no deep path
-    was emitted at all.
+- **`openapi.list_query_params` accepts a YAML list** as the
+  preferred shape, alongside the JSON-string form shipped in
+  v0.15.0 (#12 follow-up). LinkML-runtime preserves structured
+  annotation values natively, so a schema author can write
+  ```yaml
+  openapi.list_query_params:
+    - name: filterBy
+      type: string
+      description: Filter
+    - name: archived
+      type: boolean
+  ```
+  instead of stuffing it in a JSON string. The JSON form keeps
+  working — no schema migration needed.
 
 ### Added (refactor / docs / CLI symmetry)
 

--- a/README.md
+++ b/README.md
@@ -469,21 +469,36 @@ The envelope class owns the array slot pointing at the listed
 resource; the generator just routes the list-op response at it.
 
 **`openapi.list_query_params`** injects extra typed query
-parameters on top of slot-driven filters:
+parameters on top of slot-driven filters. Preferred form is a
+native YAML list:
 
 ```yaml
 classes:
   Dataset:
     annotations:
       openapi.resource: "true"
+      openapi.list_query_params:
+        - name: filterBy
+          type: string
+          description: Filter expression
+        - name: includeArchived
+          type: boolean
+```
+
+Each entry is a `{name, type, description?, required?}` mapping;
+`type` is one of `string` / `integer` / `number` / `boolean` /
+`array`.
+
+A JSON-array-as-string form is also accepted for back-compat with
+v0.15.0:
+
+```yaml
       openapi.list_query_params: |
-        [{"name": "filterBy", "type": "string", "description": "Filter expression"},
+        [{"name": "filterBy", "type": "string"},
          {"name": "includeArchived", "type": "boolean"}]
 ```
 
-Value is a JSON array of `{name, type, description?, required?}`
-objects. Types: `string` / `integer` / `number` / `boolean` /
-`array`.
+Both forms produce identical wire shape.
 
 The Spring side honours all three — controllers return the
 envelope class, accept the dialect's query params, and add the

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -2425,46 +2425,82 @@ class OpenAPIGenerator(Generator):
             for name, otype, description in self._PAGINATION_DIALECTS[dialect]
         ]
 
+    @staticmethod
+    def _class_annotation_raw(cls: ClassDefinition, tag: str):
+        """Read a class-level annotation's raw value (no ``str(...)``
+        coercion). Lets callers see YAML-native structured values
+        (lists, dicts) for annotations that opt into them. Returns
+        ``None`` when the annotation is absent."""
+        if not cls.annotations:
+            return None
+        for ann in cls.annotations.values():
+            if ann.tag == tag:
+                return ann.value
+        return None
+
     def _extra_list_query_params(self, cls: ClassDefinition) -> list[Parameter]:
-        """Decode ``openapi.list_query_params`` (JSON array string) into
-        Parameter objects. Each entry is ``{name, type, description?}``
-        plus optional ``required: true/false``. Unparseable JSON or
-        unknown OpenAPI scalar types raise (#105)."""
-        raw = self._class_annotation(cls, "openapi.list_query_params")
-        if not raw:
+        """Decode ``openapi.list_query_params`` into Parameter objects.
+
+        Accepts two equivalent shapes (#12 follow-up):
+
+        - **YAML list** (preferred): a list of ``{name, type,
+          description?, required?}`` mappings, written natively as
+          a LinkML annotation. linkml-runtime preserves structured
+          values, so this is just the YAML the author meant.
+        - **JSON-encoded string** (back-compat): the same array
+          serialised as a JSON string. Was the only supported form
+          in v0.15.0; kept indefinitely so existing schemas don't
+          need to change.
+
+        Each entry must declare ``name`` and ``type``; ``type`` is
+        one of ``string`` / ``integer`` / ``number`` / ``boolean``
+        / ``array``. Unparseable input or invalid types raise.
+        """
+        # Try the raw (YAML-native) value first; fall back to the
+        # string form (which is what linkml-runtime gives us for
+        # scalar annotation values).
+        raw_value = self._class_annotation_raw(cls, "openapi.list_query_params")
+        if raw_value is None:
             return []
-        # Cap the JSON input length so a pathologically deep / large
-        # annotation can't blow stack or RAM on a build.
-        if len(raw) > 65_536:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value is "
-                f"{len(raw)} bytes (cap is 65,536). Encode fewer params or "
-                "split across schemas."
-            )
-        try:
-            decoded = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value must be a "
-                f"JSON array of `{{name, type, description?}}` objects; got "
-                f"{raw!r} ({exc})."
-            ) from exc
-        except RecursionError as exc:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value is "
-                f"too deeply nested to parse safely."
-            ) from exc
-        if not isinstance(decoded, list):
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: expected a JSON "
-                f"array, got {type(decoded).__name__}."
-            )
+        if isinstance(raw_value, list):
+            decoded = raw_value
+        else:
+            raw = str(raw_value)
+            if not raw:
+                return []
+            # Cap the JSON input length so a pathologically deep /
+            # large annotation can't blow stack or RAM on a build.
+            if len(raw) > 65_536:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value is "
+                    f"{len(raw)} bytes (cap is 65,536). Encode fewer params or "
+                    "split across schemas."
+                )
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value must be "
+                    f"a YAML list (preferred) or a JSON array of "
+                    f"`{{name, type, description?}}` objects; got "
+                    f"{raw!r} ({exc})."
+                ) from exc
+            except RecursionError as exc:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value is "
+                    f"too deeply nested to parse safely."
+                ) from exc
+            if not isinstance(decoded, list):
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: expected a "
+                    f"list, got {type(decoded).__name__}."
+                )
         params: list[Parameter] = []
         valid_types = {"string", "integer", "number", "boolean", "array"}
         for idx, entry in enumerate(decoded):
             if not isinstance(entry, dict):
                 raise ValueError(
-                    f"openapi.list_query_params on {cls.name!r}: entry {idx} is not a JSON object."
+                    f"openapi.list_query_params on {cls.name!r}: entry {idx} is not a mapping."
                 )
             name = entry.get("name")
             otype = entry.get("type")

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -1537,36 +1537,47 @@ public class %(class_name)s {
         ]
 
     def _extra_list_param_dicts(self, cls: ClassDefinition) -> list[dict]:
-        """``@RequestParam`` dicts from ``openapi.list_query_params``
-        (#105 JSON array). Decoded with the same length cap and
-        error paths the OpenAPI generator uses, so a malformed value
-        produces the same error on both sides."""
-        raw = self._class_annotation(cls, "openapi.list_query_params")
-        if not raw:
+        """``@RequestParam`` dicts from ``openapi.list_query_params``.
+
+        Accepts a YAML list (preferred, native LinkML annotation
+        shape) or a JSON-encoded string (back-compat with v0.15.0).
+        Decoded with the same length cap and error paths the OpenAPI
+        generator uses, so a malformed value produces the same error
+        on both sides.
+        """
+        raw_value = self._class_annotation_raw(cls, "openapi.list_query_params")
+        if raw_value is None:
             return []
-        if len(raw) > 65_536:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value is "
-                f"{len(raw)} bytes (cap is 65,536)."
-            )
-        try:
-            decoded = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value must be a "
-                f"JSON array of `{{name, type, description?}}` objects; got "
-                f"{raw!r} ({exc})."
-            ) from exc
-        except RecursionError as exc:
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: value is "
-                "too deeply nested to parse safely."
-            ) from exc
-        if not isinstance(decoded, list):
-            raise ValueError(
-                f"openapi.list_query_params on {cls.name!r}: expected a JSON "
-                f"array, got {type(decoded).__name__}."
-            )
+        if isinstance(raw_value, list):
+            decoded = raw_value
+        else:
+            raw = str(raw_value)
+            if not raw:
+                return []
+            if len(raw) > 65_536:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value is "
+                    f"{len(raw)} bytes (cap is 65,536)."
+                )
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value must be "
+                    f"a YAML list (preferred) or a JSON array of "
+                    f"`{{name, type, description?}}` objects; got "
+                    f"{raw!r} ({exc})."
+                ) from exc
+            except RecursionError as exc:
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: value is "
+                    "too deeply nested to parse safely."
+                ) from exc
+            if not isinstance(decoded, list):
+                raise ValueError(
+                    f"openapi.list_query_params on {cls.name!r}: expected a "
+                    f"list, got {type(decoded).__name__}."
+                )
         java_type_for = {
             "string": "String",
             "integer": "Integer",
@@ -1920,6 +1931,18 @@ public class %(class_name)s {
         for ann in cls.annotations.values():
             if ann.tag == tag:
                 return str(ann.value)
+        return None
+
+    def _class_annotation_raw(self, cls: ClassDefinition, tag: str):
+        """Read a class-level annotation's raw value (no ``str(...)``
+        coercion). Mirrors the OpenAPI generator's helper so the
+        Spring side can also accept YAML-native structured values
+        (e.g. ``openapi.list_query_params`` as a YAML list)."""
+        if not cls or not cls.annotations:
+            return None
+        for ann in cls.annotations.values():
+            if ann.tag == tag:
+                return ann.value
         return None
 
     def _request_body_class(self, cls: ClassDefinition, op: str) -> str | None:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4036,7 +4036,7 @@ classes:
         assert "page" not in names
 
     def test_extra_list_query_params_inject(self):
-        # JSON-encoded array because LinkML annotations are scalar strings.
+        # JSON-encoded array — back-compat path for v0.15.0 schemas.
         params_json = (
             '[{"name": "filterBy", "type": "string", "description": "Filter"}, '
             '{"name": "archived", "type": "boolean"}]'
@@ -4054,12 +4054,39 @@ classes:
         assert "archived" in params
         assert params["archived"]["schema"]["type"] == "boolean"
 
+    def test_extra_list_query_params_as_yaml_list(self):
+        """Preferred form (#12 follow-up): `openapi.list_query_params`
+        accepts a YAML list directly — no JSON-in-string indirection.
+        Round-trips through linkml-runtime's native structured-value
+        support."""
+        schema_yaml = self.BASE.replace(
+            "openapi.path: datasets",
+            "openapi.path: datasets\n"
+            "      openapi.list_query_params:\n"
+            "        - name: filterBy\n"
+            "          type: string\n"
+            "          description: Filter\n"
+            "        - name: archived\n"
+            "          type: boolean\n",
+        )
+        spec = _generate_from_string(schema_yaml)
+        get = spec["paths"]["/datasets"]["get"]
+        params = {p["name"]: p for p in get["parameters"]}
+        assert "filterBy" in params
+        assert params["filterBy"]["schema"]["type"] == "string"
+        assert params["filterBy"].get("description") == "Filter"
+        assert "archived" in params
+        assert params["archived"]["schema"]["type"] == "boolean"
+
     def test_invalid_extra_param_json_raises(self):
         schema_yaml = self.BASE.replace(
             "openapi.path: datasets",
             'openapi.path: datasets\n      openapi.list_query_params: "not json"',
         )
-        _generate_from_string_raises(schema_yaml, match=r"JSON array")
+        # The error message names both supported shapes (YAML list
+        # preferred, JSON array back-compat) so the user knows which
+        # form to fix.
+        _generate_from_string_raises(schema_yaml, match=r"YAML list.*JSON array")
 
     def test_invalid_extra_param_type_raises(self):
         params_json = '[{"name": "bad", "type": "uuid"}]'


### PR DESCRIPTION
## Summary

PR E: `openapi.list_query_params` accepts a YAML list as the preferred form (#12 follow-up from the second code review). Closes the last non-breaking item from that batch.

LinkML-runtime preserves structured annotation values natively, so the JSON-in-string indirection v0.15.0 shipped with was unnecessary. Authors can now write the list directly:

```yaml
classes:
  Dataset:
    annotations:
      openapi.resource: "true"
      openapi.list_query_params:
        - name: filterBy
          type: string
          description: Filter
        - name: archived
          type: boolean
```

instead of stuffing it in a JSON string:

```yaml
      openapi.list_query_params: |
        [{"name": "filterBy", "type": "string"},
         {"name": "archived", "type": "boolean"}]
```

Both forms produce identical wire shape. The JSON form keeps working indefinitely — no schema migration needed.

## Implementation

Both generators add a `_class_annotation_raw()` helper that returns the annotation's raw `ann.value` (no `str(...)` coercion) so a YAML list reaches the parser as `list[dict]` instead of a stringified Python repr. The dispatch is then:

- raw value is a `list` → use directly
- raw value is anything else → coerce to string, JSON-decode (existing v0.15.0 path)

Length cap, `RecursionError` handling, and per-entry validation (`name` / `type` required; `type` ∈ `{string, integer, number, boolean, array}`) are unchanged.

The error message names both supported shapes ("YAML list (preferred) or a JSON array") so a user who hits the parser knows which form to fix.

## Test plan

- [x] `pytest tests/` — **553 passed** (+1 new YAML-list test, modified existing test's regex expectation to match the new error message)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] Verified back-compat: prior JSON-string examples still work
- [ ] CI green

## What's left from the second code review

| Item | Status |
|---|---|
| Security (PR A) | Merged #114 |
| Follow-on bugs (PR B) | Merged #115 |
| Consistency / docs / CLI symmetry (PR C) | Merged #116 |
| Test cleanup / perf (PR D) | Merged #117 |
| `openapi.list_query_params` YAML list (PR E) | **This PR** |
| Annotation vocabulary cleanup (#11) | **Deferred** — genuinely breaking; needs a deprecation cycle |
| `test_generator.py` tempfile→fixture migration | **Deferred** — mechanical refactor, low priority |

With this PR landed, the only outstanding review item is the breaking vocabulary cleanup.

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_