### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.16.0] — 2026-05-29
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.15.0"
+version = "0.16.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
## Summary

Release 0.16.0 — flips Unreleased → 0.16.0 in CHANGELOG.md, bumps `pyproject.toml` and `__init__.py` to 0.16.0.

Ships the entire second code-review batch (PRs #114 → #119) plus the test-suite perf work. **No remaining open items from the review except the deferred annotation-vocabulary cleanup (#11), which is genuinely breaking and warrants its own design discussion.**

### Headline changes

- **Security (#114)** — Java code injection + path traversal hardening on `gen-spring-server`. Strict identifier validation, universal `_escape_java`, `_escape_javadoc` for `*/` close, `Path.resolve()` containment in `emit()`, JSON DoS guards.
- **Spring↔OpenAPI parity (#115, #118)** — Spring controllers now honour `openapi.list_envelope` / `openapi.pagination` / `openapi.list_query_params`. The latter accepts a native YAML list alongside the JSON-string back-compat path.
- **Bug batch (#115)** — Mixin narrowing now triggers the `--codegen-friendly` fallback; per-op error response baseline aligns with OpenAPI; profile typo detection raises; concrete polymorphic root in `@JsonSubTypes` without explicit `openapi.type_value`; `error_responses=[]` Spring kwarg disable propagates to the sidecar.
- **CLI symmetry (#116)** — `gen-spring-server` gains `--profile`, `--emit-namespaces`, `--rdf-resolved-map`, `--post-process` to mirror `gen-openapi`. Shared helpers extracted to `src/linkml_openapi/_utils.py`. README rewrite documents all v0.15.0 features.
- **Test perf (#117, #119)** — `_generate()` caches the no-kwarg result; suite went 95s → 27s. 14 inline `tempfile.NamedTemporaryFile` blocks migrated to a `schema_to_file` fixture. New `test_helpers.py` covers the helper functions themselves.

### Stats

- **553 tests passing** (+11 since 0.15.0)
- Suite runtime: **27s** (was 95s)
- 6 PRs squash-merged: #114, #115, #116, #117, #118, #119

## Test plan

- [x] `python -c "import linkml_openapi; print(linkml_openapi.__version__)"` → `0.16.0`
- [x] `pytest tests/` — 553 passed
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [ ] CI green
- [ ] After merge: tag `v0.16.0` triggers PyPI publish workflow

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_