### PR TITLE
feat(#124): dual-discriminator surface for legacy back-compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dual-discriminator surface for legacy back-compat** (#124).
+  When both `openapi.discriminator` (semantic) and
+  `openapi.legacy_type_field` (back-compat) are declared on a
+  polymorphic chain, the generator now emits an
+  `x-discriminator-aliases` extension on the parent component
+  schema — a parallel mapping that lifts the legacy field's
+  per-subclass values up next to the primary discriminator. Lets
+  consumers route on either field without re-walking the schema.
+  Every concrete subclass must now set `openapi.type_value` AND
+  `openapi.legacy_type_value` explicitly (the silent `cls.name`
+  fallback for the semantic value is disabled in this case so
+  the wire payload's two discriminator fields can't drift). The
+  primary `discriminator` block is unchanged; schemas using only
+  one of the two fields are byte-identical.
+
 - **Parent component schemas now carry the OpenAPI `discriminator`
   block** (propertyName + mapping) in regular mode, not just under
   `--codegen-friendly`. Swagger UI and generic OpenAPI codegens read

--- a/README.md
+++ b/README.md
@@ -712,6 +712,68 @@ Polymorphic endpoints fall out automatically: an abstract parent with
 response schemas `$ref` the parent — and the discriminator block on
 the parent does the polymorphic dispatch at codegen / runtime.
 
+##### Dual discriminator (semantic + legacy back-compat field)
+
+Some schemas need TWO discriminator fields on the wire simultaneously
+— a clean **semantic** discriminator (e.g. `resourceType: API`) and a
+**legacy** discriminator carrying an opaque type marker (e.g.
+`#type: com.example.acme.dcat.DataService` — a Java FQN consumed by
+existing JVM clients). Declare both:
+
+```yaml
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.discriminator: resourceType        # primary, semantic
+      openapi.legacy_type_field: "#type"          # secondary, opaque back-compat
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      resourceType: { range: string }
+  DataService:
+    is_a: Resource
+    annotations:
+      openapi.type_value: API                                          # required
+      openapi.legacy_type_value: "com.example.acme.dcat.DataService"   # required
+    attributes:
+      endpoint: { range: string }
+  Database:
+    is_a: Resource
+    annotations:
+      openapi.type_value: DATABASE
+      openapi.legacy_type_value: "com.example.acme.dcat.Database"
+    attributes:
+      jdbcUrl: { range: string }
+```
+
+**Both annotations are required on every concrete subclass** when the
+legacy field is declared on the parent (the silent `cls.name` fallback
+for `openapi.type_value` is disabled to prevent misaligned wire
+payloads). Each subclass emits both fields as single-value `enum` on
+the wire so consumers can route on either.
+
+The generated parent schema carries:
+
+- The OpenAPI `discriminator` block (semantic field + mapping) — used
+  by Swagger UI and `oneOf`-based codegen dispatch.
+- An `x-discriminator-aliases` extension — a parallel mapping for the
+  legacy field, so back-compat consumers can route on `#type` without
+  having to walk the schema:
+
+```yaml
+Resource:
+  discriminator:
+    propertyName: resourceType
+    mapping:
+      API:      '#/components/schemas/DataService'
+      DATABASE: '#/components/schemas/Database'
+  x-discriminator-aliases:
+    - propertyName: '#type'
+      mapping:
+        com.example.acme.dcat.DataService: '#/components/schemas/DataService'
+        com.example.acme.dcat.Database:    '#/components/schemas/Database'
+```
+
 #### `openapi.media_types`
 
 Comma-separated list of media types each operation generated for the class

--- a/src/linkml_openapi/generator.py
+++ b/src/linkml_openapi/generator.py
@@ -256,6 +256,12 @@ class OpenAPIGenerator(Generator):
         # Reset the x-rdf-* maps; _build_openapi populates them as it walks the schema.
         self._x_rdf_class: dict[str, str] = {}
         self._x_rdf_property: dict[tuple[str, str], str] = {}
+        # ``x-discriminator-aliases`` lifts the per-subclass legacy
+        # field (e.g. ``#type: <java-fqn>``) into a mapping parallel
+        # to the primary OpenAPI discriminator. Populated during
+        # ``_apply_discriminators`` and injected onto each parent
+        # schema after serialisation (#124).
+        self._x_discriminator_aliases: dict[str, list[dict]] = {}
         # Per-build cache so the schema-walk helpers (descendants,
         # induced slots, etc.) don't re-traverse the class graph for
         # every reference site. Reset here to pick up any schema-view
@@ -347,6 +353,7 @@ class OpenAPIGenerator(Generator):
         self._strip_invalid_parameter_fields(raw)
         self._coerce_numeric_constraints(raw)
         self._inject_rdf_extensions(raw)
+        self._inject_discriminator_aliases(raw)
         if self.emit_namespaces:
             self._inject_namespaces(raw)
         if self.post_processors:
@@ -1350,6 +1357,22 @@ class OpenAPIGenerator(Generator):
                 ranges[str(slot.name)] = [str(d) for d in descendants]
         return ranges
 
+    def _inject_discriminator_aliases(self, raw: dict) -> None:
+        """Inject ``x-discriminator-aliases`` onto each parent
+        component schema that declared an ``openapi.legacy_type_field``
+        (#124). Populated by ``_apply_discriminators``; flattened
+        from ``self._x_discriminator_aliases`` directly onto the
+        schema's raw dict so the wire shape matches what OpenAPI
+        consumers expect for extensions (``x-*`` at the schema's
+        top level, not under an ``extensions`` wrapper)."""
+        if not self._x_discriminator_aliases:
+            return
+        schemas = (raw.get("components") or {}).get("schemas") or {}
+        for class_name, aliases in self._x_discriminator_aliases.items():
+            schema = schemas.get(class_name)
+            if isinstance(schema, dict):
+                schema["x-discriminator-aliases"] = aliases
+
     def _inject_namespaces(self, raw: dict) -> None:
         """Emit the LinkML schema's prefix map as a top-level
         ``x-namespaces`` extension (#98).
@@ -2257,8 +2280,58 @@ class OpenAPIGenerator(Generator):
                 legacy_field = legacy_field.strip()
                 codegen_name = self._class_annotation(cls, "openapi.legacy_type_codegen_name")
                 codegen_name = codegen_name.strip() if codegen_name else None
+                # When the legacy field is declared on the root, every
+                # concrete subclass must pin BOTH the semantic
+                # ``openapi.type_value`` AND ``openapi.legacy_type_value``
+                # explicitly. Falling back to ``cls.name`` for the
+                # semantic value is unsafe in the dual-discriminator
+                # case — the semantic value and the legacy FQN live on
+                # the wire together and consumers route on both; a
+                # silent ``cls.name`` default invites misaligned
+                # payloads (#124).
+                for sub_name in seen.values():
+                    sub_cls = sv.get_class(sub_name)
+                    if sub_cls is None:
+                        continue
+                    semantic = self._class_annotation(sub_cls, "openapi.type_value")
+                    if semantic is None:
+                        raise ValueError(
+                            f"Class {sub_name!r} is on a polymorphic chain "
+                            f"that declares both `openapi.discriminator` "
+                            f"({field!r}) and `openapi.legacy_type_field` "
+                            f"({legacy_field!r}). Every concrete subclass "
+                            f"must set `openapi.type_value` explicitly so "
+                            f"the semantic discriminator value and the "
+                            f"legacy field's value are both intentional. "
+                            f"Add `openapi.type_value: <value>` to "
+                            f"{sub_name!r} or drop the legacy field."
+                        )
                 for sub_name in seen.values():
                     self._inject_legacy_type_value(schemas, sub_name, legacy_field, codegen_name)
+                # Collect the legacy field's per-subclass values into
+                # an ``x-discriminator-aliases`` mapping that gets
+                # injected onto the parent's component schema after
+                # serialisation (openapi-pydantic's ``Schema.extensions``
+                # round-trips under a wrapper, so we attach the
+                # extension at the raw-dict level to match the wire
+                # shape OpenAPI consumers expect). Lets consumers
+                # route on either the semantic or the legacy field
+                # without re-walking the schema (#124).
+                legacy_mapping: dict[str, str] = {}
+                for sub_name in seen.values():
+                    sub_cls = sv.get_class(sub_name)
+                    if sub_cls is None:
+                        continue
+                    lv = self._class_annotation(sub_cls, "openapi.legacy_type_value")
+                    if lv:
+                        legacy_mapping[lv.strip()] = f"#/components/schemas/{sub_name}"
+                if legacy_mapping:
+                    self._x_discriminator_aliases[class_name] = [
+                        {
+                            "propertyName": legacy_field,
+                            "mapping": dict(legacy_mapping),
+                        }
+                    ]
 
     @staticmethod
     def _writable_local_schema(schema: Schema) -> Schema:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4503,3 +4503,135 @@ classes:
         # Polymorphic dispatch reaches subtypes only — no abstract base.
         refs = sorted(r["$ref"].rsplit("/", 1)[-1] for r in items_inner["oneOf"])
         assert refs == ["Car", "Truck"]
+
+
+class TestDualDiscriminator:
+    """Coverage for #124 — dual-discriminator coexistence.
+
+    When both ``openapi.discriminator`` (semantic) and
+    ``openapi.legacy_type_field`` (legacy back-compat) are declared
+    on a polymorphic chain, the generator:
+
+    1. Requires every concrete subclass to set BOTH
+       ``openapi.type_value`` and ``openapi.legacy_type_value``
+       explicitly (no silent ``cls.name`` fallback for the semantic
+       value when the legacy field is declared).
+    2. Emits ``x-discriminator-aliases`` on the parent component
+       schema — a parallel mapping that lifts the legacy field's
+       per-subclass values up next to the primary discriminator, so
+       consumers can route on either field without re-walking the
+       schema.
+    """
+
+    DUAL_SCHEMA = """
+id: https://example.org/dual
+name: dual
+default_range: string
+classes:
+  Resource:
+    abstract: true
+    annotations:
+      openapi.resource: "true"
+      openapi.discriminator: resourceType
+      openapi.legacy_type_field: "#type"
+    attributes:
+      id: { identifier: true, range: string, required: true }
+      resourceType: { range: string }
+  DataService:
+    is_a: Resource
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: API
+      openapi.legacy_type_value: "com.example.acme.dcat.DataService"
+    attributes:
+      endpoint: { range: string }
+  Database:
+    is_a: Resource
+    annotations:
+      openapi.resource: "true"
+      openapi.type_value: DATABASE
+      openapi.legacy_type_value: "com.example.acme.dcat.Database"
+    attributes:
+      jdbcUrl: { range: string }
+"""
+
+    def test_x_discriminator_aliases_on_parent(self):
+        """Parent component schema carries ``x-discriminator-aliases``."""
+        spec = _generate_from_string(self.DUAL_SCHEMA)
+        resource = spec["components"]["schemas"]["Resource"]
+        aliases = resource.get("x-discriminator-aliases")
+        assert aliases is not None, "expected x-discriminator-aliases on Resource"
+        assert isinstance(aliases, list) and len(aliases) == 1
+        alias = aliases[0]
+        assert alias["propertyName"] == "#type"
+        assert alias["mapping"] == {
+            "com.example.acme.dcat.DataService": "#/components/schemas/DataService",
+            "com.example.acme.dcat.Database": "#/components/schemas/Database",
+        }
+
+    def test_primary_discriminator_still_emitted(self):
+        """Primary semantic discriminator block lives alongside the alias."""
+        spec = _generate_from_string(self.DUAL_SCHEMA)
+        resource = spec["components"]["schemas"]["Resource"]
+        disc = resource.get("discriminator")
+        assert disc is not None
+        assert disc["propertyName"] == "resourceType"
+        assert disc["mapping"] == {
+            "API": "#/components/schemas/DataService",
+            "DATABASE": "#/components/schemas/Database",
+        }
+
+    def test_each_subclass_pins_both_fields(self):
+        """Both semantic and legacy fields pin as single-value enum on every
+        concrete subclass — wire carries both for consumers routing on either."""
+        spec = _generate_from_string(self.DUAL_SCHEMA)
+        ds_local = spec["components"]["schemas"]["DataService"]["allOf"][1]
+        assert ds_local["properties"]["resourceType"]["enum"] == ["API"]
+        assert ds_local["properties"]["#type"]["enum"] == ["com.example.acme.dcat.DataService"]
+        assert "resourceType" in ds_local["required"]
+        assert "#type" in ds_local["required"]
+
+    def test_missing_type_value_raises_when_legacy_field_set(self):
+        """Every concrete subclass on a dual-discriminator chain must set
+        ``openapi.type_value`` explicitly. Silent ``cls.name`` fallback
+        is unsafe here — semantic value lives on the wire next to the
+        legacy FQN; mismatching them invites broken consumer routing."""
+        broken = self.DUAL_SCHEMA.replace("      openapi.type_value: API\n", "")
+        _generate_from_string_raises(
+            broken,
+            match=r"must set `openapi\.type_value` explicitly.*'DataService'",
+        )
+
+    def test_missing_legacy_value_still_raises(self):
+        """The existing legacy_type_value check (#107) still fires."""
+        broken = self.DUAL_SCHEMA.replace(
+            '      openapi.legacy_type_value: "com.example.acme.dcat.DataService"\n',
+            "",
+        )
+        _generate_from_string_raises(broken, match=r"openapi\.legacy_type_value")
+
+    def test_single_discriminator_unchanged_no_validation(self):
+        """When ONLY ``openapi.discriminator`` is set (no legacy field),
+        the existing ``cls.name`` fallback for ``openapi.type_value``
+        still works — schemas not opted into the dual-discriminator
+        pattern are byte-identical."""
+        single = self.DUAL_SCHEMA.replace('      openapi.legacy_type_field: "#type"\n', "")
+        single = single.replace("      openapi.type_value: API\n", "")
+        single = single.replace(
+            '      openapi.legacy_type_value: "com.example.acme.dcat.DataService"\n',
+            "",
+        )
+        single = single.replace("      openapi.type_value: DATABASE\n", "")
+        single = single.replace(
+            '      openapi.legacy_type_value: "com.example.acme.dcat.Database"\n',
+            "",
+        )
+        spec = _generate_from_string(single)
+        resource = spec["components"]["schemas"]["Resource"]
+        # No alias extension when no legacy field.
+        assert "x-discriminator-aliases" not in resource
+        # Primary discriminator still emitted with cls.name fallback values.
+        assert resource["discriminator"]["mapping"] == {
+            "DataService": "#/components/schemas/DataService",
+            "Database": "#/components/schemas/Database",
+        }


### PR DESCRIPTION
## Summary

Implements #124. When a polymorphic chain declares both `openapi.discriminator` (semantic, e.g. `resourceType: API`) and `openapi.legacy_type_field` (back-compat opaque marker, e.g. `#type: com.example.acme.dcat.DataService`), the wire payload carries both fields. The spec previously only surfaced the semantic discriminator's dispatch mapping; the legacy field was opaque to consumers reading the spec.

### Two changes

**1. Strict validation when the legacy field is declared on the root.** Every concrete subclass must set BOTH `openapi.type_value` AND `openapi.legacy_type_value` explicitly. The silent `cls.name` fallback for `type_value` is unsafe here — the two fields live on the wire together and consumers route on either; a silent default invites misaligned payloads. Today's behaviour was: missing `legacy_type_value` raised; missing `type_value` fell back silently to `cls.name`. Now both raise with the class name + the missing annotation.

**2. New `x-discriminator-aliases` extension on the parent component schema.** A parallel mapping that lifts the legacy field's per-subclass values up next to the primary discriminator block:

```yaml
Resource:
  discriminator:
    propertyName: resourceType
    mapping:
      API:      '#/components/schemas/DataService'
      DATABASE: '#/components/schemas/Database'
  x-discriminator-aliases:
    - propertyName: '#type'
      mapping:
        com.example.acme.dcat.DataService: '#/components/schemas/DataService'
        com.example.acme.dcat.Database:    '#/components/schemas/Database'
```

Back-compat consumers (e.g. legacy Jackson clients with `@JsonAlias`) can now route on `#type` directly from the parent schema, without having to walk every subclass to find the const values. The linkage between the two fields is also visible to anyone reading the spec.

### Back-compat

Schemas using only ONE of the two annotations (no `legacy_type_field` at all, or no `openapi.discriminator`) are byte-identical — the validation and the extension are both gated on both annotations being present.

### Test plan

- [x] **6 new regression tests** in `TestDualDiscriminator` covering: alias emission, primary discriminator coexistence, per-subclass dual-field pinning, the new `type_value` requirement, the existing `legacy_type_value` requirement, single-discriminator back-compat
- [x] `pytest tests/` — **574 passed** (+6)
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] README section showing the dual-discriminator pattern end-to-end
- [ ] CI green

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_