### PR TITLE
chore(release): 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.16.1] — 2026-05-31
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.16.0"
+version = "0.16.1"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"


### PR DESCRIPTION
## Summary

Release 0.16.1 — flips Unreleased → 0.16.1 in CHANGELOG.md, bumps `pyproject.toml` and `__init__.py` to 0.16.1.

Ships **`openapi.singleton: "true"`** (#121) for one-URL no-fork resources. A class-level annotation that emits all verbs in `openapi.operations` on ONE canonical URL with no `/{id}` segment — covers top-level singletons, sub-resource singletons via `path_template`, and single-verb singletons. Eliminates hand-authored controllers for the singleton-resource shape.

Both `gen-openapi` and `gen-spring-server` honour the annotation; sidecar spec and Spring controller annotations agree wire-for-wire.

## Test plan

- [x] `python -c "import linkml_openapi; print(linkml_openapi.__version__)"` → `0.16.1`
- [x] `pytest tests/` — 562 passed
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [ ] CI green
- [ ] After merge: tag `v0.16.1` triggers PyPI publish workflow

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_