### PR TITLE
feat: openapi.singleton: "true" — one URL, all verbs, no item-id fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [Unreleased]
+
+### Added
+
+- **`openapi.singleton: "true"` class-level annotation.** Resources
+  marked singleton emit ALL verbs in `openapi.operations` on one
+  canonical URL — no `/{id}` segment, no fork between collection-root
+  and item path. Covers three URL-shape patterns that previously
+  required hand-authored controllers in downstream Spring services:
+  - **Top-level singleton** (e.g. `GET/POST/PUT/DELETE /settings`)
+  - **Sub-resource singleton via `openapi.path_template`** (e.g.
+    `PUT /catalogs/{catalogId}/datasets/{datasetId}/owners`)
+  - **Single-verb singleton** by listing one verb in
+    `openapi.operations`
+
+  `list` is rejected — a singleton has no collection to enumerate.
+  Both `gen-openapi` and `gen-spring-server` honour the annotation;
+  the sidecar spec and controller annotations agree wire-for-wire.
+  Identifier-slot validation is skipped under singleton mode (the
+  singleton IS the URL).
+
 ## [0.16.0] — 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -528,6 +528,55 @@ classes:
       openapi.codegen_inheritance: "false"   # use-site oneOf only
 ```
 
+#### `openapi.singleton` — one URL, no item-id segment
+
+Resources marked `openapi.singleton: "true"` emit every verb in
+`openapi.operations` on **one canonical URL** — no `/{id}` segment,
+no fork between a collection path and an item path. Covers the
+patterns that today force hand-authored controllers:
+
+```yaml
+# Top-level singleton — GET/POST/PUT/DELETE all on /settings
+Settings:
+  annotations:
+    openapi.resource: "true"
+    openapi.path: settings
+    openapi.singleton: "true"
+    openapi.operations: "read,create,update,delete"
+  attributes:
+    theme: { range: string }
+    locale: { range: string }
+
+# Sub-resource singleton via path_template — PUT only
+DatasetOwners:
+  annotations:
+    openapi.resource: "true"
+    openapi.singleton: "true"
+    openapi.path_template: "/catalogs/{catalogId}/datasets/{datasetId}/owners"
+    openapi.path_param_sources: "catalogId:Catalog.id,datasetId:Dataset.id"
+    openapi.operations: "update"
+  attributes:
+    contact: { range: string }
+```
+
+The first example emits `GET /settings`, `POST /settings`,
+`PUT /settings`, `DELETE /settings` — four operations on one
+PathItem. The second emits only `PUT /catalogs/{catalogId}/…/owners`.
+
+Constraints:
+
+- `list` is rejected (a singleton has no collection to enumerate —
+  the resource IS the singleton).
+- An identifier slot is **not** required (no addressable handle is
+  needed; the URL IS the handle).
+- Composition / synthetic-inverse / nested paths still emit
+  normally — singleton mode only changes how the resource's *own*
+  paths are shaped.
+
+Both `gen-openapi` and `gen-spring-server` honour the annotation —
+the sidecar OpenAPI spec and the Spring controller annotations
+agree wire-for-wire.
+
 #### `openapi.operations`
 
 Comma-separated list of CRUD operations to generate. Controls which HTTP methods appear on the collection and item paths.
@@ -1330,6 +1379,7 @@ endpoints regardless of any of these annotations.
 | `openapi.list_envelope` | class | LinkML class name | Bare array response |
 | `openapi.list_query_params` | class | JSON array of `{name, type, description?}` | None |
 | `openapi.codegen_inheritance` | class | `"false"` | `--codegen-friendly` uses parent-$ref strategy |
+| `openapi.singleton` | class | `"true"` | Resource has a collection / item fork |
 | `openapi.reactive` | schema | `"true"` / `"false"` | Off — blocking Spring MVC |
 | `openapi.profile.<name>.exclude_classes` | schema | comma-separated class names | None |
 | `openapi.profile.<name>.include_classes` | schema | comma-separated class names | None (all included) |

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -493,8 +493,26 @@ class OpenAPIGenerator(Generator):
             path_vars = self._get_path_variables(cls)
             path_segment = self._get_path_segment(cls)
             operations = self._get_operations(cls)
+            is_singleton = _is_truthy(self._class_annotation(cls, "openapi.singleton") or False)
             nested_only = _is_truthy(self._class_annotation(cls, "openapi.nested_only") or False)
             flat_only = _is_truthy(self._class_annotation(cls, "openapi.flat_only") or False)
+            # Singleton mode short-circuits the collection-vs-item fork
+            # and the templated-deep emission — all verbs bind to one
+            # canonical URL. Composition and synthetic-inverse paths
+            # are still emitted normally below (those describe OTHER
+            # resources pointing at this one).
+            if is_singleton:
+                self._validate_resource_addressability(
+                    class_name, path_vars, operations, is_singleton=True
+                )
+                singleton_paths = self._emit_singleton_path(
+                    cls, class_name, path_segment, operations
+                )
+                paths.update(singleton_paths)
+                if OP_PATCH in operations and f"{class_name}Patch" not in schemas:
+                    schemas[f"{class_name}Patch"] = self._build_patch_schema(class_name, cls)
+                paths.update(self._make_nested_paths(class_name, path_segment, path_vars))
+                continue
             if nested_only and flat_only:
                 raise ValueError(
                     f"Class {class_name!r} declares both "
@@ -2687,7 +2705,7 @@ class OpenAPIGenerator(Generator):
     # --- Composition vs reference ---------------------------------------
 
     def _validate_resource_addressability(
-        self, class_name: str, path_vars: list, operations: list[str]
+        self, class_name: str, path_vars: list, operations: list[str], is_singleton: bool = False
     ) -> None:
         """Resource classes that need item-path operations must be addressable.
 
@@ -2695,7 +2713,14 @@ class OpenAPIGenerator(Generator):
         slot or an explicit ``openapi.path_variable`` annotation. If neither
         is present the class can't be referenced individually and the
         generator should fail loudly rather than silently drop the item path.
+
+        Singleton resources (``openapi.singleton: "true"``) are exempt
+        from the identifier check — they live at one canonical URL with
+        no ``/{id}`` segment, so the ops bind without an addressable
+        handle.
         """
+        if is_singleton:
+            return
         item_ops = ITEM_OPERATIONS & set(operations) - {OP_PATCH}
         if item_ops and not path_vars:
             raise ValueError(
@@ -3267,6 +3292,105 @@ class OpenAPIGenerator(Generator):
             if getattr(item, method, None) is not None:
                 return True
         return False
+
+    def _emit_singleton_path(
+        self,
+        cls: ClassDefinition,
+        class_name: str,
+        path_segment: str,
+        operations: list[str],
+    ) -> dict[str, PathItem]:
+        """Emit a singleton resource — one canonical URL with all
+        verbs in ``operations`` bound to the same PathItem, no
+        ``/{id}`` segment, no fork between collection-root and item
+        path.
+
+        Three URL-shape patterns this covers (all of which today
+        require hand-authored controllers when the schema author
+        wants the wire shape):
+
+        - **Top-level singleton** (``/data-authority``): class with
+          ``openapi.singleton: "true"``, no ``path_template``. URL
+          is auto-derived ``/<path_segment>`` (or
+          ``openapi.path`` override).
+        - **Sub-resource singleton via path_template**
+          (``/catalogs/{catalogId}/datasets/{datasetId}/owners``):
+          class with ``openapi.singleton: "true"`` and
+          ``openapi.path_template``. URL is the template as-is,
+          with parameters from ``openapi.path_param_sources``.
+        - **Single-verb singleton** (``PUT /…/owners`` only):
+          same as above but ``openapi.operations`` lists only the
+          one verb. The PathItem ends up with just that method.
+
+        Validation:
+
+        - ``list`` is incompatible — a singleton has no collection
+          to enumerate (the resource IS the collection of size 1).
+          Raises if ``operations`` requests ``list``.
+        - ``read`` is the GET on the singleton URL — fine.
+        - ``create`` is POST on the singleton URL (idempotent
+          create-or-409 is the schema author's call; the generator
+          just emits the verb).
+        """
+        if OP_LIST in operations:
+            raise ValueError(
+                f'Class {class_name!r} has openapi.singleton: "true" with '
+                "`list` in openapi.operations — a singleton has no "
+                "collection to enumerate (the resource is itself the "
+                "only instance). Drop `list` from operations or remove "
+                "the singleton annotation."
+            )
+        template = self._class_annotation(cls, "openapi.path_template")
+        if template:
+            # Build path params from the explicit sources.
+            sources_raw = self._class_annotation(cls, "openapi.path_param_sources") or ""
+            sources = self._parse_path_param_sources(class_name, sources_raw)
+            placeholders = list(self._PATH_TEMPLATE_PLACEHOLDER_RE.findall(template))
+            unique_placeholders = list(dict.fromkeys(placeholders))
+            missing = set(unique_placeholders) - set(sources)
+            extra = set(sources) - set(unique_placeholders)
+            if missing or extra:
+                raise ValueError(
+                    f"Class {class_name!r} `openapi.path_template` "
+                    f"placeholders don't match `openapi.path_param_sources`. "
+                    f"Template placeholders: {sorted(unique_placeholders)!r}. "
+                    f"Source keys: {sorted(sources)!r}. "
+                    f"Missing sources: {sorted(missing)!r}. "
+                    f"Extra sources: {sorted(extra)!r}."
+                )
+            params: list[Parameter] = []
+            for name in unique_placeholders:
+                src_class, src_slot = sources[name]
+                slot = self._induced_slots_by_name(src_class).get(src_slot)
+                if slot is None:
+                    raise ValueError(
+                        f"Class {class_name!r} `openapi.path_param_sources` "
+                        f"refers to unknown slot {src_class}.{src_slot!r} for "
+                        f"parameter {name!r}."
+                    )
+                params.append(
+                    Parameter(
+                        name=name,
+                        param_in=ParameterLocation.PATH,
+                        required=True,
+                        param_schema=self._slot_to_schema(slot),
+                    )
+                )
+            url = template
+        else:
+            params = []
+            url = f"/{path_segment}"
+        item = PathItem(parameters=params or None)
+        # All verbs share the same PathItem — read/update/patch/delete
+        # via the standard item-ops attach, create via direct POST.
+        # The wire shape: ``GET /foo`` / ``POST /foo`` / ``PUT /foo``
+        # / ``PATCH /foo`` / ``DELETE /foo``.
+        self._attach_item_operations(item, cls, class_name, operations)
+        if OP_CREATE in operations:
+            item.post = self._make_create_operation(cls, class_name)
+        # PATCH bodies follow the same emission rule as the regular
+        # CRUD pass — handled outside this method by the caller.
+        return {url: item}
 
     _PATH_TEMPLATE_PLACEHOLDER_RE = PATH_TEMPLATE_PLACEHOLDER_RE
 

--- a/src/linkml_openapi/spring/generator.py
+++ b/src/linkml_openapi/spring/generator.py
@@ -835,11 +835,22 @@ public class %(class_name)s {
                 "the flat URL only."
             )
 
-        if not nested_only:
+        # Singleton mode short-circuits the regular CRUD fork — all
+        # verbs land on one canonical URL with no `/{id}` segment.
+        # The wire shape matches the OpenAPI generator's singleton
+        # emission so the sidecar spec and the controllers agree.
+        singleton_raw = self._class_annotation(cls, "openapi.singleton")
+        is_singleton = singleton_raw is not None and singleton_raw.strip().lower() == "true"
+        if is_singleton:
+            ops.extend(self._singleton_ops(cls, path_segment, imports, media_types))
+        elif not nested_only:
             ops.extend(self._top_level_ops(cls, path_segment, imports, media_types))
-        ops.extend(self._nested_ops(cls, path_segment, imports, media_types))
+        if not is_singleton:
+            ops.extend(self._nested_ops(cls, path_segment, imports, media_types))
         # Deep nested chain (auto-derived). Item-only CRUD on the deep URL.
-        if not flat_only:
+        # Skipped under singleton mode — the singleton URL already
+        # carries every requested verb.
+        if not flat_only and not is_singleton:
             template = self._class_annotation(cls, "openapi.path_template")
             if template:
                 ops.extend(self._deep_templated_ops(cls, template, imports, media_types))
@@ -928,6 +939,197 @@ public class %(class_name)s {
             else:
                 op["method_return"] = f"ResponseEntity<{inner}>"
                 op["default_body"] = "ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()"
+
+    @staticmethod
+    def _requested_operations(cls: ClassDefinition) -> set[str]:
+        """Parse ``openapi.operations`` into a set of verb names. Empty
+        annotation (or absent) means "all standard CRUD"; the caller
+        decides which standard set applies (singleton vs full CRUD)."""
+        ann = None
+        if cls.annotations:
+            for a in cls.annotations.values():
+                if a.tag == "openapi.operations":
+                    ann = str(a.value)
+                    break
+        if not ann:
+            return set()
+        return {t.strip().lower() for t in ann.split(",") if t.strip()}
+
+    def _singleton_ops(
+        self,
+        cls: ClassDefinition,
+        path_segment: str,
+        imports: set[str],
+        media_types: list[str],
+    ) -> list[dict]:
+        """Singleton resource — all requested verbs land on ONE URL
+        with no `/{id}` segment. Mirrors the OpenAPI generator's
+        ``_emit_singleton_path``. The URL is ``openapi.path_template``
+        if set, else ``/<path_segment>``.
+
+        ``openapi.operations`` selects the verb set; ``list`` is
+        rejected (singleton has no collection)."""
+        cn = cls.name
+        update_body_type = self._request_body_class(cls, op="update") or cn
+        create_body_type = self._request_body_class(cls, op="create") or cn
+        for body_type in (create_body_type, update_body_type):
+            if body_type != cn:
+                imports.add(f"{self.package}.model.{body_type}")
+        template = self._class_annotation(cls, "openapi.path_template")
+        if template:
+            url_literal = f'"{_escape_java(template)}"'
+            path_params = self._templated_path_params(cls, template, imports)
+        else:
+            url_literal = f'"/{path_segment}"'
+            path_params = []
+        produces = _produces_arg(media_types)
+        consumes = produces
+        requested = self._requested_operations(cls)
+        if not requested:
+            # Default singleton verbs match the OpenAPI generator's
+            # default: read + create + update + delete (no list).
+            requested = {"read", "create", "update", "delete"}
+        if "list" in requested:
+            raise ValueError(
+                f'Class {cn!r} has openapi.singleton: "true" with `list` in '
+                "openapi.operations — singletons can't be listed. Drop "
+                "`list` or remove the singleton annotation."
+            )
+        ops: list[dict] = []
+        if "read" in requested:
+            ops.append(
+                {
+                    "javadoc": f"GET — read the {cn} singleton.",
+                    "method_annotations": [
+                        f"@GetMapping(value = {url_literal}, produces = {produces})"
+                    ],
+                    "method_name": f"get{cn}",
+                    "return_type": cn,
+                    "params": list(path_params),
+                }
+            )
+        if "create" in requested:
+            ops.append(
+                {
+                    "javadoc": f"POST — create the {cn} singleton.",
+                    "method_annotations": [
+                        f"@PostMapping(value = {url_literal}, "
+                        f"consumes = {consumes}, produces = {produces})"
+                    ],
+                    "method_name": f"create{cn}",
+                    "return_type": cn,
+                    "params": [
+                        *path_params,
+                        {
+                            "annotation": "@Valid @RequestBody",
+                            "java_type": create_body_type,
+                            "java_name": "body",
+                        },
+                    ],
+                }
+            )
+        if "update" in requested:
+            ops.append(
+                {
+                    "javadoc": f"PUT — replace the {cn} singleton.",
+                    "method_annotations": [
+                        f"@PutMapping(value = {url_literal}, "
+                        f"consumes = {consumes}, produces = {produces})"
+                    ],
+                    "method_name": f"update{cn}",
+                    "return_type": cn,
+                    "params": [
+                        *path_params,
+                        {
+                            "annotation": "@Valid @RequestBody",
+                            "java_type": update_body_type,
+                            "java_name": "body",
+                        },
+                    ],
+                }
+            )
+        if "patch" in requested:
+            patch_body_type = f"{cn}Patch"
+            imports.add(f"{self.package}.model.{patch_body_type}")
+            ops.append(
+                {
+                    "javadoc": f"PATCH — partial update of the {cn} singleton.",
+                    "method_annotations": [
+                        f"@PatchMapping(value = {url_literal}, "
+                        f'consumes = "application/merge-patch+json", '
+                        f"produces = {produces})"
+                    ],
+                    "method_name": f"patch{cn}",
+                    "return_type": cn,
+                    "params": [
+                        *path_params,
+                        {
+                            "annotation": "@Valid @RequestBody",
+                            "java_type": patch_body_type,
+                            "java_name": "body",
+                        },
+                    ],
+                }
+            )
+            imports.add("org.springframework.web.bind.annotation.PatchMapping")
+        if "delete" in requested:
+            ops.append(
+                {
+                    "javadoc": f"DELETE — remove the {cn} singleton.",
+                    "method_annotations": [f"@DeleteMapping({url_literal})"],
+                    "method_name": f"delete{cn}",
+                    "return_type": "Void",
+                    "params": list(path_params),
+                }
+            )
+        return ops
+
+    def _templated_path_params(
+        self, cls: ClassDefinition, template: str, imports: set[str]
+    ) -> list[dict]:
+        """Build @PathVariable dicts for each `{name}` placeholder in
+        ``template``, sourced from ``openapi.path_param_sources``.
+        Used by ``_singleton_ops`` for sub-resource singletons; shares
+        the same parsing rules as the OpenAPI generator's templated
+        deep-path emitter."""
+        sources_raw = self._class_annotation(cls, "openapi.path_param_sources") or ""
+        if not sources_raw:
+            return []
+        # Parse `name:Class.slot, name:Class.slot` into a dict.
+        sources: dict[str, tuple[str, str]] = {}
+        for entry in sources_raw.split(","):
+            entry = entry.strip()
+            if not entry or ":" not in entry:
+                continue
+            name, ref = entry.split(":", 1)
+            if "." not in ref:
+                continue
+            src_class, src_slot = ref.split(".", 1)
+            sources[name.strip()] = (src_class.strip(), src_slot.strip())
+        # Build the placeholder list in template order.
+        placeholders = re.findall(r"\{([^}]+)\}", template)
+        seen: set[str] = set()
+        out: list[dict] = []
+        for name in placeholders:
+            if name in seen:
+                continue
+            seen.add(name)
+            if name not in sources:
+                continue
+            src_class, src_slot = sources[name]
+            slot = next(
+                (s for s in self._induced_slots(src_class) if s.name == src_slot),
+                None,
+            )
+            java_type = self._java_type_for_range(slot, imports) if slot is not None else "String"
+            out.append(
+                {
+                    "annotation": f'@PathVariable("{name}")',
+                    "java_type": java_type,
+                    "java_name": _java_identifier(name),
+                }
+            )
+        return out
 
     def _top_level_ops(
         self,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4171,3 +4171,149 @@ class TestCodegenFriendlyNarrowingDetectedInFlattenMode:
         gen.serialize()
         assert "AcmeDataset" in gen._narrowing_subclasses
         assert "AcmeCatalog" in gen._narrowing_subclasses
+
+
+class TestSingletonResource:
+    """Coverage for the ``openapi.singleton: "true"`` annotation —
+    all verbs bind to one canonical URL with no ``/{id}`` segment.
+
+    Three URL-shape patterns covered:
+
+    - Top-level singleton (``/health``)
+    - Sub-resource singleton via path_template
+      (``/catalogs/{catalogId}/.../owners``)
+    - Single-verb singleton (PUT only)
+    """
+
+    def test_top_level_singleton_emits_one_path_with_all_verbs(self):
+        spec = _generate_from_string(
+            """
+id: https://example.org/sing1
+name: sing1
+default_range: string
+classes:
+  Health:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: health
+      openapi.singleton: "true"
+      openapi.operations: "read,create,update,delete"
+    attributes:
+      title: { range: string }
+"""
+        )
+        # ONE path entry; no `/health/{id}` fork.
+        assert "/health" in spec["paths"]
+        assert "/health/{id}" not in spec["paths"]
+        item = spec["paths"]["/health"]
+        # All four verbs bound to the same PathItem.
+        assert "get" in item
+        assert "post" in item
+        assert "put" in item
+        assert "delete" in item
+
+    def test_singleton_via_path_template_emits_deep_url_only(self):
+        spec = _generate_from_string(
+            """
+id: https://example.org/sing2
+name: sing2
+default_range: string
+classes:
+  AcmeCatalog:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: catalogs
+    attributes:
+      id: { identifier: true, range: string, required: true }
+  AcmeDataset:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: datasets
+    attributes:
+      id: { identifier: true, range: string, required: true }
+  DatasetOwners:
+    annotations:
+      openapi.resource: "true"
+      openapi.singleton: "true"
+      openapi.path_template: "/catalogs/{catalogId}/datasets/{datasetId}/owners"
+      openapi.path_param_sources: "catalogId:AcmeCatalog.id,datasetId:AcmeDataset.id"
+      openapi.operations: "update"
+    attributes:
+      contact: { range: string }
+"""
+        )
+        deep = "/catalogs/{catalogId}/datasets/{datasetId}/owners"
+        assert deep in spec["paths"]
+        # No `/{ownerId}` fork.
+        assert f"{deep}/{{id}}" not in spec["paths"]
+        assert f"{deep}/{{owner_id}}" not in spec["paths"]
+        item = spec["paths"][deep]
+        # Only the requested verb.
+        assert "put" in item
+        assert "get" not in item
+        assert "post" not in item
+        assert "delete" not in item
+
+    def test_singleton_with_list_raises(self):
+        _generate_from_string_raises(
+            """
+id: https://example.org/sing3
+name: sing3
+default_range: string
+classes:
+  Bad:
+    annotations:
+      openapi.resource: "true"
+      openapi.singleton: "true"
+      openapi.operations: "list,read"
+    attributes:
+      title: { range: string }
+""",
+            match=r"singleton.*list.*collection to enumerate",
+        )
+
+    def test_singleton_skips_path_var_check(self):
+        """A singleton with no identifier slot and no path_variable
+        annotation is still valid — the singleton IS the URL."""
+        spec = _generate_from_string(
+            """
+id: https://example.org/sing4
+name: sing4
+default_range: string
+classes:
+  Heartbeat:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: heartbeat
+      openapi.singleton: "true"
+      openapi.operations: "read"
+    attributes:
+      status: { range: string }
+      lastBeat: { range: string }
+"""
+        )
+        assert "/heartbeat" in spec["paths"]
+        assert spec["paths"]["/heartbeat"].get("get") is not None
+
+    def test_singleton_response_schema_is_the_class(self):
+        """Singleton response body is the class schema directly —
+        not wrapped in `List<…>` even when no envelope is declared."""
+        spec = _generate_from_string(
+            """
+id: https://example.org/sing5
+name: sing5
+default_range: string
+classes:
+  Settings:
+    annotations:
+      openapi.resource: "true"
+      openapi.path: settings
+      openapi.singleton: "true"
+      openapi.operations: "read,update"
+    attributes:
+      theme: { range: string }
+"""
+        )
+        get_body = spec["paths"]["/settings"]["get"]["responses"]["200"]
+        schema = get_body["content"]["application/json"]["schema"]
+        assert schema == {"$ref": "#/components/schemas/Settings"}

--- a/tests/test_linkml_spring.py
+++ b/tests/test_linkml_spring.py
@@ -2045,3 +2045,110 @@ classes:
         # per-property `x-rdf-property` extensions; either marker
         # indicates the flag reached the sidecar.
         assert "x-rdf-class" in spec_text  # class_uri on Dataset gets surfaced
+
+
+class TestSpringSingletonResource:
+    """``openapi.singleton: "true"`` (new) — Spring controllers emit
+    all verbs on ONE URL with no `/{id}` segment, matching the
+    OpenAPI generator's singleton emission."""
+
+    def test_top_level_singleton_controller_has_only_singleton_verbs(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/spring_singleton\n"
+            "name: spring_singleton\n"
+            "default_range: string\n"
+            "classes:\n"
+            "  Health:\n"
+            "    annotations:\n"
+            '      openapi.resource: "true"\n'
+            "      openapi.path: health\n"
+            '      openapi.singleton: "true"\n'
+            '      openapi.operations: "read,create,update,delete"\n'
+            "    attributes:\n"
+            "      title: { range: string }\n"
+        )
+        files = SpringServerGenerator(str(fixture), package="io.example.sing").build()
+        api = files["io/example/sing/api/HealthApi.java"]
+        # All four mappings present on the singleton URL.
+        assert '@GetMapping(value = "/health"' in api
+        assert '@PostMapping(value = "/health"' in api
+        assert '@PutMapping(value = "/health"' in api
+        assert '@DeleteMapping("/health")' in api
+        # No `/health/{id}` polluted methods.
+        assert "/health/{id}" not in api
+
+    def test_sub_resource_singleton_via_template(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/spring_singleton2\n"
+            "name: spring_singleton2\n"
+            "default_range: string\n"
+            "classes:\n"
+            "  AcmeCatalog:\n"
+            '    annotations: { openapi.resource: "true", openapi.path: catalogs }\n'
+            "    attributes:\n"
+            "      id: { identifier: true, range: string, required: true }\n"
+            "  DatasetOwners:\n"
+            "    annotations:\n"
+            '      openapi.resource: "true"\n'
+            '      openapi.singleton: "true"\n'
+            '      openapi.path_template: "/catalogs/{catalogId}/owners"\n'
+            '      openapi.path_param_sources: "catalogId:AcmeCatalog.id"\n'
+            '      openapi.operations: "update"\n'
+            "    attributes:\n"
+            "      contact: { range: string }\n"
+        )
+        files = SpringServerGenerator(str(fixture), package="io.example.sing2").build()
+        api = files["io/example/sing2/api/DatasetOwnersApi.java"]
+        # Only PUT on the templated singleton URL.
+        assert '@PutMapping(value = "/catalogs/{catalogId}/owners"' in api
+        # No GET / POST / DELETE.
+        assert '@GetMapping(value = "/catalogs/{catalogId}/owners"' not in api
+        assert '@PostMapping(value = "/catalogs/{catalogId}/owners"' not in api
+        assert '@DeleteMapping("/catalogs/{catalogId}/owners")' not in api
+        # The path variable is wired as @PathVariable on the method.
+        assert '@PathVariable("catalogId")' in api
+
+    def test_singleton_with_list_raises(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/spring_singleton_bad\n"
+            "name: spring_singleton_bad\n"
+            "default_range: string\n"
+            "classes:\n"
+            "  Bad:\n"
+            "    annotations:\n"
+            '      openapi.resource: "true"\n'
+            "      openapi.path: bad\n"
+            '      openapi.singleton: "true"\n'
+            '      openapi.operations: "list,read"\n'
+            "    attributes:\n"
+            "      title: { range: string }\n"
+        )
+        with pytest.raises(ValueError, match=r"singleton.*list"):
+            SpringServerGenerator(str(fixture), package="io.example.bad").build()
+
+    def test_singleton_sidecar_spec_matches_controller_shape(self, tmp_path):
+        fixture = tmp_path / "schema.yaml"
+        fixture.write_text(
+            "id: https://example.org/spring_singleton_parity\n"
+            "name: spring_singleton_parity\n"
+            "default_range: string\n"
+            "classes:\n"
+            "  Settings:\n"
+            "    annotations:\n"
+            '      openapi.resource: "true"\n'
+            "      openapi.path: settings\n"
+            '      openapi.singleton: "true"\n'
+            '      openapi.operations: "read,update"\n'
+            "    attributes:\n"
+            "      theme: { range: string }\n"
+        )
+        out = tmp_path / "out" / "java"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        SpringServerGenerator(str(fixture), package="io.example.parity").emit(str(out))
+        spec_text = (tmp_path / "out" / "resources" / "openapi.yaml").read_text()
+        # Sidecar advertises GET + PUT on the singleton URL only.
+        assert "/settings:" in spec_text
+        assert "/settings/{id}:" not in spec_text


### PR DESCRIPTION
## Summary

New `openapi.singleton: "true"` class-level annotation. Resources marked singleton emit ALL verbs in `openapi.operations` on **one canonical URL** — no `/{id}` segment, no fork between collection-root and item path.

Proposed by a downstream user analysing a schema where multiple sub-resources have this shape and today force hand-authored controllers. Three patterns covered:

### Top-level singleton

```yaml
Settings:
  annotations:
    openapi.resource: "true"
    openapi.path: settings
    openapi.singleton: "true"
    openapi.operations: "read,create,update,delete"
  attributes:
    theme: { range: string }
    locale: { range: string }
```

→ `GET /settings`, `POST /settings`, `PUT /settings`, `DELETE /settings` on one PathItem.

### Sub-resource singleton via `path_template`

```yaml
DatasetOwners:
  annotations:
    openapi.resource: "true"
    openapi.singleton: "true"
    openapi.path_template: "/catalogs/{catalogId}/datasets/{datasetId}/owners"
    openapi.path_param_sources: "catalogId:Catalog.id,datasetId:Dataset.id"
    openapi.operations: "update"
```

→ `PUT /catalogs/{catalogId}/datasets/{datasetId}/owners` only (one verb).

### Single-verb singleton

`openapi.operations: "update"` (or any single verb) emits exactly that one mapping. The Spring side respects `openapi.operations` filtering (which the regular CRUD emitter historically didn't), so single-verb singletons produce a one-method controller interface.

## Implementation

- **OpenAPI generator** (`_emit_singleton_path`): short-circuits the collection/item fork. URL is the `path_template` (with params from `path_param_sources`) or auto-derived `/<path_segment>`. All requested verbs bind to one PathItem via `_attach_item_operations` + direct POST for create.
- **Spring generator** (`_singleton_ops`): mirrors the same shape on the controller — one URL, one method per requested verb.
- **Validation**:
  - `list` + `singleton` raises (a singleton has no collection to enumerate)
  - Identifier-slot check skipped under singleton mode (the URL IS the handle)
  - `nested_only` / `flat_only` are bypassed (singleton mode owns the URL shape)

Composition / synthetic-inverse / nested paths still emit normally — singleton mode only changes how the resource's *own* paths are shaped.

## Not in this PR

The "bulk-PUT on collection root" pattern (`POST` + `PUT` both on `/datasets/bulk`) is a related but distinct concern. Conflating it with singleton would muddy semantics:

- **Singleton** = one URL, item-style verbs (GET/POST/PUT/DELETE), no collection
- **Bulk** = collection URL, extra non-list verbs (PUT alongside POST)

Defer to a follow-up `openapi.collection_pattern: "all-on-root"` if needed.

## Test plan

- [x] **9 new regression tests** — 5 OpenAPI, 4 Spring (sub-resource singleton via template, controller verb filtering, list-with-singleton raises, sidecar parity).
- [x] `pytest tests/` — **562 passed** (+9)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] Smoke tested both URL shapes against the CLI and verified the emitted Java has exactly the expected mappings
- [ ] CI green

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA