### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (while pre-1.0, minor bumps may carry visible behaviour changes).
 
-## [Unreleased]
+## [0.17.0] — 2026-06-07
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "linkml-openapi"
-version = "0.16.1"
+version = "0.17.0"
 description = "Generate OpenAPI 3.1 specifications from LinkML schemas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/linkml_openapi/__init__.py
+++ b/src/linkml_openapi/__init__.py
@@ -1,3 +1,3 @@
 """LinkML to OpenAPI 3.1 generator."""
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"


### PR DESCRIPTION
## Summary

Release 0.17.0 — flips Unreleased → 0.17.0 in CHANGELOG.md, bumps `pyproject.toml` and `__init__.py` to 0.17.0.

Ships the polymorphic-codegen fix batch (#123) plus two new feature extensions (#124, #125):

### #123 — Polymorphic codegen gap fixes

- `slot_usage.<discriminator>.equals_string` is now read as the discriminator value (pure-LinkML schemas no longer silently emit `cls.name`).
- Parent component schemas carry the OpenAPI `discriminator` block in regular mode, not just under `--codegen-friendly` (Swagger UI dispatch).
- `openapi.list_envelope` validates the envelope's array slot is `inlined: true` when the listed class is polymorphic (raises with a clear remediation otherwise).

### #124 — Dual-discriminator surface

When both `openapi.discriminator` (semantic) and `openapi.legacy_type_field` (back-compat) are declared on a polymorphic chain:
- Strict validation: every concrete subclass must set both `openapi.type_value` AND `openapi.legacy_type_value` explicitly.
- New `x-discriminator-aliases` extension on the parent component schema — a parallel mapping that lifts the legacy field's per-subclass values up next to the primary discriminator.

### #125 — Asymmetric subtype surfacing

`x-subtype-property-suppression` extension on the polymorphic root lists each asymmetric subtype's suppressed inherited slots (e.g. `DatasetSeries: [distribution]`) so consumers can see the asymmetry without diffing every subclass's `allOf`.

### Minor (not major) bump?

These are additive: new annotations, new extensions, and stricter validation gated on opt-in (`legacy_type_field` present). Schemas not using these features regenerate byte-identically. The polymorphic-codegen fixes change the wire shape for schemas that already used those features incorrectly (parent discriminator block now emitted in regular mode) — but each is documented in #123 as a correctness fix where the old behaviour was a bug.

## Test plan

- [x] `python -c "import linkml_openapi; print(linkml_openapi.__version__)"` → `0.17.0`
- [x] `pytest tests/` — 573 passed
- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [ ] CI green
- [ ] After merge: tag `v0.17.0` triggers PyPI publish workflow

https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqhfRJXN51bT9ipAodZiSA)_