### PR TITLE
fix: polymorphic codegen gaps (equals_string, parent discriminator, envelope items validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
+## [Unreleased]
+
+### Added
+
+- **Parent component schemas now carry the OpenAPI `discriminator`
+  block** (propertyName + mapping) in regular mode, not just under
+  `--codegen-friendly`. Swagger UI and generic OpenAPI codegens read
+  the dispatch mapping from the parent component schema; without it,
+  polymorphic responses render as the bare parent shape with subtype
+  fields hidden. Use-site `oneOf` blocks are unchanged. The
+  codegen-friendly guard (narrowing detection + `openapi.codegen_inheritance: "false"`
+  opt-out) still applies when relevant.
+
+### Fixed
+
+- **LinkML-native `slot_usage.<discriminator>.equals_string` is now
+  read as the discriminator value.** Previously schemas using pure
+  LinkML conventions (`designates_type: true` on the discriminator
+  slot + `equals_string: CAR` on each subclass) silently fell back to
+  `cls.name`, emitting the wrong wire value (`Car` instead of `CAR`).
+  Resolution order: `openapi.type_value` > `equals_string` > `cls.name`.
+- **`openapi.list_envelope` now validates the envelope's array slot
+  is `inlined: true`** when the listed class is polymorphic. Without
+  inlining, the envelope's `items` ends up as URI strings on the
+  wire — silently losing the polymorphic `oneOf` dispatch. The
+  generator now raises with a clear remediation (name the slot, name
+  the fix) instead of shipping a misleading spec.
+
+### Notes for `--codegen-friendly` users
+
+The reporter's other observations (abstract base in `oneOf`, GET
+response uses bare `$ref`, subtype `enum` stripped) only surface
+under `--codegen-friendly`. These are intentional trade-offs for
+openapi-generator's Java template (#64, #95, #108). The parent
+discriminator block change above lifts that one item out of
+`--codegen-friendly` so both modes get it.
+
 ## [0.16.1] — 2026-05-31
 
 ### Added

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -2095,12 +2095,38 @@ class OpenAPIGenerator(Generator):
     def _type_value(self, cls: ClassDefinition) -> str:
         """The discriminator value for a concrete subclass.
 
-        Defaults to the class name as-is, matching ``designates_type``'s
-        LinkML default. ``openapi.type_value`` overrides — used when an
-        existing system has a fixed value the schema needs to honour.
+        Resolution order (most specific wins):
+
+        1. ``openapi.type_value`` annotation on the class — used when
+           the schema needs to honour a wire value that doesn't match
+           any LinkML-derivable name.
+        2. ``slot_usage.<discriminator>.equals_string`` — the
+           LinkML-native way to pin the discriminator value for a
+           subclass. Picked up here so pure-LinkML schemas (no
+           ``openapi.*`` annotations on the discriminator) emit the
+           correct const on each subclass.
+        3. ``cls.name`` — matches ``designates_type``'s LinkML default.
         """
         override = self._class_annotation(cls, "openapi.type_value")
-        return override.strip() if override else cls.name
+        if override:
+            return override.strip()
+        # LinkML-native fallback: when the discriminator slot's
+        # ``equals_string`` is pinned in this class's ``slot_usage``,
+        # that's the wire value.
+        field = self._inherited_discriminator_field(cls.name)
+        if field and cls.slot_usage:
+            slot_usage_items = (
+                cls.slot_usage.values() if isinstance(cls.slot_usage, dict) else cls.slot_usage
+            )
+            for su in slot_usage_items:
+                if isinstance(su, str):
+                    continue
+                if getattr(su, "name", None) != field:
+                    continue
+                equals = getattr(su, "equals_string", None)
+                if equals:
+                    return str(equals).strip()
+        return cls.name
 
     def _apply_discriminators(self, schemas: dict[str, Schema | Reference]) -> None:
         """Patch component schemas with OpenAPI ``discriminator`` blocks.
@@ -2189,7 +2215,23 @@ class OpenAPIGenerator(Generator):
             descendants = self._concrete_descendants_including_self(class_name)
             has_narrowing = any(d in self._narrowing_subclasses for d in descendants)
             opt_out = _is_falsy(self._class_annotation(cls, "openapi.codegen_inheritance"))
-            if self.codegen_friendly and not has_narrowing and not opt_out:
+            # Attach the ``discriminator`` block to the parent's
+            # component schema in BOTH modes (regular and
+            # codegen-friendly). Swagger UI and most OpenAPI codegens
+            # read the dispatch mapping from the parent's schema even
+            # when use sites carry it too — without it, polymorphic
+            # responses render as the bare parent shape with subtype
+            # fields hidden. The codegen-friendly guard (narrowing
+            # detection + ``codegen_inheritance: "false"`` opt-out)
+            # only applies to the inheritance-based ``$ref`` strategy
+            # used by openapi-generator's Java template; in regular
+            # mode the parent block is harmless and useful.
+            attach_parent_block = True
+            if self.codegen_friendly and (has_narrowing or opt_out):
+                # Avoid the Java covariance collision under
+                # codegen-friendly + narrowing (#106 / #65 trade-off).
+                attach_parent_block = False
+            if attach_parent_block:
                 parent_schema = schemas.get(class_name)
                 if isinstance(parent_schema, Schema):
                     parent_schema.discriminator = Discriminator(
@@ -2405,7 +2447,15 @@ class OpenAPIGenerator(Generator):
         response becomes a ``$ref`` to the envelope class (which must
         exist in the schema); otherwise it's today's bare array
         (#105). The envelope class is responsible for declaring the
-        array slot that points at the listed resource type."""
+        array slot that points at the listed resource type.
+
+        Validation: when the listed class is polymorphic (an abstract
+        root with concrete descendants) and the envelope's array slot
+        is NOT ``inlined: true``, the envelope's ``items`` ends up as
+        URI strings on the wire — losing the polymorphic dispatch.
+        Raise with a clear remediation so authors don't ship envelopes
+        that hide their subtypes.
+        """
         envelope = self._class_annotation(cls, "openapi.list_envelope")
         if not envelope:
             return self._list_response_items_schema(class_name)
@@ -2416,7 +2466,47 @@ class OpenAPIGenerator(Generator):
                 f"class {envelope!r}; add the class to the schema or remove "
                 "the annotation."
             )
+        self._validate_envelope_items_inlined(class_name, envelope)
         return Reference(ref=f"#/components/schemas/{envelope}")
+
+    def _validate_envelope_items_inlined(self, listed_class: str, envelope_class: str) -> None:
+        """When the listed class has concrete descendants (polymorphic),
+        the envelope must carry the array slot as ``inlined: true`` so
+        the polymorphic ``oneOf`` reaches the wire. Without it, the
+        envelope ships URI strings and consumers can't deserialise
+        subtypes. Raise with the slot name and the fix."""
+        if not self._concrete_descendants_excluding_self(listed_class):
+            # Not polymorphic — the URI-vs-inlined choice is the
+            # author's call and either shape is valid.
+            return
+        target_slot_name: str | None = None
+        for slot in self._induced_slots_iter(envelope_class):
+            if not slot.multivalued or not slot.range:
+                continue
+            # Slot ranges on the listed class directly, or on one of
+            # its abstract ancestors (envelope items typed at the
+            # polymorphic root).
+            if slot.range == listed_class:
+                target_slot_name = slot.name
+                if not slot.inlined:
+                    raise ValueError(
+                        f"openapi.list_envelope on {listed_class!r} points "
+                        f"at {envelope_class!r}, whose slot {slot.name!r} "
+                        f"(range {listed_class!r}, multivalued) is NOT "
+                        f"`inlined: true`. The envelope would ship URI "
+                        f"references on the wire and consumers would lose "
+                        f"the polymorphic ``oneOf`` dispatch. Mark "
+                        f"{envelope_class}.{slot.name} as `inlined: true` "
+                        f"(or `inlined: true, inlined_as_list: true` for "
+                        f"a JSON array) so each subtype's full object "
+                        f"reaches the client."
+                    )
+                return
+        if target_slot_name is None:
+            # Envelope doesn't carry a slot ranging on the listed
+            # class at all — fine, the author owns the envelope's
+            # shape (might wrap a different aggregate).
+            return
 
     def _pagination_params(self, cls: ClassDefinition) -> list[Parameter]:
         """Build query Parameters for the dialect declared by

--- a/tests/test_dcat3.py
+++ b/tests/test_dcat3.py
@@ -87,10 +87,23 @@ class TestDiscriminatorPlacement:
     is unambiguous.
     """
 
-    def test_resource_has_no_schema_level_discriminator(self, schemas):
-        assert "discriminator" not in schemas["Resource"]
+    def test_resource_carries_discriminator_block(self, schemas):
+        """The polymorphic root component schema carries the OpenAPI
+        ``discriminator`` block (propertyName + mapping) so Swagger UI
+        and codegens can dispatch from the root schema. Behaviour
+        change in 0.16.x — prior to the polymorphic-codegen gaps fix,
+        the root had no block in regular mode."""
+        disc = schemas["Resource"].get("discriminator")
+        assert disc is not None
+        assert disc["propertyName"] == "resourceType"
+        mapping = disc.get("mapping") or {}
+        # Every concrete leaf is represented in the mapping.
+        for leaf in ("Dataset", "Catalog", "DatasetSeries", "DataService"):
+            assert leaf in mapping, f"{leaf} missing from discriminator.mapping"
 
     def test_resource_has_no_schema_level_oneof(self, schemas):
+        # The discriminator block lives on the root; the instance-level
+        # ``oneOf`` still only appears at use sites.
         assert "oneOf" not in schemas["Resource"]
 
     def test_resource_does_not_carry_discriminator_field_itself(self, schemas):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1984,12 +1984,26 @@ class TestDiscriminator:
 
     def test_designates_type_does_not_pollute_abstract_parent(self):
         """`designates_type: true` is a discriminator declaration. The
-        abstract parent (Animal) carries no instances, so the
-        synthesised single-value enum lives on each concrete
-        subclass's ``allOf[1]`` local block, not on the parent."""
+        abstract parent (Animal) carries the OpenAPI ``discriminator``
+        block (propertyName + mapping) so Swagger UI / codegens can
+        dispatch on the wire value — but no instance data (no
+        ``oneOf`` at the schema root, no synthesised single-value
+        enum on the parent). The single-value enum lives on each
+        concrete subclass's ``allOf[1]`` local block.
+
+        Behaviour change in 0.16.x: prior to the polymorphic-codegen
+        gaps fix, the parent had no ``discriminator`` block in
+        regular mode and consumers couldn't dispatch from the parent
+        schema. The block is now attached unconditionally (Swagger
+        UI requires it for polymorphic rendering).
+        """
         spec = _generate()
         animal = spec["components"]["schemas"]["Animal"]
-        assert "discriminator" not in animal
+        assert animal.get("discriminator", {}).get("propertyName") == "species"
+        mapping = animal.get("discriminator", {}).get("mapping") or {}
+        assert "Dog" in mapping
+        assert "Cat" in mapping
+        # No instance-level oneOf on the parent — that lives at use sites.
         assert "oneOf" not in animal
         dog_local = spec["components"]["schemas"]["Dog"]["allOf"][1]
         cat_local = spec["components"]["schemas"]["Cat"]["allOf"][1]
@@ -2073,13 +2087,25 @@ classes:
         (``type: object``, properties, required) so codegens generate a
         class for it. The discriminator field is not injected on the
         abstract root — that's handled by each concrete subclass — but
-        the root's own ``sku`` etc. survive."""
+        the root's own ``sku`` etc. survive.
+
+        Behaviour change in 0.16.x: the parent component schema now
+        carries the OpenAPI ``discriminator`` block (propertyName +
+        mapping) so Swagger UI can render polymorphic dispatch from
+        the parent schema directly. No ``oneOf`` at the root — that
+        still lives at use sites.
+        """
         spec = _generate()
         product = spec["components"]["schemas"]["Product"]
         assert product["type"] == "object"
         assert "sku" in product["properties"]
         assert "oneOf" not in product
-        assert "discriminator" not in product
+        disc = product.get("discriminator")
+        assert disc is not None
+        assert disc["propertyName"] == "kind"
+        mapping = disc.get("mapping") or {}
+        assert "BOOK" in mapping
+        assert "VINYL" in mapping
 
     def test_discriminator_default_keeps_parent_properties(self):
         """Without --flatten-inheritance, the parent keeps its own
@@ -4317,3 +4343,163 @@ classes:
         get_body = spec["paths"]["/settings"]["get"]["responses"]["200"]
         schema = get_body["content"]["application/json"]["schema"]
         assert schema == {"$ref": "#/components/schemas/Settings"}
+
+
+class TestPolymorphicCodegenGaps:
+    """Coverage for the polymorphic-class codegen gaps reported
+    against 0.16.1:
+
+    A) LinkML-native ``slot_usage.<discriminator>.equals_string``
+       is read as a fallback discriminator value (was previously
+       ignored — only ``openapi.type_value`` was honoured).
+    B) The parent component schema now carries the OpenAPI
+       ``discriminator`` block (propertyName + mapping) so Swagger
+       UI / codegens can dispatch from the parent schema directly.
+    C) An ``openapi.list_envelope`` whose array slot ranges on a
+       polymorphic class but is NOT ``inlined: true`` raises with
+       a clear remediation (would otherwise silently ship URI
+       strings, hiding the subtype dispatch on the wire).
+    """
+
+    POLY_SCHEMA = """
+id: https://example.org/poly-gaps
+name: poly_gaps
+default_range: string
+classes:
+  Vehicle:
+    abstract: true
+    annotations:
+      openapi.resource: "true"
+      openapi.discriminator: vehicleType
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      vehicleType: { range: string }
+  Car:
+    is_a: Vehicle
+    annotations:
+      openapi.resource: "true"
+    slot_usage:
+      vehicleType:
+        equals_string: CAR
+    attributes:
+      doors: { range: integer }
+  Truck:
+    is_a: Vehicle
+    annotations:
+      openapi.resource: "true"
+    slot_usage:
+      vehicleType:
+        equals_string: TRUCK
+    attributes:
+      payloadCapacity: { range: integer }
+"""
+
+    def test_equals_string_drives_discriminator_value(self):
+        """A) ``slot_usage.<discrim>.equals_string`` should pin the
+        wire value. Without this, pure-LinkML schemas fall back to
+        ``cls.name`` and emit ``Car`` / ``Truck`` instead of the
+        intended ``CAR`` / ``TRUCK``."""
+        spec = _generate_from_string(self.POLY_SCHEMA)
+        car_local = spec["components"]["schemas"]["Car"]["allOf"][1]
+        truck_local = spec["components"]["schemas"]["Truck"]["allOf"][1]
+        assert car_local["properties"]["vehicleType"]["enum"] == ["CAR"]
+        assert car_local["properties"]["vehicleType"]["default"] == "CAR"
+        assert truck_local["properties"]["vehicleType"]["enum"] == ["TRUCK"]
+        assert truck_local["properties"]["vehicleType"]["default"] == "TRUCK"
+
+    def test_openapi_type_value_still_wins_over_equals_string(self):
+        """Resolution order: ``openapi.type_value`` > ``equals_string``
+        > ``cls.name``. Schemas that already set ``openapi.type_value``
+        for legacy wire compat must keep their existing values."""
+        # Insert `openapi.type_value: passenger-car` into Car's
+        # existing annotations block.
+        car_before = '  Car:\n    is_a: Vehicle\n    annotations:\n      openapi.resource: "true"'
+        car_after = car_before + "\n      openapi.type_value: passenger-car"
+        schema = self.POLY_SCHEMA.replace(car_before, car_after)
+        spec = _generate_from_string(schema)
+        car_local = spec["components"]["schemas"]["Car"]["allOf"][1]
+        # openapi.type_value wins.
+        assert car_local["properties"]["vehicleType"]["default"] == "passenger-car"
+
+    def test_discriminator_mapping_uses_equals_string_values(self):
+        """A): the use-site mapping reflects the ``equals_string``
+        values (mapping keys are the wire values, refs target the
+        subclass schemas)."""
+        spec = _generate_from_string(self.POLY_SCHEMA)
+        post = spec["paths"]["/vehicles"]["post"]
+        body = post["requestBody"]["content"]["application/json"]["schema"]
+        mapping = body["discriminator"]["mapping"]
+        assert mapping == {
+            "CAR": "#/components/schemas/Car",
+            "TRUCK": "#/components/schemas/Truck",
+        }
+
+    def test_parent_component_schema_carries_discriminator_block(self):
+        """B) The parent component schema carries the OpenAPI
+        ``discriminator`` block so Swagger UI / generic codegens can
+        dispatch from the root schema directly. Required for Swagger
+        UI to render polymorphic dispatch in the request-body
+        selector and the response renderer."""
+        spec = _generate_from_string(self.POLY_SCHEMA)
+        vehicle = spec["components"]["schemas"]["Vehicle"]
+        disc = vehicle.get("discriminator")
+        assert disc is not None
+        assert disc["propertyName"] == "vehicleType"
+        mapping = disc.get("mapping") or {}
+        assert mapping == {
+            "CAR": "#/components/schemas/Car",
+            "TRUCK": "#/components/schemas/Truck",
+        }
+        # No instance-level ``oneOf`` on the parent — that still
+        # lives at use sites only.
+        assert "oneOf" not in vehicle
+
+    _DISC_LINE = "      openapi.discriminator: vehicleType"
+    _DISC_WITH_ENVELOPE = (
+        "      openapi.discriminator: vehicleType\n      openapi.list_envelope: GetVehiclesResponse"
+    )
+
+    def test_envelope_with_non_inlined_polymorphic_slot_raises(self):
+        """C) An envelope's array slot that ranges on a polymorphic
+        class must be ``inlined: true`` — otherwise the wire ships
+        URI references and consumers can't deserialise subtypes."""
+        schema_yaml = (
+            self.POLY_SCHEMA.replace(self._DISC_LINE, self._DISC_WITH_ENVELOPE)
+            + """
+  GetVehiclesResponse:
+    attributes:
+      items:
+        range: Vehicle
+        multivalued: true
+      nextCursor: { range: string }
+"""
+        )
+        _generate_from_string_raises(
+            schema_yaml,
+            match=r"openapi.list_envelope.*NOT `inlined: true`",
+        )
+
+    def test_envelope_with_inlined_polymorphic_slot_emits_oneof(self):
+        """C) sanity: when the envelope's array slot IS inlined, the
+        polymorphic dispatch reaches the ``items`` schema as expected."""
+        schema_yaml = (
+            self.POLY_SCHEMA.replace(self._DISC_LINE, self._DISC_WITH_ENVELOPE)
+            + """
+  GetVehiclesResponse:
+    attributes:
+      items:
+        range: Vehicle
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+      nextCursor: { range: string }
+"""
+        )
+        spec = _generate_from_string(schema_yaml)
+        env = spec["components"]["schemas"]["GetVehiclesResponse"]
+        items_inner = env["properties"]["items"]["items"]
+        assert "oneOf" in items_inner
+        assert items_inner["discriminator"]["propertyName"] == "vehicleType"
+        # Polymorphic dispatch reaches subtypes only — no abstract base.
+        refs = sorted(r["$ref"].rsplit("/", 1)[-1] for r in items_inner["oneOf"])
+        assert refs == ["Car", "Truck"]


### PR DESCRIPTION
## Summary

Three fixes after triaging the downstream bug report against a polymorphic DCAT-derived schema. **Two real bugs, one UX gap with a clear remediation.**

### Fix A: `slot_usage.<discriminator>.equals_string` is now read

LinkML schemas using the **native** discriminator pattern (no `openapi.*` annotations on the discriminator slot itself) silently fell back to `cls.name` for the wire value:

```yaml
Car:
  is_a: Vehicle
  slot_usage:
    vehicleType:
      equals_string: CAR        # ← was ignored
```

Result: wire emitted `Car` instead of `CAR`, and Swagger UI's dispatch mapping was keyed on the wrong value. Now `equals_string` is read as a fallback. Resolution order: `openapi.type_value` > `equals_string` > `cls.name`. Schemas that already set `openapi.type_value` are unaffected.

### Fix B: Parent schema carries the `discriminator` block

The parent component schema had no `discriminator` block in regular mode — only at use sites. Swagger UI and many OpenAPI codegens read the dispatch mapping from the parent's component schema; without it polymorphic responses render as the bare parent shape with subtype fields hidden.

Lifted out of `--codegen-friendly`:

```yaml
components:
  schemas:
    Vehicle:
      type: object
      discriminator:               # ← NEW, was only under --codegen-friendly
        propertyName: vehicleType
        mapping:
          CAR: '#/components/schemas/Car'
          TRUCK: '#/components/schemas/Truck'
      properties:
        id: { type: string }
        vehicleType: { type: string }
```

The codegen-friendly guard (narrowing detection + `openapi.codegen_inheritance: "false"` opt-out) still applies when relevant — only the unconditional default-mode attach is new.

### Fix C: `openapi.list_envelope` validates the array slot is inlined

When the envelope's array slot ranges on a polymorphic class but isn't `inlined: true`, the wire ships URI strings — silently losing the `oneOf` dispatch. The generator now raises:

```
ValueError: openapi.list_envelope on 'Vehicle' points at 'GetVehiclesResponse',
whose slot 'items' (range 'Vehicle', multivalued) is NOT `inlined: true`. The
envelope would ship URI references on the wire and consumers would lose the
polymorphic ``oneOf`` dispatch. Mark GetVehiclesResponse.items as
`inlined: true` (or `inlined: true, inlined_as_list: true` for a JSON array)
so each subtype's full object reaches the client.
```

## What's NOT in this PR (and why)

The reporter listed 5 issues. After running their reproducer against 0.16.1:

| # | Their claim | Status |
|---|---|---|
| 1 | Abstract base in `oneOf` | ❌ NOT a bug. `oneOf` already excludes abstract. Reporter likely has intermediate concrete classes (e.g., a `DataService` not marked `abstract: true`). |
| 2 | GET response uses bare `$ref` | ❌ Only under `--codegen-friendly` — intentional (#64). Bare `$ref` to the parent + the new parent-schema discriminator block (Fix B) gives codegens what they need. |
| 3 | `discriminator.mapping` missing on parent | ✅ **Fix B** lifts this out of `--codegen-friendly`. |
| 4 | Subtype's discriminator field unconstrained | ❌ Only under `--codegen-friendly` — intentional (#108 trade-off). Regular mode already emits the `enum: [CAR]` const. |
| 5 | List-envelope `items` empty | ✅ **Fix C** raises clearly when the slot isn't inlined. With `inlined: true`, the polymorphic dispatch already reaches `items.items`. |

Plus **Fix A** (the `equals_string` bug) which the reporter's reproducer surfaced but didn't explicitly call out.

## Test plan

- [x] **6 new regression tests** in `TestPolymorphicCodegenGaps` covering all three fixes
- [x] **3 pre-existing tests updated** to pin the new wire shape (parent schema now carries the discriminator block)
- [x] `pytest tests/` — **568 passed** (+6)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] Examples regenerated — no diff (changes only surface for polymorphic schemas; examples are non-polymorphic)
- [ ] CI green

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_